### PR TITLE
Add rel=preconnect hints for third-party resources (see #502)

### DIFF
--- a/concordia/templates/base.html
+++ b/concordia/templates/base.html
@@ -13,6 +13,11 @@
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,700|Roboto+Slab" rel="stylesheet">
     <link rel="stylesheet" href="{% static 'css/base.css' %}">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css" integrity="sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ" crossorigin="anonymous">
+    {% block prefetch %}
+        <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin>
+        <link href="https://thelibraryofcongress.tt.omtrdc.net" rel="preconnect" crossorigin>
+        <link href="https://smon.loc.gov" rel="preconnect" crossorigin>
+    {% endblock prefetch %}
     {% block head_content %}{% endblock head_content %}
     {% comment %}
     Adobe's tag manager requires this script to be placed at the top even though it's bad for performance:

--- a/concordia/templates/home.html
+++ b/concordia/templates/home.html
@@ -1,6 +1,11 @@
 {% extends "base.html" %}
 {% load staticfiles %}
 
+{% block prefetch %}
+    <link href="https://crowd-content.s3.amazonaws.com" rel="preconnect" crossorigin>
+    {{ block.super }}
+{% endblock prefetch %}
+
 {% block title %}Home{% endblock title %}
 
 {% block breadcrumbs-container %}{% endblock breadcrumbs-container %}


### PR DESCRIPTION
This adds hints for the third-party resources which aren't referenced
directly in the HTML source so modern browsers can start the process of
DNS resolution and HTTPS connection before the JavaScript / CSS gets
around to issuing the request.

References:

https://caniuse.com/#feat=link-rel-preconnect
https://www.igvita.com/2015/08/17/eliminating-roundtrips-with-preconnect/