### PR TITLE
Latest version of pip breaks pipenv, workaround for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_script:
   - psql -c 'create database concordia;' -U postgres
 install:
   - pip install pipenv
+  - pipenv run pip install pip==18.0
   - pipenv install --dev --deploy
 # command to run tests
 script:


### PR DESCRIPTION
Pip 18.1 causes errors with pipenv. See https://github.com/pypa/pipenv/issues/2924 