### PR TITLE
Enable maintenance mode page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ mss*
 *.swp
 config-optional-override.json
 env/
+concordia/maintenance_mode_state.txt

--- a/Pipfile
+++ b/Pipfile
@@ -29,6 +29,7 @@ python-dotenv = "*"
 django-elasticsearch-dsl = "*"
 elasticsearch-dsl = "==6.1.0"
 raven = "*"
+django-maintenance-mode = "*"
 
 [dev-packages]
 invoke = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a433328ee24888e0c63ded66e70158ef804324e9dd420df91f4917d9e5ef0ea2"
+            "sha256": "2c0f507f6776245e0385865c8aaddb86ad7543615d7c3d63286374d0f1a32471"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -50,7 +50,8 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:3b2cab368572ee987a6236321ddea491e4253c819009c87ebc9e42e60371e3ae"
+                "sha256:3b2cab368572ee987a6236321ddea491e4253c819009c87ebc9e42e60371e3ae",
+                "sha256:7834eba53c6bedea21eb76f25a39e477dede3a24aeb51ff19c0248ea8348f007"
             ],
             "version": "==1.12.4"
         },
@@ -142,6 +143,13 @@
             "index": "pypi",
             "version": "==0.7.1"
         },
+        "django-maintenance-mode": {
+            "hashes": [
+                "sha256:bbed43c16ed95496c7c9e5ef080f6ec5bcd9ed33815c342dd447d02db46e0bfb"
+            ],
+            "index": "pypi",
+            "version": "==0.10.0"
+        },
         "django-mptt": {
             "hashes": [
                 "sha256:18a41d1b56ca7c02a5b04d246e33ee2d18f6ee5459c02ed1d945f5abdef23a2e",
@@ -198,7 +206,7 @@
                 "sha256:7546cc08e3899716e12fe67d12d7cfe9a64647014d1134b014c3c392b63cad42",
                 "sha256:aada5cfdc4a543c47098eb3aca6663848ef5d04b4324935ced441debc11ec98b"
             ],
-            "markers": "python_version != '3.3.*' and python_version != '3.2.*' and python_version < '4' and python_version != '3.1.*' and python_version >= '2.6' and python_version != '3.0.*'",
+            "markers": "python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.6' and python_version < '4' and python_version != '3.3.*' and python_version != '3.0.*'",
             "version": "==6.3.1"
         },
         "elasticsearch-dsl": {
@@ -312,7 +320,7 @@
                 "sha256:f8b3d413c5a8f84b12cd4c5df1d8e211777c9852c6be3ee9c094b626644d3eab"
             ],
             "index": "pypi",
-            "markers": "python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version >= '2.7'",
+            "markers": "python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version >= '2.7'",
             "version": "==5.2.0"
         },
         "prometheus-client": {
@@ -398,6 +406,7 @@
                 "sha256:1adb80e7a782c12e52ef9a8182bebeb73f1d7e24e374397af06fb4956c8dc5c0",
                 "sha256:e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8"
             ],
+            "markers": "python_version >= '2.7'",
             "version": "==2.7.3"
         },
         "python-dotenv": {
@@ -466,7 +475,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version != '3.3.*' and python_version != '3.2.*' and python_version < '4' and python_version != '3.1.*' and python_version >= '2.6' and python_version != '3.0.*'",
+            "markers": "python_version != '3.0.*' and python_version >= '2.6' and python_version != '3.2.*' and python_version != '3.3.*' and python_version < '4' and python_version != '3.1.*'",
             "version": "==1.23"
         },
         "vine": {
@@ -499,7 +508,7 @@
                 "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
                 "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
+            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version >= '2.7'",
             "version": "==1.2.1"
         },
         "attrs": {
@@ -554,7 +563,7 @@
                 "sha256:e624daef32f8808296312e72190c7e576852cb75c27935b31c1bbbde14ab353c",
                 "sha256:ef4278e5ac1e47c731ec5e3e48351721e01d2eb4fefa9b97fcdba7495a82cfad"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version < '4' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.1.*'",
+            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.1.*' and python_version < '4' and python_version != '3.0.*' and python_version >= '2.7'",
             "version": "==5.0a2"
         },
         "django-extensions": {
@@ -596,7 +605,7 @@
                 "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
                 "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
+            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version >= '2.7'",
             "version": "==0.7.1"
         },
         "py": {
@@ -604,7 +613,7 @@
                 "sha256:06a30435d058473046be836d3fc4f27167fd84c45b99704f2fb5509ef61f9af1",
                 "sha256:50402e9d1c9005d759426988a492e0edaadb7f4e68bcddfea586bc7432d009c6"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
+            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version >= '2.7'",
             "version": "==1.6.0"
         },
         "pycodestyle": {
@@ -644,7 +653,6 @@
                 "sha256:2d495b61542cb25dfc52fbf40c7a02220c7c127b7ba8974e6c72d6c9593c547a",
                 "sha256:ec37c48f44e7973cc6d06b36a148d3a3432e5dda8b8a40239fb52099b202907f"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==1.7.0"
         },
         "six": {

--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -77,6 +77,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "raven.contrib.django.raven_compat",
+    "maintenance_mode",
     "rest_framework",
     "concordia",
     "exporter",
@@ -108,6 +109,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     # Machina
     "machina.apps.forum_permission.middleware.ForumPermissionMiddleware",
+    "maintenance_mode.middleware.MaintenanceModeMiddleware",
 ]
 
 TEMPLATES = [
@@ -287,3 +289,8 @@ SENTRY_PUBLIC_DSN = os.environ.get("SENTRY_PUBLIC_DSN", "")
 
 if SENTRY_DSN:
     RAVEN_CONFIG = {"dsn": SENTRY_DSN, "environment": CONCORDIA_ENVIRONMENT}
+
+# When the MAINTENANCE_MODE setting is true, this template will be used to
+# generate a 503 response:
+MAINTENANCE_MODE_TEMPLATE = "maintenance-mode.html"
+

--- a/concordia/templates/maintenance-mode.html
+++ b/concordia/templates/maintenance-mode.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block title %}Crowd is being upgraded{% endblock title %}
+{% block main_content %}
+<div class="container container-fluid">
+    <div class="jumbotron jumbotron-fluid">
+        <div class="container">
+            <p class="lead text-center">
+                Crowd is being upgraded. Please try again soon.
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock main_content %}

--- a/concordia/urls.py
+++ b/concordia/urls.py
@@ -246,3 +246,6 @@ urlpatterns += [
 urlpatterns += [url("", include("django_prometheus_metrics.urls"))]
 
 urlpatterns += [url(r"^captcha/", include("captcha.urls"))]
+
+urlpatterns += [url(r"^maintenance-mode/", include("maintenance_mode.urls"))]
+


### PR DESCRIPTION
This allows us to toggle the server into a maintenance mode
where all requests will get 503 responses using the new
maintenance mode template. 

Maintenance mode can be activated by toggling the boolean 
`MAINTENANCE_MODE` setting or by visiting 
`/maintenance-mode/on/` or `/maintenance-mode/off/` while
logged in as a superuser.