### PR TITLE
Add shebang to Docker entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 mkdir -p /app/logs
 touch /app/logs/concordia.log
 


### PR DESCRIPTION
Since this will be run under Bash the shebang will tell tools like [`shellcheck`](https://www.shellcheck.net/) what linting rules to apply