### PR TITLE
Change the textarea placeholder for review / completed items

### DIFF
--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -107,7 +107,7 @@
                     <h2>Transcription</h2>
 
                     {% spaceless %}
-                        <textarea readonly class="form-control w-100 rounded flex-grow-1" name="text" id="transcription-input" placeholder="Go ahead, start typing. You got this!" aria-label="Transcription input">
+                        <textarea readonly class="form-control w-100 rounded flex-grow-1" name="text" id="transcription-input" placeholder="{% if transcription_status == 'edit' %}Go ahead, start typing. You got this!{% else %}Nothing to transcribe{% endif %}" aria-label="Transcription input">
                             {{ transcription.text }}
                         </textarea>
 


### PR DESCRIPTION
Now the “Go ahead, start type…” placeholder will only be shown when the text is in fact editable. For the remaining states the placeholder will only be seen when there is no text and that’s only the case when someone checked the “nothing to transcribe” box.

See #453