### PR TITLE
Expose environment to RavenJS

### DIFF
--- a/concordia/templates/base.html
+++ b/concordia/templates/base.html
@@ -157,7 +157,7 @@
 
     {% if SENTRY_PUBLIC_DSN %}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/raven.js/3.26.1/raven.min.js" integrity="sha256-N3YzTdAC27tvNKpIM2rly/WvlJf8YAat0NjPXgh5Bw4=" crossorigin="anonymous"></script>
-    <script>Raven.config('{{ SENTRY_PUBLIC_DSN }}').install()</script>
+    <script>Raven.config('{{ SENTRY_PUBLIC_DSN }}', {'environment': '{{ CONCORDIA_ENVIRONMENT }}'}).install()</script>
     {% endif %}
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>


### PR DESCRIPTION
This allows the Sentry reports to be filtered based on the environment
just as we're doing on the backend.