### PR TITLE
Campaign report: update user breakdown

### DIFF
--- a/concordia/templates/transcriptions/campaign_report.html
+++ b/concordia/templates/transcriptions/campaign_report.html
@@ -39,8 +39,12 @@
                                 <td class="text-monospace text-right">{{ project.asset_count|intcomma }}</td>
                             </tr>
                             <tr>
-                                <th>Number of Contributors</th>
-                                <td class="text-monospace text-right">{{ project.contributor_count|intcomma }} </td>
+                                <th>Number of Transcribers</th>
+                                <td class="text-monospace text-right">{{ project.transcriber_count|intcomma }} </td>
+                            </tr>
+                            <tr>
+                                <th>Number of Reviewers</th>
+                                <td class="text-monospace text-right">{{ project.reviewer_count|intcomma }} </td>
                             </tr>
                             <tr>
                                 <th>Tags</th>

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -807,9 +807,8 @@ class ReportCampaignView(TemplateView):
             tag_count=Count("item__asset__userassettagcollection__tags", distinct=True)
         )
         projects_qs = projects_qs.annotate(
-            contributor_count=Count(
-                "item__asset__userassettagcollection__user", distinct=True
-            )
+            transcriber_count=Count("item__asset__transcription__user", distinct=True),
+            reviewer_count=Count("item__asset__transcription__reviewed_by", distinct=True)
         )
 
         paginator = Paginator(projects_qs, ASSETS_PER_PAGE)


### PR DESCRIPTION
We consider transcription the core feature for this report so we'll report that number instead of the number of users who've helped tag items.

Transcription and reviewing are separate activities and they're now listed independently to avoid a fairly big subquery needed to calculate the unique values across both fields because Django's subquery support doesn't support `.count()` and the performance impact is non-trivial anyway