### PR TITLE
Use IAM role with ECS tasks

### DIFF
--- a/cloudformation/services/concordia-service/service.yaml
+++ b/cloudformation/services/concordia-service/service.yaml
@@ -56,9 +56,10 @@ Resources:
 
     TaskDefinition:
         Type: AWS::ECS::TaskDefinition
-        Memory: 2048
-        Cpu: 1024
         Properties:
+            Memory: 2048
+            Cpu: 1024
+            TaskRoleArn: !GetAtt TaskRole.Arn
             Family: !Sub concordia-${EnvName}
             Volumes:
                 - Name: images_volume
@@ -162,6 +163,48 @@ Resources:
                 - TargetGroupArn: !Ref TargetGroup
                   Type: forward
 
+    TaskRole:
+        Type: AWS::IAM::Role
+        Properties:
+            Path: /
+            RoleName: !Sub ecs-concordia-taskrole-${AWS::StackName}
+            AssumeRolePolicyDocument: |
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                        "Sid": "",
+                        "Effect": "Allow",
+                        "Principal": {
+                            "Service": "ecs-tasks.amazonaws.com"
+                        },
+                        "Action": "sts:AssumeRole"
+                        }
+                    ]
+                }
+            Policies:
+                - PolicyName: !Sub ecs-concordia-taskpolicy-${AWS::StackName}
+                  PolicyDocument: |
+                    {
+                        "Statement": [{
+                            "Effect": "Allow",
+                            "Action": [
+                                "s3:PutObject",
+                                "s3:GetObject",
+                                "s3:AbortMultipartUpload",
+                                "s3:ListMultipartUploadParts",
+                                "s3:ListBucket",
+                                "s3:ListBucketMultipartUploads",
+                                "secretsmanager:GetResourcePolicy",
+                                "secretsmanager:GetSecretValue",
+                                "secretsmanager:DescribeSecret",
+                                "secretsmanager:ListSecretVersionIds"
+                            ],
+                            "Resource": "*"
+                        }]
+                    }
+    
+    
     # This IAM Role grants the service access to register/unregister with the 
     # Application Load Balancer (ALB). It is based on the default documented here:
     # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_IAM_role.html

--- a/cloudformation/update_services.sh
+++ b/cloudformation/update_services.sh
@@ -5,7 +5,7 @@ set -eu
 # DEV ENVIRONMENT
 
 # CLUSTER_NAME=crowd-dev
-# SERVICE_NAME=crowd-dev-app2-Service-FJM8LRJNL7HN
+# SERVICE_NAME=crowd-dev-app-Service-GNP6S8RBB14T
 # ECS AutoScaling role ARN
 # arn:aws:iam::351149051428:role/crowd-dev-ECS-RQZSJ89GYY4-ECSServiceAutoScalingRol-KJ5SO8E1KIWF	
 # Load Balancer Listener

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,6 @@
 
 set -e -u # Exit immediately for unhandled errors or undefined variables
 
-source ./.env
-
 mkdir -p /app/logs
 touch /app/logs/concordia.log
 

--- a/importer/entrypoint.sh
+++ b/importer/entrypoint.sh
@@ -2,8 +2,6 @@
 
 set -e -u # Exit immediately for unhandled errors or undefined variables
 
-source ./.env
-
 mkdir -p /app/logs
 touch /app/logs/concordia.log
 


### PR DESCRIPTION
This update creates a Task Role and attaches it to the ECS tasks. However, the application and importer still can't retrieve secrets from the secrets manager even with this role added to the task. Does it also need to be a "taskExecutionRole"  in addition to "taskRole" ?