### PR TITLE
Add published checks to public views

### DIFF
--- a/concordia/admin.py
+++ b/concordia/admin.py
@@ -318,6 +318,7 @@ class ItemAdmin(admin.ModelAdmin):
 @admin.register(Asset)
 class AssetAdmin(admin.ModelAdmin, CustomListDisplayFieldsMixin):
     list_display = (
+        "published",
         "transcription_status",
         "item_id",
         "sequence",
@@ -335,6 +336,7 @@ class AssetAdmin(admin.ModelAdmin, CustomListDisplayFieldsMixin):
         "item__item_id",
     ]
     list_filter = (
+        "published",
         "item__project__campaign",
         "item__project",
         "media_type",


### PR DESCRIPTION
This ensures that `.published()` queryset filters are consistently applied to the Campaign, Project, Item, and Asset views. As part of testing this I added filtering to the Asset admin view since I had many items which had no published assets.