### PR TITLE
Refactor campaign reporting

### DIFF
--- a/concordia/models.py
+++ b/concordia/models.py
@@ -1,8 +1,5 @@
-import os
-import shutil
 from logging import getLogger
 
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.postgres.fields import JSONField
 from django.db import models
@@ -152,7 +149,10 @@ class Tag(models.Model):
 
 class UserAssetTagCollection(models.Model):
     asset = models.ForeignKey(Asset, on_delete=models.CASCADE)
+
+    # FIXME: why is this not a foreignkey on User?
     user_id = models.PositiveIntegerField(db_index=True)
+
     tags = models.ManyToManyField(Tag, blank=True)
     created_on = models.DateTimeField(auto_now_add=True)
     updated_on = models.DateTimeField(auto_now=True)
@@ -181,19 +181,6 @@ class PageInUse(models.Model):
     user = models.ForeignKey(User, models.DO_NOTHING)
     created_on = models.DateTimeField(editable=False)
     updated_on = models.DateTimeField()
-
-    def save(self, *args, **kwargs):
-        """
-        On save, update timestamps. Allows assignment of created_on and updated_on timestamp used in testing
-        :param args:
-        :param kwargs:
-        :return:
-        """
-        # if not self.id and not self.created_on:
-        #     self.created_on = timezone.now()
-        #
-        # self.updated_on = timezone.now()
-        # return super(PageInUse, self).save(*args, **kwargs)
 
     def save(self, force_insert=False, *args, **kwargs):
         updated = False

--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -73,6 +73,7 @@ INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
+    "django.contrib.humanize",
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",

--- a/concordia/templates/transcriptions/report.html
+++ b/concordia/templates/transcriptions/report.html
@@ -1,95 +1,101 @@
 {% extends "transcriptions/base.html" %}
+
+{% load humanize %}
 {% load staticfiles %}
-{% block title %}Citizen Historian Reporting{% endblock title %}
-{% block head_content %}
-<style>
-    /* FIXME: document why we are using this and switch to a more semantic class name */
-    .col-sm-3 {
-        margin-bottom: 20px;
-    }
-</style>
-{% endblock head_content %}
+
+{% block title %}Citizen Historian Reporting: Campaign {{ title }}{% endblock title %}
+
 {% block main_content %}
 <div class="container">
-    <h4>Campaign and Project Level Reporting</h4>
-    <table class="table table-bordered" style="width: 50%;">
-        <tbody>
-            <tr>
-                <td>CAMPAIGN: </td>
-                <td>{{ campaign_json.title }}</td>
-            </tr>
-            <tr>
-                <td>Total Images in Campaign: </td>
-                <td>{{ campaign_json.assets|length }}</td>
-            </tr>
-            <tr>
-                <td>Total Projects in Campaign: </td>
-                <td>{{ paginator.count }} </td>
-            </tr>
-        </tbody>
-    </table>
     <div class="row">
-        {% for p in projects %}
-        <div class="col-sm-3">
-            <div class="card">
+        <h3>Campaign Summary: {{ title }}</h3>
+        <table class="table table-bordered table-hover">
+            <tbody>
+                <tr>
+                    <th>Total Images:</th>
+                    <td class="text-monospace text-right">{{ total_asset_count|intcomma }}</td>
+                </tr>
+                <tr>
+                    <th>Total Projects:</th>
+                    <td class="text-monospace text-right">{{ projects.paginator.count|intcomma }} </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <div class="row">
+        <div class="card-columns">
+            {% for project in projects %}
+            <div class="card" style="width: 20em">
                 <div class="card-header">
-                    {{p.slug}}
+                    <a class="card-title" href="{% url 'transcriptions:project-detail' campaign_slug=campaign_slug slug=project.slug %}">
+                        {{ project.title }}
+                    </a>
                 </div>
-                <div class="card-body" style="padding:0px">
-                    <table class="table table-bordered" style="margin-bottom:0px">
+                <div class="card-body">
+                    <table class="table table-sm table-bordered table-striped">
                         <tbody>
                             <tr>
-                                <td>Images in this Project</td>
-                                <td>{{ p.total }}</td>
+                                <th>Images in this Project</th>
+                                <td class="text-monospace text-right">{{ project.asset_count|intcomma }}</td>
                             </tr>
                             <tr>
