### PR TITLE
Asset detail pagination

### DIFF
--- a/concordia/models.py
+++ b/concordia/models.py
@@ -187,6 +187,17 @@ class Asset(models.Model):
     def __str__(self):
         return self.title
 
+    def get_absolute_url(self):
+        return reverse(
+            "transcriptions:asset-detail",
+            kwargs={
+                "campaign_slug": self.item.project.campaign.slug,
+                "project_slug": self.item.project.slug,
+                "item_id": self.item.item_id,
+                "slug": self.slug,
+            },
+        )
+
 
 class Tag(models.Model):
     TAG_VALIDATOR = RegexValidator(r"^[- _'\w]{1,50}$")

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -35,6 +35,16 @@ Crowd: {{ asset.title }} ({{ asset.project.campaign.title }} — {{ asset.projec
         </div>
 
         <div class="col-6 p-2 contribute-box d-flex flex-column flex-nowrap justify-content-between" id="contribute-box">
+            <nav id="asset-navigation" class="d-flex justify-content-end">
+                <div class="btn-group btn-group-sm" role="navigation" aria-label="Links to related pages">
+                {% if previous_asset_url %}
+                    <a class="btn btn-secondary" href="{{ previous_asset_url }}">&larr; Previous Page</a>
+                {% endif %}
+                {% if next_asset_url %}
+                    <a class="btn btn-secondary" href="{{ next_asset_url }}">Next Page &rarr;</a>
+                {% endif %}
+                </div>
+            </nav>
             <table class="table-dark table-compact table-striped offwhite-text small">
                 <tr>
                     <th>Status</th>

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -286,6 +286,21 @@ class ConcordiaAssetView(DetailView):
         ctx["project"] = project = item.project
         ctx["campaign"] = project.campaign
 
+        previous_asset = (
+            item.asset_set.filter(sequence__lt=asset.sequence)
+            .order_by("sequence")
+            .last()
+        )
+        next_asset = (
+            item.asset_set.filter(sequence__gt=asset.sequence)
+            .order_by("sequence")
+            .first()
+        )
+        if previous_asset:
+            ctx["previous_asset_url"] = previous_asset.get_absolute_url()
+        if next_asset:
+            ctx["next_asset_url"] = next_asset.get_absolute_url()
+
         # Get the most recent transcription
         latest_transcriptions = Transcription.objects.filter(
             asset__slug=asset.slug


### PR DESCRIPTION
This is a first pass at #337 which adds basic next/previous links to the asset detail view:
 
![screenshot 2018-10-04 15 38 34](https://user-images.githubusercontent.com/46565/46498491-97a1b780-c7eb-11e8-9073-9ad453973caf.png)
