### PR TITLE
Item detail asset list appearance improvements

### DIFF
--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -801,6 +801,9 @@ div.nav-secondary {
     flex-grow: 0;
     flex-basis: 200px;
 
+    width: 200px;
+    min-height: 300px;
+
     margin: 0.25rem;
 
     justify-content: start;

--- a/concordia/templates/transcriptions/item_detail.html
+++ b/concordia/templates/transcriptions/item_detail.html
@@ -61,37 +61,38 @@ Crowd: {{ item.title }} ({{ campaign.title }} — {{ project.title }})
                 </div>
             </div>
         </form>
-        <div class="card-deck justify-content-center">
-            {% for a in assets %}
-                {% url 'transcriptions:asset-detail' a.item.project.campaign.slug a.item.project.slug a.item.item_id a.slug as asset_detail_url %}
+    </div>
+    <div class="card-deck justify-content-center">
+        {% for a in assets %}
+            {% url 'transcriptions:asset-detail' a.item.project.campaign.slug a.item.project.slug a.item.item_id a.slug as asset_detail_url %}
 
-                <div class="card concordia-object-card" data-transcription-status="{{ a.transcription_status }}">
-                    <a href="{{ asset_detail_url }}">
-                        <img class="card-img" alt="{{ a.slug }}" src="{% asset_media_url a %}">
+            <div class="card concordia-object-card" data-transcription-status="{{ a.transcription_status }}">
+                <a href="{{ asset_detail_url }}">
+                    <img class="card-img" alt="{{ a.slug }}" src="{% asset_media_url a %}">
+                </a>
+
+                <a class="card-title" href="{{ asset_detail_url }}">
+                    #{{ a.sequence }}
+                </a>
+
+                <div class="card-actions">
+                    <a class="btn btn-sm btn-block btn-default">
+                        {% if a.transcription_status == 'submitted' %}
+                            <span class="fas fa-list tx-submitted"></span>
+                            Review
+                        {% elif a.transcription_status == 'completed' %}
+                            <span class="fas fa-check tx-completed"></span>
+                            Complete
+                        {% else %}
+                            <span class="fas fa-edit tx-edit"></span>
+                            Transcribe
+                        {% endif %}
                     </a>
-
-                    <a class="card-title" href="{{ asset_detail_url }}">
-                        #{{ a.sequence }}
-                    </a>
-
-                    <div class="card-actions">
-                        <a class="btn btn-sm btn-block btn-default">
-                            {% if a.transcription_status == 'submitted' %}
-                                <span class="fas fa-list tx-submitted"></span>
-                                Review
-                            {% elif a.transcription_status == 'completed' %}
-                                <span class="fas fa-check tx-completed"></span>
-                                Complete
-                            {% else %}
-                                <span class="fas fa-edit tx-edit"></span>
-                                Transcribe
-                            {% endif %}
-                        </a>
-                    </div>
                 </div>
-            {% endfor %}
-        </div>
-
+            </div>
+        {% endfor %}
+    </div>
+    <div class="row">
         {% include "standard-pagination.html" %}
     </div>
 </div>


### PR DESCRIPTION
* Set a minimum card height so the cards don’t look bad if there is no image available on a misconfigured server
* Adjust card display to avoid double-nesting rows (in Bootstrap 4 a card-deck is equivalent to a row) which caused content not to be centered if there were less than one row's worth of assets