### PR TITLE
Use https://crowd-media.loc.gov for prod MEDIA_URL

### DIFF
--- a/concordia/settings_prod.py
+++ b/concordia/settings_prod.py
@@ -61,7 +61,10 @@ DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 AWS_STORAGE_BUCKET_NAME = S3_BUCKET_NAME
 AWS_DEFAULT_ACL = None  # Don't set an ACL on the files, inherit the bucket ACLs
 
-MEDIA_URL = "https://%s.s3.amazonaws.com/" % S3_BUCKET_NAME
+if CONCORDIA_ENVIRONMENT == "production":
+    MEDIA_URL = "https://crowd-media.loc.gov"
+else:
+    MEDIA_URL = "https://%s.s3.amazonaws.com/" % S3_BUCKET_NAME
 
 ELASTICSEARCH_DSL_AUTOSYNC = False
 


### PR DESCRIPTION
This is an alias which will get the full CDN performance benefits.

This will be slightly tricky to test since it's tied only to environment=production. We should have test URLs for campaign, project, and asset thumbnails ready to go first.