-                                <td>Not Started</td>
-                                <td>{{ p.not_started }}</td>
+                                <th>Number of Contributors</th>
+                                <td class="text-monospace text-right">{{ project.contributor_count|intcomma }} </td>
                             </tr>
                             <tr>
-                                <td>In Edit</td>
-                                <td>{{ p.edit }} </td>
-                            </tr>
-                            <tr>
-                                <td>Submitted for Review</td>
-                                <td>{{ p.submitted }} </td>
-                            </tr>
-                            <tr>
-                                <td>Complete</td>
-                                <td>{{ p.complete }} </td>
-                            </tr>
-                            <tr>
-                                <td>Number of Contributors</td>
-                                <td>{{ p.contributors }} </td>
-                            </tr>
-                            <tr>
-                                <td>Tags</td>
-                                <td>{{ p.tags }} </td>
+                                <th>Tags</th>
+                                <td class="text-monospace text-right">{{ project.tag_count|intcomma }} </td>
                             </tr>
                         </tbody>
                     </table>
 
+                    <table class="table table-sm table-bordered table-striped mb-0">
+                        <caption style="caption-side: top">Transcription Statuses</caption>
+                        <tbody>
+                            {% for status, count in project.transcription_statuses %}
+                            <tr>
+                                <th>{{ status }}</th>
+                                <td class="text-monospace text-right">{{ count }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
                 </div>
             </div>
+            {% endfor %}
         </div>
-        {% endfor %}
     </div>
-</div>
-<div class="pagination">
-    <span class="step-links">
-        {% if projects.has_previous %}
-        <a href="?page=1">&laquo; first</a>
-        <a href="?page={{ projects.previous_page_number }}">previous</a>
-        {% endif %}
 
-        <span class="current">
-            Page {{ projects.number }} of {{ projects.paginator.num_pages }}.
-        </span>
+    <div class="row mt-3">
+        <nav class="w-100">
+            <ul class="pagination mx-auto justify-content-center">
+                {% if projects.has_previous %}
+                <li class="page-item">
+                    <a class="page-link" href="?page={{ projects.previous_page_number }}">Previous</a>
+                </li>
+                {% else %}
+                <li class="page-item disabled">
+                    <span class="page-link">Previous</span>
+                </li>
+                {% endif %}
 
-        {% if projects.has_next %}
-        <a href="?page={{ projects.next_page_number }}">next</a>
-        <a href="?page={{ projects.paginator.num_pages }}">last &raquo;</a>
-        {% endif %}
-    </span>
+                {% for page_num in paginator.page_range %}
+                <li class="page-item {% if page_num == projects.number %}active{% endif %}">
+                    <a class="page-link" href="?page={{ page_num }}">{{ page_num }}</a>
+                </li>
+                {% endfor %}
+
+                {% if projects.has_next %}
+                <li class="page-item">
+                    <a class="page-link" href="?page={{ projects.next_page_number }}">Next</a>
+                </li>
+                {% else %}
+                <li class="page-item disabled">
+                    <span class="page-link">Next</span>
+                </li>
+                {% endif %}
+            </ul>
+        </nav>
+    </div>
 </div>
 {% endblock main_content %}

--- a/concordia/views_ws.py
+++ b/concordia/views_ws.py
@@ -348,13 +348,18 @@ class AssetUpdate(generics.UpdateAPIView):
             request_data = request.data
 
         campaign = Campaign.objects.get(slug=request_data["campaign"])
+
+        # FIXME: use .update for performance
+        # FIXME: do validation before updating
         asset = Asset.objects.get(slug=request_data["slug"], campaign=campaign)
         asset.status = Status.INACTIVE
         asset.save()
 
         serializer = CampaignDetailSerializer(data=request_data)
+        # FIXME: do something when validation fails
         if serializer.is_valid():
             pass
+
         return Response(serializer.data)
 
 


### PR DESCRIPTION
* Performance is improved from 7,000ms to ~70ms and it generates a small constant number of queries rather than many-per-asset
* Results now correctly report the counts per-project rather than repeating the per-campaign totals for each project
* Use Bootstrap’s standard pagination control
* Actually link to the project rather than simply printing the slug
* Clearly label the transcription status values as such
* Replace custom CSS override with equivalent standard Bootstrap class
* Use Django’s intcomma template filter to display numbers
* Display all numbers as right-aligned monospaced text
* Mark table headers as <th> rather than data cells