### PR TITLE
Enable persistent database connections

### DIFF
--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -65,6 +65,7 @@ DATABASES = {
         "PASSWORD": "$(POSTGRESQL_PW)",
         "HOST": "$(POSTGRESQL_HOST)",
         "PORT": "5432",
+        "CONN_MAX_AGE": 15 * 60,  # Keep database connections open for 15 minutes
     }
 }
 


### PR DESCRIPTION
This avoids the overhead of DNS, network connection, TLS, authentication, etc. per-view.