### PR TITLE
Item detail progress bar

### DIFF
--- a/concordia/forms.py
+++ b/concordia/forms.py
@@ -79,18 +79,8 @@ class AssetFilteringForm(forms.Form):
         widget=forms.Select(attrs={"class": "form-control"}),
     )
 
-    def __init__(self, asset_qs, *args, **kwargs):
+    def __init__(self, status_counts, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        # We want to get a list of all of the available asset states in this
-        # item's assets and will return that with the preferred display labels
-        # including the asset count to be displayed in the filter UI
-        asset_state_qs = asset_qs.values_list("transcription_status")
-        asset_state_qs = asset_state_qs.annotate(
-            Count("transcription_status")
-        ).order_by()
-
-        status_counts = dict(asset_state_qs)
 
         asset_statuses = {
             status: "%s (%d)" % (TranscriptionStatus.CHOICE_MAP[status], count)

--- a/concordia/templates/transcriptions/item_detail.html
+++ b/concordia/templates/transcriptions/item_detail.html
@@ -26,8 +26,8 @@ Crowd: {{ item.title }} ({{ campaign.title }} — {{ project.title }})
         </div>
         <div class="col-md-4">
             {% widthratio in_progress_percent paginator.count 100 as edit_percent %}
-            {% widthratio transcription_status_counts.submitted paginator.count 100 as submitted_percent %}
-            {% widthratio transcription_status_counts.completed paginator.count 100 as completed_percent %}
+            {% widthratio transcription_status_counts.submitted|default:0 paginator.count 100 as submitted_percent %}
+            {% widthratio transcription_status_counts.completed|default:0 paginator.count 100 as completed_percent %}
             <div class="row text-center">
                 <div class="col-md-4">
                     {{ in_progress_percent }}% in progress

--- a/concordia/templates/transcriptions/item_detail.html
+++ b/concordia/templates/transcriptions/item_detail.html
@@ -20,9 +20,33 @@ Crowd: {{ item.title }} ({{ campaign.title }} — {{ project.title }})
 {% block main_content %}
 <div class="container py-default">
     <div class="row">
-        <div class="col-md-12">
+        <div class="col-md-8">
             <h1 class="mt-default mb-3 ml-3">{{ item.title }}</h1>
             <p class="ml-default mb-default hero-text">{{ item.description }}</p>
+        </div>
+        <div class="col-md-4">
+            {% widthratio in_progress_percent paginator.count 100 as edit_percent %}
+            {% widthratio transcription_status_counts.submitted paginator.count 100 as submitted_percent %}
+            {% widthratio transcription_status_counts.completed paginator.count 100 as completed_percent %}
+            <div class="row text-center">
+                <div class="col-md-4">
+                    {{ in_progress_percent }}% in progress
+                </div>
+                <div class="col-md-4">
+                    {{ completed_percent }}% complete
+                </div>
+                <div class="col-md-4">
+                    {{ contributor_count|intcomma }} contributors
+                </div>
+            </div>
+            <div class="progress" style="height: 2rem">
+                <div title="In Progress" class="progress-bar progress-bar-striped progress-bar-animated bg-warning" role="progressbar" style="width: {{ edit_percent }}%" aria-valuenow="{{ edit_percent }}" aria-valuemin="0" aria-valuemax="100">
+                </div>
+                <div title="Submitted for Review" class="progress-bar bg-info" role="progressbar" style="width: {{ submitted_percent }}%" aria-valuenow="{{ submitted_percent }}" aria-valuemin="0" aria-valuemax="100">
+                </div>
+                <div title="Completed" class="progress-bar bg-success" role="progressbar" style="width: {{ completed_percent }}%" aria-valuenow="{{ completed_percent }}" aria-valuemin="0" aria-valuemax="100">
+                </div>
+            </div>
         </div>
     </div>
     <div class="row">

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -261,11 +261,16 @@ class ItemDetailView(ListView):
         # transcription, no matter how far along it is:
 
         contributors = Transcription.objects.filter(asset__item=self.item).aggregate(
-            Count("user", distinct=True),
-            Count("asset", distinct=True),
+            Count("user", distinct=True), Count("asset", distinct=True)
         )
 
-        in_progress_percent = round(100 * (contributors["asset__count"] / len(self.object_list)))
+        asset_count = len(self.object_list)
+        if asset_count:
+            in_progress_percent = round(
+                100 * (contributors["asset__count"] / asset_count)
+            )
+        else:
+            in_progress_percent = 0
 
         res.update(
             {
@@ -275,7 +280,7 @@ class ItemDetailView(ListView):
                 "filter_form": self.filter_form,
                 "transcription_status_counts": self.transcription_status_counts,
                 "contributor_count": contributors["user__count"],
-                "in_progress_percent": in_progress_percent
+                "in_progress_percent": in_progress_percent,
             }
         )
         return res


### PR DESCRIPTION
This adds a basic progress bar to the item detail page next to the title above the asset listing:

![screenshot_2018-10-12 crowd rosa parks papers general correspondence 1928-2006 letters and drawings from children 1986 4](https://user-images.githubusercontent.com/46565/46876105-75232600-ce0b-11e8-8ebd-64531dec661c.png)

I tried including text labels in the bar but the text will be truncated when the values aren't fairly large (e.g. >10%) so I made them tooltips instead:

![screenshot_2018-10-12 crowd rosa parks papers general correspondence 1928-2006 letters and drawings from children 1986](https://user-images.githubusercontent.com/46565/46876121-7bb19d80-ce0b-11e8-9b51-edd0f40c6fa3.png)

Displaying the edit state including items which have not been transcribed yet makes our progress bar always add up to 100% which felt misleading, so the final version above only lists assets which have at least some transcription progress in the “In Progress” state:

![screenshot_2018-10-12 crowd rosa parks papers general correspondence 1928-2006 letters and drawings from children 1986 1](https://user-images.githubusercontent.com/46565/46876151-95eb7b80-ce0b-11e8-9c64-22ac73dc0c60.png)

Closes #158 