### PR TITLE
Item detail: asset cards have larger image click target

### DIFF
--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -842,6 +842,12 @@ ul.nav-secondary {
     background-color: var(--light-shadow-color);
 }
 
+.concordia-object-card .card-img-container {
+    display: block;
+    height: 100%;
+    width: 100%;
+}
+
 /*
  * Homepage customizations
  */

--- a/concordia/templates/transcriptions/item_detail.html
+++ b/concordia/templates/transcriptions/item_detail.html
@@ -71,7 +71,7 @@
             {% url 'transcriptions:asset-detail' a.item.project.campaign.slug a.item.project.slug a.item.item_id a.slug as asset_detail_url %}
 
             <div class="card concordia-object-card" data-transcription-status="{{ a.transcription_status }}">
-                <a href="{{ asset_detail_url }}">
+                <a class="card-img-container" href="{{ asset_detail_url }}">
                     <img class="card-img" alt="{{ a.slug }}" src="{% asset_media_url a %}">
                 </a>
 


### PR DESCRIPTION
Previously a row with images of mixed heights would have only the actual
image clickable. Now the entire card body is the click target.

Closes #470