### PR TITLE
Gracefully handle cases where Adobe's JavaScript fails to load

### DIFF
--- a/concordia/templates/base.html
+++ b/concordia/templates/base.html
@@ -145,6 +145,14 @@
 
     {% block body_scripts %}{% endblock body_scripts %}
 
-    <script type="text/javascript">_satellite.pageBottom();</script>
+    <script type="text/javascript">
+        if (typeof _satellite == "undefined") {
+            if (typeof raven != "undefined") {
+                raven.captureMessage("Adobe Analytics did not load");
+            }
+        } else {
+            _satellite.pageBottom();
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
With this increasingly being blocked in the default configuration for
many users we can avoid an outright JavaScript error but, if Sentry is
enabled, still get an idea for the number of visitors who were affected.