### PR TITLE
Restore anonymous transcription captcha

### DIFF
--- a/concordia/forms.py
+++ b/concordia/forms.py
@@ -1,6 +1,5 @@
 from logging import getLogger
 
-from captcha.fields import CaptchaField
 from django import forms
 from django.contrib.auth import get_user_model
 from django_registration.forms import RegistrationForm
@@ -53,10 +52,6 @@ class ContactUsForm(forms.Form):
     story = forms.CharField(
         label="Let us know how we can help:", required=True, widget=forms.Textarea
     )
-
-
-class CaptchaEmbedForm(forms.Form):
-    captcha = CaptchaField()
 
 
 class AssetFilteringForm(forms.Form):

--- a/concordia/forms.py
+++ b/concordia/forms.py
@@ -45,9 +45,9 @@ class ContactUsForm(forms.Form):
     email = forms.EmailField(label="Your email:", required=True)
     subject = forms.CharField(label="Subject:", required=False)
 
-
     link = forms.URLField(
-        label="Have a specific page you need help with? Add the link below:", required=False
+        label="Have a specific page you need help with? Add the link below:",
+        required=False,
     )
 
     story = forms.CharField(

--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -268,8 +268,8 @@ AUTHENTICATION_BACKENDS = [
 ]
 
 CAPTCHA_CHALLENGE_FUNCT = "captcha.helpers.random_char_challenge"
-CAPTCHA_FIELD_TEMPLATE = "captcha/field.html"
-CAPTCHA_TEXT_FIELD_TEMPLATE = "captcha/text_field.html"
+#: Anonymous sessions require captcha validation every day by default:
+ANONYMOUS_CAPTCHA_VALIDATION_INTERVAL = 86400
 
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 WHITENOISE_ROOT = STATIC_ROOT

--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -1042,15 +1042,6 @@ div.related-links {
 }
 
 /*
-* CAPTCHA styling
-*/
-
-.captcha {
-    width: 10rem;
-    height: auto;
-}
-
-/*
 * Alerts
 */
 

--- a/concordia/static/js/contribute.js
+++ b/concordia/static/js/contribute.js
@@ -177,7 +177,12 @@ $transcriptionEditor
     .on('form-submit-failure', function(evt, info) {
         displayMessage(
             'error',
-            'Unable to save your work: ' + info.textStatus + info.errorThrown,
+            'Unable to save your work: ' +
+                buildErrorMessage(
+                    info.jqXHR,
+                    info.textStatus,
+                    info.errorThrown
+                ),
             'transcription-save-result'
         );
         $transcriptionEditor.trigger('update-ui-state');

--- a/concordia/static/js/contribute.js
+++ b/concordia/static/js/contribute.js
@@ -23,6 +23,30 @@ function buildErrorMessage(jqXHR, textStatus, errorThrown) {
     return errMessage;
 }
 
+var $captchaModal = $('#captcha-modal');
+var $captchaForm = $captchaModal.find('form').on('submit', function(evt) {
+    evt.preventDefault();
+
+    var formData = $captchaForm.serializeArray();
+
+    $.ajax({
+        url: $captchaForm.attr('action'),
+        method: 'POST',
+        data: $.param(formData)
+    })
+        .done(function() {
+            $captchaModal.modal('hide');
+        })
+        .fail(function(jqXHR) {
+            if (jqXHR.status == 401) {
+                $captchaModal.find('[name=key]').val(jqXHR.responseJSON.key);
+                $captchaModal
+                    .find('#captcha-image')
+                    .attr('src', jqXHR.responseJSON.image);
+            }
+        });
+});
+
 $('form.ajax-submission').each(function(idx, formElement) {
     /*
     Generic AJAX submission logic which takes a form and POSTs its data to the
@@ -63,6 +87,15 @@ $('form.ajax-submission').each(function(idx, formElement) {
                 });
             })
             .fail(function(jqXHR, textStatus, errorThrown) {
+                if (jqXHR.status == 401) {
+                    $captchaModal
+                        .find('[name=key]')
+                        .val(jqXHR.responseJSON.key);
+                    $captchaModal
+                        .find('#captcha-image')
+                        .attr('src', jqXHR.responseJSON.image);
+                    $captchaModal.modal();
+                }
                 $form.trigger('form-submit-failure', {
                     textStatus: textStatus,
                     errorThrown: errorThrown,

--- a/concordia/templates/captcha/field.html
+++ b/concordia/templates/captcha/field.html
@@ -1,7 +1,0 @@
-{{image}}{{hidden_field}}<button class="btn btn-default js-captcha-refresh">Change Image</button>
-<div class="input-group 'd-flex justify-content-center pt-2" id="input_group_for_captcha">
-	{{text_field}}
-    <div class="input-group-append">
-        <button class="btn btn-secondary" type="submit" name="action" value="Save">Enter</button>
-    </div>
-</div>

--- a/concordia/templates/captcha/text_field.html
+++ b/concordia/templates/captcha/text_field.html
@@ -1,1 +1,0 @@
-<input class="col-6 form-control" autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false" id="{{id}}_1" name="{{name}}_1" type="text" />

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -103,14 +103,6 @@
                             {{ transcription.text }}
                         </textarea>
 
-                        {% if user.is_anonymous %}
-                            <div class="d-none my-2 col-12 col-md-10 col-lg-8 mx-auto" id="captcha_container">
-                                <div class="text-center mt-3" id="captcha_div">
-                                    {{ captcha_form.captcha }}
-                                </div>
-                            </div>
-                        {% endif %}
-
                         <div class="my-3 d-flex flex-wrap justify-content-around align-items-center btn-row">
                             {% if transcription_status == 'edit' %}
                                 <div class="form-check w-100 text-center mt-0 mb-3">
@@ -281,6 +273,37 @@
                 </div>
             </div>
         </div>
+    </div>
+    <div id="captcha-modal" class="modal" tabindex="-1" role="dialog">
+        <form action="{% url 'ajax-captcha' %}" class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Please confirm you are not a robot</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <div class="form-row">
+                        <div class="help-text">
+                            Before continuing please enter the letters in the image
+                            below so we know you are a human:
+                        </div>
+                        <img id="captcha-image" class="d-block my-3 mx-auto border rounded">
+
+                    </div>
+                    <div class="form-row">
+                        <input name="response" class="form-control" autocomplete="off">
+                    </div>
+                    <input type="hidden" name="key"/>
+                </div>
+                <div class="modal-footer">
+                    <button type="submit" class="btn btn-primary">
+                        Continue
+                    </button>
+                </div>
+            </div>
+        </form>
     </div>
 </div>
 {% endblock main_content %}

--- a/concordia/tests/test_view.py
+++ b/concordia/tests/test_view.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime, timedelta
 
+from captcha.models import CaptchaStore
 from django.test import TestCase, TransactionTestCase
 from django.urls import reverse
 from django.utils.timezone import now
@@ -199,6 +200,27 @@ class TransactionalViewTests(TransactionTestCase):
 
         self.client.login(username="tester", password="top_secret")
 
+    def completeCaptcha(self, key=None):
+        """Submit a CAPTCHA response using the provided challenge key"""
+
+        if key is None:
+            challenge_data = self.assertValidJSON(
+                self.client.get(reverse("ajax-captcha")), expected_status=401
+            )
+            self.assertIn("key", challenge_data)
+            self.assertIn("image", challenge_data)
+            key = challenge_data["key"]
+
+        self.assertValidJSON(
+            self.client.post(
+                reverse("ajax-captcha"),
+                data={
+                    "key": key,
+                    "response": CaptchaStore.objects.get(hashkey=key).response,
+                },
+            )
+        )
+
     def test_asset_reservation(self):
         """
         Test the basic Asset reservation process
@@ -326,8 +348,28 @@ class TransactionalViewTests(TransactionTestCase):
 
         return data
 
+    def test_anonymous_transcription_save_captcha(self):
+        asset = create_asset()
+
+        resp = self.client.post(
+            reverse("save-transcription", args=(asset.pk,)), data={"text": "test"}
+        )
+        data = self.assertValidJSON(resp, expected_status=401)
+        self.assertIn("key", data)
+        self.assertIn("image", data)
+
+        self.completeCaptcha(data["key"])
+
+        resp = self.client.post(
+            reverse("save-transcription", args=(asset.pk,)), data={"text": "test"}
+        )
+        data = self.assertValidJSON(resp, expected_status=201)
+
     def test_transcription_save(self):
         asset = create_asset()
+
+        # We're not testing the CAPTCHA here so we'll complete it:
+        self.completeCaptcha()
 
         resp = self.client.post(
             reverse("save-transcription", args=(asset.pk,)), data={"text": "test"}
@@ -375,8 +417,32 @@ class TransactionalViewTests(TransactionTestCase):
         data = self.assertValidJSON(resp, expected_status=201)
         self.assertIn("submissionUrl", data)
 
+    def test_anonymous_transcription_submission(self):
+        asset = create_asset()
+        anon = get_anonymous_user()
+
+        transcription = Transcription(asset=asset, user=anon, text="previous entry")
+        transcription.full_clean()
+        transcription.save()
+
+        resp = self.client.post(
+            reverse("submit-transcription", args=(transcription.pk,))
+        )
+        data = self.assertValidJSON(resp, expected_status=401)
+        self.assertIn("key", data)
+        self.assertIn("image", data)
+
+        self.assertFalse(Transcription.objects.filter(submitted__isnull=False).exists())
+
+        self.completeCaptcha(data["key"])
+        self.client.post(reverse("submit-transcription", args=(transcription.pk,)))
+        self.assertTrue(Transcription.objects.filter(submitted__isnull=False).exists())
+
     def test_transcription_submission(self):
         asset = create_asset()
+
+        # We're not testing the CAPTCHA here so we'll complete it:
+        self.completeCaptcha()
 
         resp = self.client.post(
             reverse("save-transcription", args=(asset.pk,)), data={"text": "test"}
@@ -398,6 +464,9 @@ class TransactionalViewTests(TransactionTestCase):
 
     def test_stale_transcription_submission(self):
         asset = create_asset()
+
+        # We're not testing the CAPTCHA here so we'll complete it:
+        self.completeCaptcha()
 
         anon = get_anonymous_user()
 

--- a/concordia/urls.py
+++ b/concordia/urls.py
@@ -118,6 +118,7 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     # Apps
     path("forum/", include(board.urls)),
+    path("captcha/ajax/", views.ajax_captcha, name="ajax-captcha"),
     path("captcha/", include("captcha.urls")),
     re_path(r"^password_reset/$", auth_views.password_reset, name="password_reset"),
     re_path(


### PR DESCRIPTION
This now uses a fully AJAX approach which will only prompt
the user when the underlying view being called returns an
HTTP 401 error.

This adds a @validate_anonymous_captcha view decorator which
either processes the view as expected or returns an HTTP 401
with the CAPTCHA key & challenge image URL. 

The AJAX handler for form submissions automatically displays
the CAPTCHA modal and the error handler will update the 
image as many times as needed before successful completion.

It does not currently repeat the operation which the user 
was attempting since that would involve preserving the state
for whether the operation being attempted was a save or a
submission. We can add that after the UX is accepted.

![image](https://user-images.githubusercontent.com/46565/47116857-d34b7100-d230-11e8-9688-995af752c5f1.png)

Closes #384 