### PR TITLE
Remove insecure url patterns

### DIFF
--- a/concordia/urls.py
+++ b/concordia/urls.py
@@ -226,15 +226,6 @@ urlpatterns += [
     ),
 ]
 
-# FIXME: these should only be enabled for debugging as per https://docs.djangoproject.com/en/2.0/ref/views/#django.views.static.serve
-urlpatterns += [
-    re_path(r"^static/(?P<path>.*)$", serve, {"document_root": settings.STATIC_ROOT})
-]
-
-urlpatterns += [
-    re_path(r"^media/(?P<path>.*)$", serve, {"document_root": settings.MEDIA_ROOT})
-]
-
 urlpatterns += [url("", include("django_prometheus_metrics.urls"))]
 
 urlpatterns += [url(r"^captcha/", include("captcha.urls"))]


### PR DESCRIPTION
These aren’t used when DEBUG=True for local development. On
server deployments, whitenoise serves static files and the
uploaded media files are served directly from S3.