### PR TITLE
Homepage: add aria-hidden to redundant links

### DIFF
--- a/concordia/templates/home.html
+++ b/concordia/templates/home.html
@@ -36,17 +36,17 @@
             </div>
             <div id="homepage-contribute-activities" class="d-flex justify-content-around text-center">
                 <div class="homepage-activity px-1 pl-mx-2 px-lg-3">
-                    <a href="{% url 'how-to-transcribe' %}"><img class="img-fluid" alt="Transcribe" src="{% static 'img/homepage-pencil.svg' %}"></a>
+                    <a aria-hidden="true" href="{% url 'how-to-transcribe' %}"><img class="img-fluid" src="{% static 'img/homepage-pencil.svg' %}"></a>
                     <h4 class="mt-3"><a class="offwhite-text" href="{% url 'how-to-transcribe' %}">TRANSCRIBE</a></h4>
                     <p class="offwhite-text">Type what you see on the page.</p>
                 </div>
                 <div class="homepage-activity px-1 pl-mx-2 px-lg-3">
-                    <a class="offwhite-text" href="{% url 'how-to-review' %}"><img class="img-fluid" src="{% static 'img/homepage-checkmark.svg' %}"></a>
+                    <a aria-hidden="true" class="offwhite-text" href="{% url 'how-to-review' %}"><img class="img-fluid" src="{% static 'img/homepage-checkmark.svg' %}"></a>
                     <h4 class="offwhite-text mt-3"><a class="offwhite-text" href="{% url 'how-to-review' %}">REVIEW</a></h4>
                     <p class="offwhite-text">Register to edit and complete transcriptions.</p>
                 </div>
                 <div class="homepage-activity px-1 pl-mx-2 px-lg-3">
-                    <a class="offwhite-text" href="{% url 'how-to-tag' %}"><img class="img-fluid" src="{% static 'img/homepage-tag.svg' %}"></a>
+                    <a aria-hidden="true" class="offwhite-text" href="{% url 'how-to-tag' %}"><img class="img-fluid" src="{% static 'img/homepage-tag.svg' %}"></a>
                     <h4 class="offwhite-text mt-3"><a class="offwhite-text" href="{% url 'how-to-tag' %}">TAG</a></h4>
                     <p class="offwhite-text">Register to add tags and share what you find.</p>
                 </div>


### PR DESCRIPTION
Both the images & text link to same page so well simply hide one of them to avoid presenting screen readers with redundant links.