### PR TITLE
Upgrade minimum version of Django to 2.0.9

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,7 @@ django-haystack = "*"
 "boto3" = "*"
 botocore = '*'
 requests = "*"
-Django = "<2.1,>=2"
+Django = "<2.1,>=2.0.9"
 Pillow = "*"
 confusable_homoglyphs = ">=3.1.1"
 Whoosh = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e90f0bd667d68e3d5a8b939621f23aa17d66fcb3ee8b0cf0d2972868d4bb0f84"
+            "sha256": "97a9ebb185c6e2926df56b84e04d875dc4eadc952ae9720218806366d1d56e81"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -236,7 +236,7 @@
                 "sha256:7546cc08e3899716e12fe67d12d7cfe9a64647014d1134b014c3c392b63cad42",
                 "sha256:aada5cfdc4a543c47098eb3aca6663848ef5d04b4324935ced441debc11ec98b"
             ],
-            "markers": "python_version >= '2.6' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version < '4'",
+            "markers": "python_version != '3.0.*' and python_version < '4' and python_version != '3.3.*' and python_version >= '2.6' and python_version != '3.1.*' and python_version != '3.2.*'",
             "version": "==6.3.1"
         },
         "elasticsearch-dsl": {
@@ -370,7 +370,7 @@
                 "sha256:ff8cff01582fa1a7e533cb97f628531c4014af4b5f38e33cdcfe5eec29b6d888"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.2.*'",
+            "markers": "python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*'",
             "version": "==5.3.0"
         },
         "prometheus-client": {
@@ -524,7 +524,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version != '3.0.*' and python_version >= '2.6' and python_version != '3.2.*' and python_version < '4' and python_version != '3.3.*' and python_version != '3.1.*'",
+            "markers": "python_version != '3.1.*' and python_version >= '2.6' and python_version != '3.2.*' and python_version < '4' and python_version != '3.3.*' and python_version != '3.0.*'",
             "version": "==1.23"
         },
         "vine": {
@@ -580,7 +580,7 @@
                 "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
                 "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.0.*'",
+            "markers": "python_version != '3.1.*' and python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.2.*'",
             "version": "==7.0"
         },
         "django": {

--- a/importer/setup.py
+++ b/importer/setup.py
@@ -2,9 +2,9 @@
 from setuptools import find_packages, setup
 
 VERSION = __import__("importer").get_version()
-INSTALL_REQUIREMENTS = ["boto3", "celery", "requests", "Django<2.1", "Pillow"]
+INSTALL_REQUIREMENTS = ["boto3", "celery", "requests", "Django<2.1,>=2.0.9", "Pillow"]
 DESCRIPTION = "Download collections of images from loc.gov"
-CLASSIFIERS = """\
+CLASSIFIERS = """
 Environment :: Web Environment
 Framework :: Django :: 2.0
 Development Status :: 2 - Pre-Alpha

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 VERSION = __import__("concordia").get_version()
-INSTALL_REQUIREMENTS = ["Django<2.1"]
+INSTALL_REQUIREMENTS = ["<2.1,>=2.0.9"]
 SCRIPTS = ["manage.py"]
 DESCRIPTION = "Transcription crowdsourcing"
 CLASSIFIERS = """\


### PR DESCRIPTION
This avoids security regressions if installed in a manner
which somehow ignored the newer 2.0.x releases.