### PR TITLE
Change importer item uniqueness check

### DIFF
--- a/importer/tasks.py
+++ b/importer/tasks.py
@@ -271,7 +271,10 @@ def create_item_import_task(self, import_job_pk, item_url):
     if not item_created:
         logger.warning("Not reprocessing existing item %s", item)
         import_item.status = "Not reprocessing existing item %s" % item
-        import_item.completed = now()
+        import_item.completed = import_item.last_started = now()
+        import_item.task_id = self.request.id
+        import_item.full_clean()
+        import_item.save()
         return
 
     import_item.item.metadata.update(item_data)

--- a/importer/tasks.py
+++ b/importer/tasks.py
@@ -16,7 +16,7 @@ from django.template.defaultfilters import slugify
 from django.utils.timezone import now
 from requests.exceptions import HTTPError
 
-from concordia.models import Asset, MediaType
+from concordia.models import Asset, Item, MediaType
 from concordia.storage import ASSET_STORAGE
 from importer.models import ImportItem, ImportItemAsset, ImportJob
 
@@ -259,10 +259,9 @@ def create_item_import_task(self, import_job_pk, item_url):
     resp.raise_for_status()
     item_data = resp.json()
 
-    item, item_created = import_job.project.item_set.get_or_create(
+    item, item_created = Item.objects.get_or_create(
         item_id=get_item_id_from_item_url(item_data["item"]["id"]),
-        item_url=item_url,
-        project=import_job.project,
+        defaults={"item_url": item_url, "project": import_job.project},
     )
 
     import_item, import_item_created = import_job.items.get_or_create(


### PR DESCRIPTION
This makes the importer's check for existing items apply globally rather than per-project, preventing the problem @VVH identified when seeding separate projects from search results which overlap.

Closes #369 