### PR TITLE
Overhaul Contact Us form

### DIFF
--- a/concordia/forms.py
+++ b/concordia/forms.py
@@ -39,17 +39,10 @@ class UserProfileForm(forms.Form):
 
 
 class ContactUsForm(forms.Form):
-    email = forms.CharField(
-        label="Your email",
-        required=True,
-        widget=forms.EmailInput(attrs={"class": "form-control"}),
-    )
+    referrer = forms.CharField(label="Referring Page", widget=forms.HiddenInput())
 
-    subject = forms.CharField(
-        label="Subject",
-        required=False,
-        widget=forms.TextInput(attrs={"class": "form-control"}),
-    )
+    email = forms.EmailField(label="Your email", required=True)
+    subject = forms.CharField(label="Subject", required=False)
 
     category = forms.CharField(
         label="Category",
@@ -59,21 +52,16 @@ class ContactUsForm(forms.Form):
                 ("General", "General"),
                 ("Campaign", "Question about campaign"),
                 ("Problem", "Something is not working"),
-            ),
-            attrs={"class": "form-control"},
+            )
         ),
     )
 
-    link = forms.CharField(
-        label="Link to the page you need support with",
-        required=False,
-        widget=forms.URLInput(attrs={"class": "form-control"}),
+    link = forms.URLField(
+        label="Link to the page you need support with", required=False
     )
 
     story = forms.CharField(
-        label="Why are you contacting us",
-        required=True,
-        widget=forms.Textarea(attrs={"class": "form-control"}),
+        label="Why are you contacting us", required=True, widget=forms.Textarea
     )
 
 

--- a/concordia/templates/contact.html
+++ b/concordia/templates/contact.html
@@ -1,99 +1,23 @@
 {% extends "base.html" %}
 
+{% load bootstrap4 %}
+
 {% block main_content %}
-<div class="container-fluid py-default">
-    {% if messages %}
-    {% for message in messages %}
-    <div class="alert {% if message.tags %}alert-{{ message.tags }}{% endif %} alert-dismissable col-md-10 mx-auto rounded">
-        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&#215;</button>
-        {{ message }}
-    </div>
-    {% endfor %}
-    {% endif %}
-
+<div class="container">
     <div class="row">
-        <div class="col-md-10 mx-auto bg-offwhite rounded">
-            <div class="mxy-default">
-                <h1 class="mt-half mb-quarter text-center">Contact Us</h1>
-                <form method="post" action="{% url 'contact' %}" id="contact-form" class="col-10 mx-auto">
-                    {% csrf_token %}
-                    {{ form.non_field_errors }}
-                    {% if form.errors %}
-                    <p class="text-center">Please fix the errors below:</p>
-                    {% endif %}
+        <div class="col-md-10 mx-auto">
+            <h1 class="text-center">Contact Us</h1>
+            <form method="post" action="{% url 'contact' %}" id="contact-form" class="col-10 mx-auto">
+                {% csrf_token %}
 
-                    <div class="form-group row">
-                        <label class="col-sm-2 col-form-label" for="{{ form.email.id_for_label }}">
-                            {{ form.email.label }}
-                        </label>
-                        <div class="col-sm-10">
-                            {{ form.email }}
-                            {% if form.email.errors %}
-                            <div class="text-danger">
-                                {% for error in form.email.errors %}{{ error }} {% endfor %}
-                            </div>
-                            {% endif %}
-                        </div>
-                    </div>
-                    <div class="form-group row justify-content-center">
-                        <label class="col-sm-2 col-form-label" for="{{ form.subject.id_for_label }}">
-                            {{ form.subject.label }}
-                        </label>
-                        <div class="col-sm-10">
-                            {{ form.subject }}
-                            {% if form.subject.errors %}
-                            <div class="text-danger">
-                                {% for error in form.subject.errors %}{{ error }} {% endfor %}
-                            </div>
-                            {% endif %}
-                        </div>
-                    </div>
-                    <div class="form-group row justify-content-center">
-                        <label class="col-sm-2 col-form-label" for="{{ form.category.id_for_label }}">
-                            {{ form.category.label }}
-                        </label>
-                        <div class="col-sm-10">
-                            {{ form.category }}
-                            {% if form.subject.errors %}
-                            <div class="text-danger">
-                                {% for error in form.subject.errors %}{{ error }} {% endfor %}
-                            </div>
-                            {% endif %}
-                        </div>
-                    </div>
-                    <div class="form-group row justify-content-center">
-                        <label class="col-sm-2 col-form-label" for="{{ form.link.id_for_label }}">
-                            {{ form.link.label }}
-                        </label>
-                        <div class="col-sm-10">
-                            {{ form.link }}
-                            {% if form.link.errors %}
-                            <div class="text-danger">
-                                {% for error in form.link.errors %}{{ error }} {% endfor %}
-                            </div>
-                            {% endif %}
-                        </div>
-                    </div>
-                    <div class="form-group row justify-content-center">
-                        <label class="col-sm-2 col-form-label" for="{{ form.story.id_for_label }}">
-                            {{ form.story.label }}
-                        </label>
-                        <div class="col-sm-10">
-                            {{ form.story }}
-                            {% if form.story.errors %}
-                            <div class="text-danger">
-                                {% for error in form.story.errors %}{{ error }} {% endfor %}
-                            </div>
-                            {% endif %}
-                        </div>
-                    </div>
-                    <div class="form-group row justify-content-center">
-                        <div class="col-sm-10 offset-sm-2">
-                            <input class="btn btn-primary btn-lg" type="submit" value="Submit">
-                        </div>
-                    </div>
-                </form>
-            </div>
+                {% bootstrap_form form %}
+
+                {% buttons %}
+                    <button type="submit" class="btn btn-primary">
+                        Save
+                    </button>
+                {% endbuttons %}
+            </form>
         </div>
     </div>
 </div>

--- a/concordia/templates/emails/contact_us_email.html
+++ b/concordia/templates/emails/contact_us_email.html
@@ -1,0 +1,28 @@
+<p>Contact request from <a href="mailto:{{ email|urlencode }}">{{ email }}</a>:</p>
+
+<table>
+    <tr>
+        <th>Subject</th>
+        <td>{{ subject }}</td>
+    </tr>
+    <tr>
+        <th>Category</th>
+        <td>{{ category }}</td>
+    </tr>
+    {% if link %}
+        <tr>
+            <th>Link</th>
+            <td><a href="{{ link }}">{{ link }}</a></td>
+        </tr>
+    {% endif %}
+    {% if referrer %}
+        <tr>
+            <th>Referring Page</th>
+            <td><a href="{{ referrer }}">{{ referrer }}</a></td>
+        </tr>
+    {% endif %}
+    <tr>
+        <th>Story</th>
+        <td>{{ story }}</td>
+    </tr>
+</table>

--- a/concordia/templates/emails/contact_us_email.txt
+++ b/concordia/templates/emails/contact_us_email.txt
@@ -1,9 +1,9 @@
-Hello:
+Contact request from {{ email }}:
 
-  We got an email from {{ from_email }}:
-   
-  Subject: {{ subject }}
-  Category: {{ category }}
-  Link:  {{ link }}
-  Story: 
-    {{ story }}
+Subject: {{ subject }}
+Category: {{ category }}
+Link:  {{ link }}
+Referring Page: {{ referrer|default:"Unspecified" }}
+
+Story:
+{{ story }}

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -135,7 +135,7 @@ Crowd: {{ asset.title }} ({{ asset.project.campaign.title }} — {{ asset.projec
                 </form>
             </div>
 
-            <a id="contact-button" class="btn btn-minimal-secondary" href="{% url 'contact' %}?pre_populate=1">
+            <a id="contact-button" class="btn btn-minimal-secondary" href="{% url 'contact' %}">
                 Contact a Manager
             </a>
         </div>

--- a/concordia/tests/test_1st_level_views.py
+++ b/concordia/tests/test_1st_level_views.py
@@ -33,9 +33,7 @@ class ViewTest_1st_level(TestCase):
         test_http_referrer = "http://foo/bar"
 
         # Act
-        response = self.client.get(
-            reverse("contact") + "?pre_populate=true", HTTP_REFERER=test_http_referrer
-        )
+        response = self.client.get(reverse("contact"), HTTP_REFERER=test_http_referrer)
 
         # Assert:
         self.assertEqual(response.status_code, 200)

--- a/concordia/tests/test_view.py
+++ b/concordia/tests/test_view.py
@@ -1125,7 +1125,7 @@ class ViewTest_Concordia(TestCase):
 
         # Assert
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, "/contact/?pre_populate=true")
+        self.assertEqual(response.url, "/contact/")
 
     @responses.activate
     def test_ConcordiaAssetView_post_anonymous_happy_path(self):

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -1,9 +1,9 @@
-import html
 import json
 import os
 import time
 from datetime import datetime
 from logging import getLogger
+from smtplib import SMTPException
 
 import markdown
 from django.conf import settings
@@ -715,41 +715,47 @@ class ContactUsView(FormView):
         return res
 
     def get_initial(self):
-        if self.request.GET.get("pre_populate"):
-            return {
-                "email": (
-                    None if self.request.user.is_anonymous else self.request.user.email
-                ),
-                "link": (
-                    self.request.META.get("HTTP_REFERER")
-                ),
-            }
+        initial = super().get_initial()
 
-    def post(self, *args, **kwargs):
-        email = html.escape(self.request.POST.get("email") or "")
-        subject = html.escape(self.request.POST.get("subject") or "")
-        category = html.escape(self.request.POST.get("category") or "")
-        link = html.escape(self.request.POST.get("link") or "")
-        story = html.escape(self.request.POST.get("story") or "")
+        if (
+            self.request.user.is_authenticated
+            and self.request.user.username != "anonymous"
+        ):
+            initial["email"] = self.request.user.email
 
-        t = loader.get_template("emails/contact_us_email.txt")
-        send_mail(
-            subject,
-            t.render(
-                {
-                    "from_email": email,
-                    "subject": subject,
-                    "category": category,
-                    "link": link,
-                    "story": story,
-                }
-            ),
-            getattr(settings, "DEFAULT_FROM_EMAIL"),
-            [getattr(settings, "DEFAULT_TO_EMAIL")],
-            fail_silently=True,
-        )
+        initial["referrer"] = self.request.META.get("HTTP_REFERER")
 
-        messages.success(self.request, "Your contact message has been sent...")
+        return initial
+
+    def form_valid(self, form):
+        text_template = loader.get_template("emails/contact_us_email.txt")
+        text_message = text_template.render(form.cleaned_data)
+
+        html_template = loader.get_template("emails/contact_us_email.html")
+        html_message = html_template.render(form.cleaned_data)
+
+        try:
+            send_mail(
+                "Contact Us: %(subject)s" % form.cleaned_data,
+                message=text_message,
+                html_message=html_message,
+                from_email=settings.DEFAULT_FROM_EMAIL,
+                recipient_list=[settings.DEFAULT_TO_EMAIL],
+            )
+
+            messages.success(self.request, "Your contact message has been sent...")
+        except SMTPException as exc:
+            logger.error(
+                "Unable to send contact message to %s: %s",
+                settings.DEFAULT_TO_EMAIL,
+                exc,
+                exc_info=True,
+                extra={"data": form.cleaned_data},
+            )
+            messages.error(
+                self.request,
+                "Your message could not be sent. Our support team has been notified.",
+            )
 
         return redirect("contact")
 
@@ -836,4 +842,3 @@ class ReportCampaignView(TemplateView):
             project.transcription_statuses.insert(
                 0, ("Not Started", project.asset_count - total_statuses)
             )
-


### PR DESCRIPTION
* [x] Use type-specific Django form fields
* [x] Use bootstrap4 instead of hand-coding everything
* [x] Always include the HTTP Referer distinct from the optional  link field
* [x] Use Django’s form API to validate inputs
* [x] Use Django’s form API to provide the template context  rather than building it by hand
* [x] Don’t HTML escape the plain-text content
* [x] Add HTML alternative message
* [x] Handle errors rather than ignoring them