### PR TITLE
Adobe analytics support for dev sites

### DIFF
--- a/concordia/context_processors.py
+++ b/concordia/context_processors.py
@@ -6,7 +6,10 @@ def system_configuration(request):
     Expose some system configuration to the default template context
     """
 
-    return {"SENTRY_PUBLIC_DSN": getattr(settings, "SENTRY_PUBLIC_DSN", None)}
+    return {
+        "SENTRY_PUBLIC_DSN": getattr(settings, "SENTRY_PUBLIC_DSN", None),
+        "CONCORDIA_ENVIRONMENT": settings.CONCORDIA_ENVIRONMENT,
+    }
 
 
 def site_navigation(request):

--- a/concordia/templates/base.html
+++ b/concordia/templates/base.html
@@ -20,7 +20,7 @@
         {% endcomment %}
         <script src="https://assets.adobedtm.com/dac62e20b491e735c6b56e64c39134d8ee93f9cf/satelliteLib-6b47f831c184878d7338d4683ecf773a17973bb9.js"></script>
     </head>
-    <body class="view-{{ VIEW_NAME_FOR_CSS }} section-{{ PATH_LEVEL_1|default:'homepage' }}">
+    <body class="view-{{ VIEW_NAME_FOR_CSS }} section-{{ PATH_LEVEL_1|default:'homepage' }} environment-{{ CONCORDIA_ENVIRONMENT }}">
         <header>
             <nav class="navbar navbar-expand-lg flex-row navbar-offwhite bg-offwhite justify-content-between align-items-end py-half px-md-default pl-2">
                 <div class="d-flex navbar-brand">

--- a/concordia/templates/base.html
+++ b/concordia/templates/base.html
@@ -18,7 +18,11 @@
         {% comment %}
             Adobe's tag manager requires this script to be placed at the top even though it's bad for performance:
         {% endcomment %}
-        <script src="https://assets.adobedtm.com/dac62e20b491e735c6b56e64c39134d8ee93f9cf/satelliteLib-6b47f831c184878d7338d4683ecf773a17973bb9.js"></script>
+        {% if CONCORDIA_ENVIRONMENT == "production" %}
+            <script src="https://assets.adobedtm.com/dac62e20b491e735c6b56e64c39134d8ee93f9cf/satelliteLib-6b47f831c184878d7338d4683ecf773a17973bb9.js"></script>
+        {% else %}
+            <script src="https://assets.adobedtm.com/dac62e20b491e735c6b56e64c39134d8ee93f9cf/satelliteLib-6b47f831c184878d7338d4683ecf773a17973bb9-staging.js"></script>
+        {% endif %}
     </head>
     <body class="view-{{ VIEW_NAME_FOR_CSS }} section-{{ PATH_LEVEL_1|default:'homepage' }} environment-{{ CONCORDIA_ENVIRONMENT }}">
         <header>


### PR DESCRIPTION
Our previous instructions were clarified to add a second URL to use for non-production metrics. This adds that and exposes the environment to templates and CSS in case we want to add other conditional logic.

Closes #208 

See #160 