### PR TITLE
Always use HTTPS for password reset links

### DIFF
--- a/concordia/templates/registration/password_reset_email.html
+++ b/concordia/templates/registration/password_reset_email.html
@@ -3,7 +3,7 @@
 
 {% trans "Please go to the following page and choose a new password:" %}
 {% block reset_link %}
-{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+https://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
 {% endblock %}
 {% trans "Your username, in case you've forgotten:" %} {{ user.get_username }}
 


### PR DESCRIPTION
Since all of our deployments support HTTPS, we never want to send reset tokens in the clear