### PR TITLE
Add release to Raven config

### DIFF
--- a/concordia/context_processors.py
+++ b/concordia/context_processors.py
@@ -13,6 +13,7 @@ def system_configuration(request):
         "CONCORDIA_ENVIRONMENT": settings.CONCORDIA_ENVIRONMENT,
         "S3_BUCKET_NAME": getattr(settings, "S3_BUCKET_NAME", None),
         "APPLICATION_VERSION": get_concordia_version(),
+        "RAVEN_CONFIG": settings.RAVEN_CONFIG,
     }
 
 

--- a/concordia/settings_prod.py
+++ b/concordia/settings_prod.py
@@ -38,7 +38,7 @@ else:
 
 
 SENTRY_DSN = os.environ.get("SENTRY_BACKEND_DSN", "")
-RAVEN_CONFIG = {"dsn": SENTRY_DSN, "environment": CONCORDIA_ENVIRONMENT}
+RAVEN_CONFIG.update({"dsn": SENTRY_DSN, "environment": CONCORDIA_ENVIRONMENT})
 
 SENTRY_PUBLIC_DSN = os.environ.get("SENTRY_FRONTEND_DSN", "")
 

--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -3,6 +3,8 @@ import os
 
 from django.contrib import messages
 
+import raven
+
 # Build paths inside the project like this: os.path.join(SITE_ROOT_DIR, ...)
 CONCORDIA_APP_DIR = os.path.abspath(os.path.dirname(__file__))
 SITE_ROOT_DIR = os.path.dirname(CONCORDIA_APP_DIR)
@@ -260,8 +262,11 @@ MESSAGE_TAGS = {messages.ERROR: "danger"}
 SENTRY_DSN = os.environ.get("SENTRY_DSN", "")
 SENTRY_PUBLIC_DSN = os.environ.get("SENTRY_PUBLIC_DSN", "")
 
-if SENTRY_DSN:
-    RAVEN_CONFIG = {"dsn": SENTRY_DSN, "environment": CONCORDIA_ENVIRONMENT}
+RAVEN_CONFIG = {
+    "dsn": SENTRY_DSN,
+    "environment": CONCORDIA_ENVIRONMENT,
+    "release": raven.fetch_git_sha(SITE_ROOT_DIR),
+}
 
 # When the MAINTENANCE_MODE setting is true, this template will be used to
 # generate a 503 response:

--- a/concordia/templates/base.html
+++ b/concordia/templates/base.html
@@ -157,7 +157,7 @@
 
     {% if SENTRY_PUBLIC_DSN %}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/raven.js/3.26.1/raven.min.js" integrity="sha256-N3YzTdAC27tvNKpIM2rly/WvlJf8YAat0NjPXgh5Bw4=" crossorigin="anonymous"></script>
-    <script>Raven.config('{{ SENTRY_PUBLIC_DSN }}', {'environment': '{{ CONCORDIA_ENVIRONMENT }}'}).install()</script>
+    <script>Raven.config('{{ SENTRY_PUBLIC_DSN }}', {'environment': '{{ CONCORDIA_ENVIRONMENT }}', 'release': '{{ RAVEN_CONFIG.release }}'}).install()</script>
     {% endif %}
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>


### PR DESCRIPTION
* Ensure that RAVEN_CONFIG is always set
* Expose RAVEN_CONFIG to templates
* Provide release info from Git to both Python and
  JavaScript clients