### PR TITLE
Remove underline from sub-brand crowd hover

### DIFF
--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -177,7 +177,7 @@ a.gray-text {
 
 a.gray-text:hover {
     color: var(--primary-color);
-    text-decoration: underline;
+    text-decoration: none;
 }
 
 a.nav-secondary {


### PR DESCRIPTION
When hovering over the sub-brand "CROWD" in the header, the color will change from the gray to the primary color, but there will be no underline.