### PR TITLE
Enable Adobe DTM for Analytics (closes #160)

### DIFF
--- a/concordia/templates/base.html
+++ b/concordia/templates/base.html
@@ -15,6 +15,10 @@
         <!-- It's Font Awesome time! -->
         <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css" integrity="sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ" crossorigin="anonymous">
         {% block head_content %}{% endblock head_content %}
+        {% comment %}
+            Adobe's tag manager requires this script to be placed at the top even though it's bad for performance:
+        {% endcomment %}
+        <script src="https://assets.adobedtm.com/dac62e20b491e735c6b56e64c39134d8ee93f9cf/satelliteLib-6b47f831c184878d7338d4683ecf773a17973bb9.js"></script>
     </head>
     <body class="view-{{ VIEW_NAME_FOR_CSS }} section-{{ PATH_LEVEL_1|default:'homepage' }}">
         <header>
@@ -125,6 +129,6 @@
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
         <script src="{% static 'js/base.js' %}"></script>
         {% block body_scripts %}{% endblock body_scripts %}
+        <script type="text/javascript">_satellite.pageBottom();</script>
     </body>
-
 </html>


### PR DESCRIPTION
This embeds the code but Adobe’s instructions violate web
performance guidelines and we should review this carefully
to see how much Adobe is affecting site performance.