### PR TITLE
Improved IE11 compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,11 @@ repos:
       hooks:
           - id: prettier
             files: \.(css|less|scss|ts|tsx|graphql|gql|json|js|jsx|md)$
+    - repo: https://github.com/pre-commit/mirrors-eslint
+      rev: v5.8.0
+      hooks:
+          - id: eslint
+            additional_dependencies:
+                - eslint@5.8.0
+                - eslint-plugin-prettier@3.0.0
+                - prettier@1.14.3

--- a/concordia/static/js/base.js
+++ b/concordia/static/js/base.js
@@ -79,7 +79,7 @@ function isOutdatedBrowser() {
 
 $(function() {
     if (isOutdatedBrowser()) {
-        theMessage =
+        var theMessage =
             'You are using an outdated browser. This website fully supports the current ' +
             'version of every major browser ' +
             '(Microsoft Edge, Google Chrome, Mozilla Firefox, and Apple Safari). See ' +

--- a/concordia/static/js/base.js
+++ b/concordia/static/js/base.js
@@ -87,16 +87,9 @@ $(function() {
             'for more information.';
 
         displayHtmlMessage('danger', theMessage);
-
-        $.getScript(
-            'https://cdn.jsdelivr.net/npm/css-vars-ponyfill@1.12.0/dist/css-vars-ponyfill.min.js',
-            function() {
-                /* global cssVars */
-                cssVars({
-                    onlyLegacy: true,
-                    include: 'style,link[rel="stylesheet"][href*="/static/"]'
-                });
-            }
+        $('script[type="legacy-browser-polyfill"]').attr(
+            'type',
+            'text/javascript'
         );
     }
 

--- a/concordia/static/js/base.js
+++ b/concordia/static/js/base.js
@@ -87,6 +87,17 @@ $(function() {
             'for more information.';
 
         displayHtmlMessage('danger', theMessage);
+
+        $.getScript(
+            'https://cdn.jsdelivr.net/npm/css-vars-ponyfill@1.12.0/dist/css-vars-ponyfill.min.js',
+            function() {
+                /* global cssVars */
+                cssVars({
+                    onlyLegacy: true,
+                    include: 'style,link[rel="stylesheet"][href*="/static/"]'
+                });
+            }
+        );
     }
 
     if (location.hash && $('#faqAccordion').length > 0) {

--- a/concordia/templates/base.html
+++ b/concordia/templates/base.html
@@ -172,6 +172,15 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/screenfull.js/3.3.3/screenfull.min.js" integrity="sha256-ULK0G2N+co+TT4C60EB0nElSM1e+tI2EFVa+bR/4juU=" crossorigin="anonymous"></script>
     <script src="{% static 'js/base.js' %}"></script>
 
+    {% comment %} These can be conditionally loaded later for IE11 {% endcomment %}
+    <script type="legacy-browser-polyfill" src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@1.12.0/dist/css-vars-ponyfill.min.js" crossorigin="anonymous"></script>
+    <script type="legacy-browser-polyfill">
+        cssVars({
+            onlyLegacy: true,
+            include: 'style,link[rel="stylesheet"][href*="/static/"]'
+        });
+    </script>
+
     {% block body_scripts %}{% endblock body_scripts %}
 
     <script type="text/javascript">

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -344,17 +344,21 @@
 </script>
 
 <script>
-    Split(['#viewer-column', '#editor-column'], {
+    Split(["#viewer-column", "#editor-column"], {
         sizes: [50, 50],
         minSize: 300,
         gutterSize: 8,
-        elementStyle: (dimension, size, gutterSize) => ({
-            'flex-basis': `calc(${size}% - ${gutterSize}px)`,
-        }),
-        gutterStyle: (dimension, gutterSize) => ({
-            'flex-basis':  `${gutterSize}px`,
-        }),
-    })
+        elementStyle: function(dimension, size, gutterSize) {
+            return {
+                "flex-basis": "calc(" + size + "% - " + gutterSize + "px)"
+            };
+        },
+        gutterStyle: function(dimension, gutterSize) {
+            return {
+                "flex-basis": gutterSize + "px"
+            };
+        }
+    });
 </script>
 
 {% if transcription_status == "edit" %}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "devDependencies": {
-    "eslint": "^5.6.1",
-    "eslint-plugin-prettier": "^3.0.0",
-    "prettier": "^1.14.3",
-    "stylelint": "^9.6.0",
-    "stylelint-config-prettier": "^4.0.0",
-    "stylelint-config-recommended": "^2.1.0"
-  }
+    "devDependencies": {
+        "eslint": "^5.8.0",
+        "eslint-plugin-prettier": "^3.0.0",
+        "prettier": "^1.14.3",
+        "stylelint": "^9.7.1",
+        "stylelint-config-prettier": "^4.0.0",
+        "stylelint-config-recommended": "^2.1.0"
+    }
 }


### PR DESCRIPTION
This improves the IE11 experience but raises the question of how we want to handle compatibility in the future: do we want to adopt a heavyweight tool like Webpack, Rollup, etc. or add some light-weight tooling so e.g. we process CSS with PostCSS + autoprefixer, JS with Babel, etc. without changing the entire project structure, and whether we serve the same bundle to everyone or take the polyfill.io approach of only serving support code to the older browsers which need it.