### PR TITLE
Less shouty css

### DIFF
--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -105,13 +105,6 @@ h5 {
     font-weight: normal;
 }
 
-h5.small {
-    font-family: 'Open Sans', sans-serif;
-    font-size: 0.75rem;
-    font-weight: normal;
-    text-transform: uppercase;
-}
-
 h6 {
     font-family: 'Open Sans', sans-serif;
     font-size: 0.875rem;

--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -917,7 +917,7 @@ div.nav-secondary {
 }
 
 /*
- * Homeage customizations
+ * Homepage customizations
  */
 
 .view-homepage h1,

--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -50,7 +50,6 @@ h1 {
     font-size: 3rem;
     line-height: 125%;
     font-weight: bold;
-    text-transform: uppercase;
     color: var(--text-color-primary);
     margin-bottom: 1em;
 }
@@ -70,7 +69,6 @@ h2 {
     font-size: 1.5rem;
     line-height: 125%;
     font-weight: bold;
-    text-transform: uppercase;
     color: var(--text-color-primary);
 }
 
@@ -916,6 +914,15 @@ div.nav-secondary {
 
 .asset-card .card-actions .btn-default:not(:hover) {
     background-color: var(--light-shadow-color);
+}
+
+/*
+ * Homeage customizations
+ */
+
+.view-homepage h1,
+.view-homepage h2 {
+    text-transform: uppercase;
 }
 
 /*


### PR DESCRIPTION
This avoids making the campaign/project/item h1/h2 tags used for titles VERY BIG AND VERY LOUD

See #374