### PR TITLE
Fix docker container build for pylibmc dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update -qy && apt-get install -o Dpkg::Options::='--force-confnew' -
     git curl \
     python3 python3-dev python3-pip \
     libz-dev libfreetype6-dev \
+    libmemcached-dev \
     libtiff-dev libjpeg-dev libopenjp2-7-dev libwebp-dev zlib1g-dev \
     graphviz \
     locales

--- a/concordia/templates/admin/bulk_import.html
+++ b/concordia/templates/admin/bulk_import.html
@@ -79,7 +79,7 @@
             <h4>Messages</h4>
             <ul>
                 {% for message in messages %}
-                    <li class="message {% if message.level >= DEFAULT_MESSAGE_LEVELS.error %}message-error{% elif message.level >= DEFAULT_MESSAGE_LEVELS.warning %}message-warning{% endif %}">{{ message }}</li>
+                    <li class="message {% if message.level >= DEFAULT_MESSAGE_LEVELS.ERROR %}message-error{% elif message.level >= DEFAULT_MESSAGE_LEVELS.WARNING %}message-warning{% endif %}">{{ message }}</li>
                 {% endfor %}
             </ul>
         {% endif %}

--- a/importer/Dockerfile
+++ b/importer/Dockerfile
@@ -6,6 +6,7 @@ ENV DEBIAN_FRONTEND="noninteractive"
 RUN apt-get update -qy && apt-get install -o Dpkg::Options::='--force-confnew' -qy \
     git curl \
     python3 python3-dev python3-pip \
+    libmemcached-dev \
     libtiff-dev libjpeg-dev libopenjp2-7-dev libwebp-dev zlib1g-dev \
     graphviz \
     locales


### PR DESCRIPTION
Docker containers won't build since the addition of pylibmc. Adding pre-req for ubuntu.