### PR TITLE
add exception info to logger.error()

### DIFF
--- a/importer/importer/models.py
+++ b/importer/importer/models.py
@@ -151,7 +151,7 @@ class Importer:
                                    'actual_height': actual_height})
                 return False
         except IOError:
-            self.logger.error("An exception occurred attempting to verify %s", filename)
+            self.logger.error("An exception occurred attempting to verify %s", filename, exc_info=True)
             return False
 
         return True


### PR DESCRIPTION
Refs #10 

There's currently only one place where logger.error() is called as a result of an exception, but I tagged the original issue with coding_standard label so we can keep track of issues that need to be added to the developer guidance.