### PR TITLE
Automation-friendly database configuration

### DIFF
--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -21,21 +21,6 @@ cd cloudformation
 7.  If you don't already have the ECS service linked role in your AWS account, run: `aws iam create-service-linked-role --aws-service-name ecs.amazonaws.com`
 8.  Use CloudFormation to create a stack, using the `master.yaml` in the S3 bucket you uploaded in step 1 as the initial template.
 9.  If your environment name is not dev, test, stage or prod: Create a new revision of the task definition, changing the ENV_NAME variable to point to the correct secret storage location. Update the service to use the newest task definition version.
-10. Deploy a bastion host - use `infrastructure/bastion_host.yaml` CF template
-    1. Install docker, configure aws CLI, log in to AWS and pull the latest concordia docker image from ECR:
-    ```
-    sudo yum install -y docker
-    sudo systemctl enable docker
-    sudo systemctl start docker
-    ```
-    1. AWS Configure: `aws configure`
-    1. Login to ECR: `sudo $(aws ecr get-login --no-include-email --region us-east-1)`
-    1. Pull the latest image: `sudo docker pull $(aws sts get-caller-identity --output=text --query "Account").dkr.ecr.us-east-1.amazonaws.com/concordia:latest`
-    1. Add the bastion host security group to the database security group to allow inbound postgresql traffic
-    1. Run the image: `sudo docker run -e ENV_NAME=prod -e POSTGRESQL_HOST=$POSTGRESQL_HOST -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e AWS=1 $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/concordia`
-    1. `sudo docker exec -it <container name> bash`
-    1. Run the create admin command: `python3 ./manage.py createsuperuser`
-    1. Delete the bastion host stack.
 
 ![build-status](https://codebuild.eu-west-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiKzBuNjJCUFk2STRvbDZENXlMUFJOenF2V2EyQ3FMbEtuWDlQeVp6TWlxdXhNMGVOZGo5bG9jdTl1YU16RmZIVVNxa3VqTVg3V3drSnJxOUQwSmhqV2g0PSIsIml2UGFyYW1ldGVyU3BlYyI6IlJJRE4wZGJaS25LL0s0dzkiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 

--- a/concordia/management/commands/ensure_initial_site_configuration.py
+++ b/concordia/management/commands/ensure_initial_site_configuration.py
@@ -1,0 +1,81 @@
+"""
+Ensure that our basic site configuration has been applied
+
+This is intended for automated scenarios such as a fresh database server should
+be configured on first run but a newly-launched container should not make any
+changes. For convenience with Docker, the default values for each command-line
+argument will be retrieved from the environment.
+
+Tasks:
+1. Ensure that at least one admin user account exists. If not, a new one will be
+   created but it will have an unusable password to force use of the password
+   reset process.
+2. Ensure that the Sites framework has the intended site name & domain
+"""
+
+import os
+
+from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
+from django.core.management.base import BaseCommand
+from django.db.transaction import atomic
+
+
+class Command(BaseCommand):
+    help = "Ensure that core site configuration has been applied"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--admin-username",
+            default=os.environ.get("CONCORDIA_ADMIN_USERNAME", "admin"),
+            help="Admin user's username (default=%(default)s)",
+        )
+        parser.add_argument(
+            "--admin-email",
+            default=os.environ.get("CONCORDIA_ADMIN_EMAIL", "crowd@loc.gov"),
+            help="Admin user's email address (default=%(default)s)",
+        )
+        parser.add_argument(
+            "--site-name",
+            default=os.environ.get("HOST_NAME", "example.com"),
+            help="Site name (default=%(default)s)",
+        )
+        parser.add_argument(
+            "--site-domain",
+            default=os.environ.get("HOST_NAME", "example.com"),
+            help="Site domain (default=%(default)s)",
+        )
+
+    @atomic
+    def handle(self, *, admin_username, admin_email, site_name, site_domain, **options):
+        user, user_created = User.objects.get_or_create(
+            username=admin_username, defaults={"email": admin_email}
+        )
+        user.is_staff = user.is_superuser = True
+
+        if user.email != admin_email:
+            self.stdout.write(
+                f"Changing {admin_username} email from {user.email} to {admin_email}"
+            )
+            user.email = admin_email
+
+        if user_created:
+            user.set_unusable_password()
+
+        user.full_clean()
+        user.save()
+
+        if user_created:
+            self.stdout.write(
+                f"Created superuser {admin_username} account for {admin_email}."
+                " Use the password reset form to change the unusable password."
+            )
+
+        if site_domain != "example.com":
+            updated = Site.objects.filter(domain="example.com").update(
+                name=site_name, domain=site_domain
+            )
+            if updated:
+                self.stdout.write(
+                    f"Configured site with name {site_name} and domain {site_domain}"
+                )

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,9 @@ echo Running makemigrations
 echo Running migrations
 ./manage.py migrate
 
+echo "Ensuring our base configuration is present in the database"
+./manage.py ensure_initial_site_configuration
+
 echo Running collectstatic
 ./manage.py collectstatic --clear --noinput -v0
 


### PR DESCRIPTION
This command makes it safe to have a deployment step which runs every
time we launch a container to ensure that the database has the expected
admin user and site configuration.

Closes #392