### PR TITLE
Asset detail UI updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,4 @@ repos:
       rev: 1.14.3
       hooks:
           - id: prettier
+            files: \.(css|less|scss|ts|tsx|graphql|gql|json|js|jsx|md)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,5 @@
 exclude: '.*/vendor/.*'
 repos:
-    - repo: https://github.com/pre-commit/mirrors-isort
-      rev: v4.3.4
-      hooks:
-          - id: isort
     - repo: https://github.com/ambv/black
       rev: stable
       hooks:

--- a/concordia/static/js/asset-reservation.js
+++ b/concordia/static/js/asset-reservation.js
@@ -16,14 +16,10 @@ function attemptToReserveAsset(reservationURL) {
         })
         .fail(function(jqXHR, textStatus, errorThrown) {
             if (jqXHR.status == 409) {
-                displayMessage(
-                    'warning',
-                    'Someone else is currently transcribing this page',
-                    'transcription-reservation'
-                );
                 $transcriptionEditor
                     .data('hasReservation', false)
                     .trigger('update-ui-state');
+                $('#asset-reservation-failure-modal').modal();
             } else {
                 displayMessage(
                     'error',

--- a/concordia/static/js/contribute.js
+++ b/concordia/static/js/contribute.js
@@ -232,19 +232,11 @@ function submitReview(status) {
         }
     })
         .done(function() {
-            displayMessage(
-                'info',
-                'Your transcription review has been saved',
-                'transcription-review-result'
-            );
-            if (status == 'accept') {
-                $('.tx-status-display')
-                    .children()
-                    .attr('hidden', 'hidden')
-                    .filter('.tx-completed')
-                    .removeAttr('hidden');
-            }
-            lockControls($transcriptionEditor);
+            $('#successful-review-modal')
+                .modal()
+                .on('hidden.bs.modal', function() {
+                    window.location.reload(true);
+                });
         })
         .fail(function(jqXHR, textStatus, errorThrown) {
             displayMessage(

--- a/concordia/static/js/contribute.js
+++ b/concordia/static/js/contribute.js
@@ -72,6 +72,11 @@ var $saveButton = $transcriptionEditor
 var $submitButton = $transcriptionEditor
     .find('#submit-transcription-button')
     .first();
+var $nothingToTranscribeCheckbox = $transcriptionEditor
+    .find('#nothing-to-transcribe')
+    .on('change', function() {
+        $transcriptionEditor.trigger('update-ui-state');
+    });
 
 $transcriptionEditor
     .on('update-ui-state', function() {
@@ -101,7 +106,10 @@ $transcriptionEditor
             } else {
                 $submitButton.attr('disabled', 'disabled');
 
-                if ($textarea.val()) {
+                if (
+                    $textarea.val() ||
+                    $nothingToTranscribeCheckbox.prop('checked')
+                ) {
                     $saveButton.removeAttr('disabled');
                 } else {
                     $saveButton.attr('disabled', 'disabled');
@@ -145,8 +153,20 @@ $transcriptionEditor
         $transcriptionEditor.trigger('update-ui-state');
     });
 
+$saveButton.on('click', function(evt) {
+    if (
+        !confirm(
+            'You have entered text but the “Nothing to transcribe” box is checked and that text will not be saved. Do you want to continue?'
+        )
+    ) {
+        evt.preventDefault();
+        return false;
+    }
+});
+
 $submitButton.on('click', function(evt) {
     evt.preventDefault();
+
     $.ajax({
         url: $transcriptionEditor.data('submitUrl'),
         method: 'POST'

--- a/concordia/static/js/contribute.js
+++ b/concordia/static/js/contribute.js
@@ -75,6 +75,18 @@ var $submitButton = $transcriptionEditor
 var $nothingToTranscribeCheckbox = $transcriptionEditor
     .find('#nothing-to-transcribe')
     .on('change', function() {
+        var $textarea = $transcriptionEditor.find('textarea');
+        if (this.checked && $textarea.val()) {
+            if (
+                confirm(
+                    'You currently have entered text which will not be saved because “Nothing to transcribe” is checked. Do you want to discard that text?'
+                )
+            ) {
+                $textarea.val('');
+            } else {
+                this.checked = false;
+            }
+        }
         $transcriptionEditor.trigger('update-ui-state');
     });
 
@@ -95,9 +107,13 @@ $transcriptionEditor
         if (!data.hasReservation || data.transcriptionStatus != 'edit') {
             lockControls($transcriptionEditor);
         } else {
-            var $textarea = $transcriptionEditor
-                .find('textarea')
-                .removeAttr('readonly');
+            var $textarea = $transcriptionEditor.find('textarea');
+
+            if ($nothingToTranscribeCheckbox.prop('checked')) {
+                $textarea.attr('readonly', 'readonly');
+            } else {
+                $textarea.removeAttr('readonly');
+            }
 
             if (data.transcriptionId && !data.unsavedChanges) {
                 // We have a transcription ID and it's not stale, so we can submit the transcription for review:
@@ -152,17 +168,6 @@ $transcriptionEditor
         );
         $transcriptionEditor.trigger('update-ui-state');
     });
-
-$saveButton.on('click', function(evt) {
-    if (
-        !confirm(
-            'You have entered text but the “Nothing to transcribe” box is checked and that text will not be saved. Do you want to continue?'
-        )
-    ) {
-        evt.preventDefault();
-        return false;
-    }
-});
 
 $submitButton.on('click', function(evt) {
     evt.preventDefault();

--- a/concordia/static/js/contribute.js
+++ b/concordia/static/js/contribute.js
@@ -119,6 +119,9 @@ $transcriptionEditor
                 // We have a transcription ID and it's not stale, so we can submit the transcription for review:
                 $saveButton.attr('disabled', 'disabled');
                 $submitButton.removeAttr('disabled');
+                if (!$textarea.val()) {
+                    $nothingToTranscribeCheckbox.prop('checked', true);
+                }
             } else {
                 $submitButton.attr('disabled', 'disabled');
 

--- a/concordia/static/js/contribute.js
+++ b/concordia/static/js/contribute.js
@@ -180,16 +180,16 @@ $submitButton.on('click', function(evt) {
         method: 'POST'
     })
         .done(function() {
-            displayMessage(
-                'info',
-                'The transcription has been submitted. Go to the next page when you are done tagging.',
-                'transcription-submit-result'
-            );
             $('.tx-status-display')
                 .children()
                 .attr('hidden', 'hidden')
                 .has('.tx-submitted')
                 .removeAttr('hidden');
+            $('#successful-submission-modal')
+                .modal()
+                .on('hidden.bs.modal', function() {
+                    window.location.reload(true);
+                });
         })
         .fail(function(jqXHR, textStatus, errorThrown) {
             displayMessage(

--- a/concordia/static/js/contribute.js
+++ b/concordia/static/js/contribute.js
@@ -12,6 +12,17 @@ function unlockControls($container) {
     $container.find('button').removeAttr('disabled');
 }
 
+function buildErrorMessage(jqXHR, textStatus, errorThrown) {
+    /* Construct a nice error message using optional JSON response context */
+    var errMessage;
+    if (jqXHR.responseJSON && jqXHR.responseJSON.error) {
+        errMessage = jqXHR.responseJSON.error;
+    } else {
+        errMessage = textStatus + ' ' + errorThrown;
+    }
+    return errMessage;
+}
+
 $('form.ajax-submission').each(function(idx, formElement) {
     /*
     Generic AJAX submission logic which takes a form and POSTs its data to the
@@ -194,7 +205,8 @@ $submitButton.on('click', function(evt) {
         .fail(function(jqXHR, textStatus, errorThrown) {
             displayMessage(
                 'error',
-                'Unable to save your work: ' + textStatus + ' ' + errorThrown,
+                'Unable to save your work: ' +
+                    buildErrorMessage(jqXHR, textStatus, errorThrown),
                 'transcription-submit-result'
             );
         });
@@ -235,13 +247,10 @@ function submitReview(status) {
             lockControls($transcriptionEditor);
         })
         .fail(function(jqXHR, textStatus, errorThrown) {
-            var errMessage = textStatus + ' ' + errorThrown;
-            if (jqXHR.responseJSON && jqXHR.responseJSON.error) {
-                errMessage = jqXHR.responseJSON.error;
-            }
             displayMessage(
                 'error',
-                'Unable to save your review: ' + errMessage,
+                'Unable to save your review: ' +
+                    buildErrorMessage(jqXHR, textStatus, errorThrown),
                 'transcription-review-result'
             );
         });

--- a/concordia/static/js/contribute.js
+++ b/concordia/static/js/contribute.js
@@ -108,6 +108,14 @@ $transcriptionEditor
                 }
             }
         }
+
+        if (!data.hasReservation && data.transcriptionStatus == 'edit') {
+            $('.tx-status-display')
+                .children()
+                .attr('hidden', 'hidden')
+                .filter('.tx-edit-conflict')
+                .removeAttr('hidden');
+        }
     })
     .on('form-submit-success', function(evt, extra) {
         displayMessage(

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -185,7 +185,7 @@ Crowd: {{ asset.title }} ({{ asset.item.project.campaign.title }} — {{ asset.i
             Quick Tips
         </button>
 
-        <a class="btn btn-secondary" href="alert('FIXME: this will be updated once https://github.com/LibraryOfCongress/concordia/issues/389 merges')">
+        <a class="btn btn-secondary" href="{% url 'help-center' %}">
             Questions?
         </a>
 

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -172,10 +172,12 @@ Crowd: {{ asset.title }} ({{ asset.item.project.campaign.title }} — {{ asset.i
             </div>
         </div>
     </div>
-    <div id="help-container" class="row">
+    <div id="help-container" class="row justify-content-center">
         <p>Need help?</p>
 
-        <button id="instruction-button" class="btn btn-secondary" type="button" data-toggle="collapse" data-target="#instruction-window" aria-expanded="false" aria-controls="instruction-window">Instructions</button>
+        <button id="instruction-button" class="btn btn-secondary" type="button" data-toggle="collapse" data-target="#instruction-window" aria-expanded="false" aria-controls="instruction-window">
+            Quick Tips
+        </button>
 
         <a id="contact-button" class="btn btn-secondary" href="{% url 'contact' %}">
             Contact Us

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -85,7 +85,7 @@ Crowd: {{ asset.title }} ({{ asset.item.project.campaign.title }} — {{ asset.i
                     </span>
                 </div>
 
-                <form id="transcription-editor" class="ajax-submission flex-grow-1 d-flex flex-column" method="post" action="{% url 'save-transcription' asset_pk=asset.pk %}" data-transcription-status="{{ transcription_status }}" {% if transcription %}data-transcription-id="{{ transcription.pk|default:'' }}" data-submit-url="{% url 'submit-transcription' pk=transcription.pk %}" data-review-url="{% url 'review-transcription' pk=transcription.pk %}"{% endif %}>
+                <form id="transcription-editor" class="ajax-submission flex-grow-1 d-flex flex-column" method="post" action="{% url 'save-transcription' asset_pk=asset.pk %}" data-transcription-status="{{ transcription_status }}" {% if transcription %}data-transcription-id="{{ transcription.pk|default:'' }}" {% if transcription.submitted %}data-unsaved-changes="true"{% endif %} data-submit-url="{% url 'submit-transcription' pk=transcription.pk %}" data-review-url="{% url 'review-transcription' pk=transcription.pk %}"{% endif %}>
                     {% csrf_token %}
                     <input type="hidden" name="supersedes" value="{{ transcription.pk|default:'' }}" />
 

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -246,7 +246,33 @@ Crowd: {{ asset.title }} ({{ asset.item.project.campaign.title }} — {{ asset.i
             </div>
         </div>
     </div>
-
+    <div id="successful-review-modal" class="modal" tabindex="-1" role="dialog">
+        <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Nice Job!</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <p>
+                        Your review decision has been saved. You can continue
+                        workong on this page or go to the next page needing
+                        transcription.
+                    </p>
+                </div>
+                <div class="modal-footer">
+                    <a class="btn btn-primary" href="{% url "transcriptions:redirect-to-next-transcribable-asset" campaign.slug project.slug %}">
+                        Find a new page
+                    </a>
+                    <button type="button" class="btn btn-primary" data-dismiss="modal">
+                        Continue Working
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 {% endblock main_content %}
 

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -23,29 +23,6 @@ Crowd: {{ asset.title }} ({{ asset.item.project.campaign.title }} — {{ asset.i
 
 {% block main_content %}
 <div id="contribute-main-content" class="container-fluid flex-grow-1 d-flex flex-column">
-    <div id="metadata-container" class="row">
-        <table class="d-inline table table-sm mx-3">
-            <tbody>
-                <tr>
-                    <th>Status</th>
-                    <td class="tx-status-display">
-                        <div class="tx-submitted" {% if transcription_status != 'submitted' %}hidden{% endif %}>
-                            <i class="fas fa-list tx-submitted"></i>
-                            Submitted for Review
-                        </div>
-                        <div class="tx-completed" {% if transcription_status != 'completed' %}hidden{% endif %}>
-                            <i class="fas fa-check"></i>
-                            Completed
-                        </div>
-                        <div class="tx-edit" {% if transcription_status != "edit" %}hidden{% endif %}>
-                            <i class="fas fa-edit tx-edit"></i>
-                            Open for edit
-                        </div>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
     <div id="navigation-container" class="row py-2">
         <nav id="asset-navigation" class="d-flex flex-grow-1 justify-content-between align-items-center" role="navigation">
             <div class="d-flex align-items-center">
@@ -89,6 +66,25 @@ Crowd: {{ asset.title }} ({{ asset.item.project.campaign.title }} — {{ asset.i
 
         <div class="col-6 d-flex flex-column flex-nowrap justify-content-between">
             <div class="flex-grow-1 d-flex flex-column">
+                <div class="tx-status-display">
+                    <span class="tx-submitted" {% if transcription_status != 'submitted' %}hidden{% endif %}>
+                        <span class="fas fa-list"></span>
+                        Submitted for Review
+                    </span>
+                    <span class="tx-completed" {% if transcription_status != 'completed' %}hidden{% endif %}>
+                        <span class="fas fa-check"></span>
+                        Completed
+                    </span>
+                    <span class="tx-edit" {% if transcription_status != "edit" %}hidden{% endif %}>
+                        <span class="fas fa-edit"></span>
+                        Open for edit
+                    </span>
+                    <span class="tx-edit-conflict" hidden>
+                        <span class="fas fa-exclamation-triangle"></span>
+                        Another user is transcribing this page
+                    </span>
+                </div>
+
                 <form id="transcription-editor" class="ajax-submission flex-grow-1 d-flex flex-column" method="post" action="{% url 'save-transcription' asset_pk=asset.pk %}" data-transcription-status="{{ transcription_status }}" {% if transcription %}data-transcription-id="{{ transcription.pk|default:'' }}" data-submit-url="{% url 'submit-transcription' pk=transcription.pk %}" data-review-url="{% url 'review-transcription' pk=transcription.pk %}"{% endif %}>
                     {% csrf_token %}
                     <input type="hidden" name="supersedes" value="{{ transcription.pk|default:'' }}" />

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -104,8 +104,14 @@ Crowd: {{ asset.title }} ({{ asset.item.project.campaign.title }} — {{ asset.i
                             </div>
                         {% endif %}
 
-                        <div class="my-3 d-flex justify-content-around align-items-center btn-row">
+                        <div class="my-3 d-flex flex-wrap justify-content-around align-items-center btn-row">
                             {% if transcription_status == 'edit' %}
+                                <div class="form-check w-100 text-center mt-0 mb-3">
+                                    <input id="nothing-to-transcribe" type="checkbox" class="form-check-input" />
+                                    <label class="form-check-label" for="nothing-to-transcribe">
+                                        Nothing to transcribe
+                                    </label>
+                                </div>
                                 <button id="save-transcription-button" disabled type="submit" class="btn btn-primary">Save</button>
                                 <button id="submit-transcription-button" disabled type="button" class="btn btn-primary">Submit for Review</button>
                             {% elif transcription_status == 'submitted' and user.is_authenticated and transcription.user.pk != user.pk %}

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -179,8 +179,8 @@ Crowd: {{ asset.title }} ({{ asset.item.project.campaign.title }} — {{ asset.i
             Quick Tips
         </button>
 
-        <a id="contact-button" class="btn btn-secondary" href="{% url 'contact' %}">
-            Contact Us
+        <a class="btn btn-secondary" href="alert('FIXME: this will be updated once https://github.com/LibraryOfCongress/concordia/issues/389 merges')">
+            Questions?
         </a>
 
         <div class="collapse" id="instruction-window">

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -219,6 +219,34 @@ Crowd: {{ asset.title }} ({{ asset.item.project.campaign.title }} — {{ asset.i
             </div>
         </div>
     </div>
+    <div id="successful-submission-modal" class="modal" tabindex="-1" role="dialog">
+        <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Nice Job!</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <p>
+                        This page has been submitted for review. You can
+                        continue to add tags for this page or go to the next
+                        page needing transcription.
+                    </p>
+                </div>
+                <div class="modal-footer">
+                    <a class="btn btn-primary" href="{% url "transcriptions:redirect-to-next-transcribable-asset" campaign.slug project.slug %}">
+                        Find a new page
+                    </a>
+                    <button type="button" class="btn btn-primary" data-dismiss="modal">
+                        Continue Tagging
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
 </div>
 {% endblock main_content %}
 

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -192,6 +192,25 @@ Crowd: {{ asset.title }} ({{ asset.item.project.campaign.title }} — {{ asset.i
             </p>
         </div>
     </div>
+    <div id="asset-reservation-failure-modal" class="modal " tabindex="-1" role="dialog">
+        <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Someone else is already transcribing this page</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <p>You can help by transcribing a new page, adding tags to this page, or coming back later to review this page's transcription.</p>
+                </div>
+                <div class="modal-footer">
+                    <a class="btn btn-primary" href="{% url "transcriptions:redirect-to-next-transcribable-asset" campaign.slug project.slug %}">Go to next page needing to be transcribed</a>
+                    <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 {% endblock main_content %}
 

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -236,12 +236,12 @@ Crowd: {{ asset.title }} ({{ asset.item.project.campaign.title }} — {{ asset.i
                     </p>
                 </div>
                 <div class="modal-footer">
-                    <a class="btn btn-primary" href="{% url "transcriptions:redirect-to-next-transcribable-asset" campaign.slug project.slug %}">
-                        Find a new page
-                    </a>
                     <button type="button" class="btn btn-primary" data-dismiss="modal">
                         Continue Tagging
                     </button>
+                    <a class="btn btn-primary" href="{% url "transcriptions:redirect-to-next-transcribable-asset" campaign.slug project.slug %}">
+                        Find a new page
+                    </a>
                 </div>
             </div>
         </div>

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -198,7 +198,7 @@ Crowd: {{ asset.title }} ({{ asset.item.project.campaign.title }} — {{ asset.i
             </p>
         </div>
     </div>
-    <div id="asset-reservation-failure-modal" class="modal " tabindex="-1" role="dialog">
+    <div id="asset-reservation-failure-modal" class="modal" tabindex="-1" role="dialog">
         <div class="modal-dialog modal-dialog-centered" role="document">
             <div class="modal-content">
                 <div class="modal-header">

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -55,7 +55,7 @@ Crowd: {{ asset.title }} ({{ asset.item.project.campaign.title }} — {{ asset.i
             </div>
 
             <div class="btn-group btn-group-sm align-self-end" role="navigation" aria-label="Link to the next editable page">
-                <a class="btn btn-default" href="{% url "transcriptions:redirect-to-next-transcribable-asset" campaign.slug project.slug %}">Go to next page needing to be transcribed &rarr;</a>
+                <a class="btn btn-default" href="{% url "transcriptions:redirect-to-next-transcribable-asset" campaign.slug project.slug %}">Find a new page &rarr;</a>
             </div>
         </nav>
     </div>
@@ -211,7 +211,9 @@ Crowd: {{ asset.title }} ({{ asset.item.project.campaign.title }} — {{ asset.i
                     <p>You can help by transcribing a new page, adding tags to this page, or coming back later to review this page's transcription.</p>
                 </div>
                 <div class="modal-footer">
-                    <a class="btn btn-primary" href="{% url "transcriptions:redirect-to-next-transcribable-asset" campaign.slug project.slug %}">Go to next page needing to be transcribed</a>
+                    <a class="btn btn-primary" href="{% url "transcriptions:redirect-to-next-transcribable-asset" campaign.slug project.slug %}">
+                        Find a new page
+                    </a>
                     <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
                 </div>
             </div>

--- a/concordia/tests/test_view.py
+++ b/concordia/tests/test_view.py
@@ -5,7 +5,7 @@ from django.test import TestCase, TransactionTestCase
 from django.urls import reverse
 from django.utils.timezone import now
 
-from concordia.models import AssetTranscriptionReservation, User, Transcription
+from concordia.models import AssetTranscriptionReservation, Transcription, User
 from concordia.views import get_anonymous_user
 
 from .utils import create_asset, create_campaign, create_item, create_project
@@ -134,10 +134,12 @@ class ConcordiaViewTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, template_name="transcriptions/item_detail.html")
+        self.assertTemplateUsed(
+            response, template_name="transcriptions/item_detail.html"
+        )
         self.assertContains(response, i.title)
 
-    def test_ConcordiaAssetView_get(self):
+    def test_asset_detail_view(self):
         """
         This unit test test the GET route /campaigns/<campaign>/asset/<Asset_name>/
         with already in use.
@@ -479,4 +481,3 @@ class TransactionalViewTests(TransactionTestCase):
         data = self.assertValidJSON(resp, expected_status=400)
         self.assertIn("error", data)
         self.assertEqual("This transcription has already been reviewed", data["error"])
-

--- a/concordia/urls.py
+++ b/concordia/urls.py
@@ -37,7 +37,7 @@ tx_urlpatterns = (
         ),
         path(
             "<slug:campaign_slug>/<slug:project_slug>/<slug:item_id>/<slug:slug>/",
-            views.ConcordiaAssetView.as_view(),
+            views.AssetDetailView.as_view(),
             name="asset-detail",
         ),
         path(

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -287,7 +287,7 @@ class ItemDetailView(ListView):
         return res
 
 
-class ConcordiaAssetView(DetailView):
+class AssetDetailView(DetailView):
     """
     Class to handle GET ansd POST requests on route /campaigns/<campaign>/asset/<asset>
     """


### PR DESCRIPTION
* [x] Move transcription status messages over the editor
* [x] Display a modal when an asset reservation cannot be obtained
* [x] Add this-page-intentionally-blank checkbox
* [x] Add modals for successful transcription and review submissions
* [x] Update help buttons

Current status:
![screenshot_2018-10-15 crowd mss859430156-4 rosa parks papers letters from children](https://user-images.githubusercontent.com/46565/46970624-a3149e80-d087-11e8-983f-e7f8278a0fe5.png)
