### PR TITLE
Deleting redundant .dockerignore file 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,0 @@
-.dockerignore


### PR DESCRIPTION
Which causes setuptools_scm to report incorrect version number

Refs #419 