### PR TITLE
Split AJAX messages into a separate view

### DIFF
--- a/concordia/static/js/base.js
+++ b/concordia/static/js/base.js
@@ -86,11 +86,13 @@ $.ajax({url: '/account/ajax-status/', method: 'GET', cache: true}).done(
                     .prependTo($accountMenu);
             });
         }
-
-        if (data.messages) {
-            data.messages.forEach(function(message) {
-                displayMessage(message.level, message.message);
-            });
-        }
     }
 );
+
+$.ajax({url: '/account/ajax-messages/', method: 'GET'}).done(function(data) {
+    if (data.messages) {
+        data.messages.forEach(function(message) {
+            displayMessage(message.level, message.message);
+        });
+    }
+});

--- a/concordia/tests/test_view.py
+++ b/concordia/tests/test_view.py
@@ -290,11 +290,21 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
 
         self.assertIn("links", data)
         self.assertIn("username", data)
-        self.assertIn("messages", data)
 
         self.assertEqual(data["username"], self.user.username)
 
-        # The inclusion of messages means that this view cannot currently be cached:
+        self.assertIn("private", resp["Cache-Control"])
+
+    def test_ajax_messages(self):
+        self.login_user()
+
+        resp = self.client.get(reverse("ajax-messages"))
+        data = self.assertValidJSON(resp)
+
+        self.assertIn("messages", data)
+
+        # This view cannot be cached because the messages would be displayed
+        # multiple times:
         self.assertIn("no-cache", resp["Cache-Control"])
 
 

--- a/concordia/urls.py
+++ b/concordia/urls.py
@@ -93,6 +93,7 @@ urlpatterns = [
     ),
     path("assets/<int:asset_pk>/tags/submit/", views.submit_tags, name="submit-tags"),
     path("account/ajax-status/", views.ajax_session_status, name="ajax-session-status"),
+    path("account/ajax-messages/", views.ajax_messages, name="ajax-messages"),
     path(
         "account/register/",
         views.ConcordiaRegistrationView.as_view(),


### PR DESCRIPTION
This allows the login information to be cached without repeating messages

Closes #462 