### PR TITLE
Configure isort to use the same line length as Black

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ DJANGO_SETTINGS_MODULE=concordia.settings_test
 addopts=-rf
 
 [isort]
+line_length = 88
 known_first_party = concordia,importer,exporter,faq
 default_section = THIRDPARTY
 not_skip = __init__.py


### PR DESCRIPTION
This avoids imports being wrapped and unwrapped inconsistently when
they're between 78 and 88 characters long