### PR TITLE
Update CloudFlare SecurityGroup update script

### DIFF
--- a/cloudformation/add_cloudflare_ips_to_sgs.py
+++ b/cloudformation/add_cloudflare_ips_to_sgs.py
@@ -1,32 +1,69 @@
 #!/usr/bin/env python3
+"""
+Ensure that every security group tagged with “AllowCloudFlareIngress” has
+permissions for every public CloudFlare netblock
+"""
+
+import sys
 
 import boto3
 import requests
 from botocore.exceptions import ClientError
 
-SECURITY_GROUP_ID = "sg-0cf16b045e14f5fad"
+EC2_CLIENT = boto3.client("ec2")
 
-ec2 = boto3.client("ec2")
+CLOUDFLARE_IPV4 = requests.get("https://www.cloudflare.com/ips-v4").text.splitlines()
+CLOUDFLARE_IPV6 = requests.get("https://www.cloudflare.com/ips-v6").text.splitlines()
 
-ipv4_cidrs = requests.get("https://www.cloudflare.com/ips-v4").text.splitlines()
-ipv6_cidrs = requests.get("https://www.cloudflare.com/ips-v6").text.splitlines()
 
-request_payload = {
-    "IpProtocol": "tcp",
-    "FromPort": 443,
-    "ToPort": 443,
-    "IpRanges": [
-        {"CidrIp": cidr, "Description": "CloudFlare IPv4"} for cidr in ipv4_cidrs
-    ],
-    "Ipv6Ranges": [
-        {"CidrIpv6": cidrv6, "Description": "CloudFlare IPv6"} for cidrv6 in ipv6_cidrs
-    ],
-}
+def add_ingess_rules_for_group(sg_id, existing_permissions):
+    permissions = {"IpProtocol": "tcp", "FromPort": 443, "ToPort": 443}
 
-try:
-    data = ec2.authorize_security_group_ingress(
-        GroupId=SECURITY_GROUP_ID, IpPermissions=[request_payload]
+    existing_ipv4 = set()
+    existing_ipv6 = set()
+
+    for existing in existing_permissions:
+        if any(
+            permissions[k] != existing[k] for k in ("IpProtocol", "FromPort", "ToPort")
+        ):
+            continue
+
+        existing_ipv4.update(i["CidrIp"] for i in existing["IpRanges"])
+        existing_ipv6.update(i["CidrIpv6"] for i in existing["Ipv6Ranges"])
+
+    ipv4_ranges = [
+        {"CidrIp": cidr, "Description": "CloudFlare"}
+        for cidr in CLOUDFLARE_IPV4
+        if cidr not in existing_ipv4
+    ]
+    ipv6_ranges = [
+        {"CidrIpv6": cidr, "Description": "CloudFlare"}
+        for cidr in CLOUDFLARE_IPV6
+        if cidr not in existing_ipv6
+    ]
+
+    permissions["IpRanges"] = ipv4_ranges
+    permissions["Ipv6Ranges"] = ipv6_ranges
+
+    try:
+        EC2_CLIENT.authorize_security_group_ingress(
+            GroupId=sg_id, IpPermissions=[permissions]
+        )
+    except ClientError as exc:
+        print(f"Unable to add permssions for {sg_id}: {exc}", file=sys.stderr)
+
+
+def get_security_groups():
+    paginator = EC2_CLIENT.get_paginator("describe_security_groups")
+    page_iterator = paginator.paginate(
+        Filters=[{"Name": "tag-key", "Values": ["AllowCloudFlareIngress"]}]
     )
-    print("Ingress Successfully Set %s" % data)
-except ClientError as e:
-    print(e)
+
+    for page in page_iterator:
+        for sg in page["SecurityGroups"]:
+            yield sg["GroupId"], sg["IpPermissions"]
+
+
+if __name__ == "__main__":
+    for security_group_id, existing_permissions in get_security_groups():
+        add_ingess_rules_for_group(security_group_id, existing_permissions)

--- a/cloudformation/infrastructure/security-groups.yaml
+++ b/cloudformation/infrastructure/security-groups.yaml
@@ -55,6 +55,8 @@ Resources:
             Tags:
                 - Key: Name
                   Value: !Sub ${EnvironmentName}-LoadBalancers
+                - Key: tag-key
+                  Value: AllowCloudFlareIngress
 
     DatabaseSecurityGroup:
         Type: AWS::EC2::SecurityGroup

--- a/cloudformation/infrastructure/security-groups.yaml
+++ b/cloudformation/infrastructure/security-groups.yaml
@@ -55,8 +55,8 @@ Resources:
             Tags:
                 - Key: Name
                   Value: !Sub ${EnvironmentName}-LoadBalancers
-                - Key: tag-key
-                  Value: AllowCloudFlareIngress
+                - Key: AllowCloudFlareIngress
+                  Value: true
 
     DatabaseSecurityGroup:
         Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
This applies the list to every group tagged with `AllowCloudFlareIngress` and is closer to what we need to be able to run this using Lambda with scheduled events. Still TBD is tagging the security groups with this — I was wondering whether we want to make that conditional on the environment name but am also wondering whether we should just enable it for all of the environments so testing can be done using the CDN configuration as desired.