### PR TITLE
Report view: add distinct=True to asset count

### DIFF
--- a/concordia/views.py
+++ b/concordia/views.py
@@ -822,6 +822,7 @@ class ReportCampaignView(TemplateView):
             asset_count=Count(
                 "item__asset",
                 filter=Q(item__published=True, item__asset__published=True),
+                distinct=True
             )
         )
         projects_qs = projects_qs.annotate(


### PR DESCRIPTION
The other queries added to this report invalidated the image count without `distinct=True` 

Fixes #564

Before:
![image](https://user-images.githubusercontent.com/46565/47820853-21826900-dd35-11e8-9d19-d33e92e66496.png)

After:
![image](https://user-images.githubusercontent.com/46565/47820838-17606a80-dd35-11e8-9e18-62e2100679ff.png)
