### PR TITLE
Export: upload bags to S3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,7 @@ repos:
       rev: stable
       hooks:
           - id: black
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v2.0.0
-      hooks:
-          - id: flake8
+
     - repo: https://github.com/prettier/prettier
       rev: 1.14.3
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,10 @@ repos:
       rev: stable
       hooks:
           - id: black
-
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v2.0.0
+      hooks:
+          - id: flake8
     - repo: https://github.com/prettier/prettier
       rev: 1.14.3
       hooks:

--- a/cloudformation/infrastructure/fargate-cluster.yaml
+++ b/cloudformation/infrastructure/fargate-cluster.yaml
@@ -79,6 +79,11 @@ Parameters:
         Type: String
         Description: name of the S3 bucket (public) where collection images will be stored
 
+    ExportS3BucketName:
+        Type: String
+        Description: name of the S3 bucket (public) where exported transcriptions will be stored
+
+
 Resources:
 
   ConcordiaServiceSecretAccessPolicy:
@@ -244,6 +249,8 @@ Resources:
                 Value: !Ref FullEnvironmentName
               - Name: S3_BUCKET_NAME
                 Value: !Ref S3BucketName
+              - Name: EXPORT_S3_BUCKET_NAME
+                Value: !Ref ExportS3BucketName
               - Name: CELERY_BROKER_URL
                 Value: pyamqp://guest@localhost:5672
               - Name: AWS_DEFAULT_REGION
@@ -300,6 +307,8 @@ Resources:
                 Value: !Ref FullEnvironmentName
               - Name: S3_BUCKET_NAME
                 Value: !Ref S3BucketName
+              - Name: EXPORT_S3_BUCKET_NAME
+                Value: !Ref ExportS3BucketName
               - Name: CELERY_BROKER_URL
                 Value: pyamqp://guest@localhost:5672
               - Name: AWS_DEFAULT_REGION

--- a/cloudformation/master.yaml
+++ b/cloudformation/master.yaml
@@ -54,6 +54,11 @@ Mappings:
             test: crowd-test-content
             stage: crowd-stage-content
             prod: crowd-content
+        ExportS3BucketNameMap:
+            dev: crowd-dev-export
+            test: crowd-test-export
+            stage: crowd-stage-export
+            prod: crowd-export
 
 Parameters:
 
@@ -173,6 +178,7 @@ Resources:
                 DatabaseEndpoint: !GetAtt RDS.Outputs.DatabaseHostName
                 FullEnvironmentName: !Ref FullEnvironmentName
                 S3BucketName: !FindInMap [EnvironmentMapping, S3BucketNameMap, !Ref EnvName]
+                ExportS3BucketName: !FindInMap [EnvironmentMapping, ExportS3BucketNameMap, !Ref EnvName]
 
 Outputs:
 

--- a/concordia/settings_dev.py
+++ b/concordia/settings_dev.py
@@ -20,6 +20,7 @@ CELERY_BROKER_URL = "pyamqp://guest@localhost"
 CELERY_RESULT_BACKEND = "rpc://"
 
 S3_BUCKET_NAME = "crowd-dev-content"
+EXPORT_S3_BUCKET_NAME = "crowd-dev-export"
 
 DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 AWS_STORAGE_BUCKET_NAME = S3_BUCKET_NAME

--- a/concordia/settings_dev.py
+++ b/concordia/settings_dev.py
@@ -19,7 +19,7 @@ ALLOWED_HOSTS = ["127.0.0.1", "0.0.0.0", "*"]
 CELERY_BROKER_URL = "pyamqp://guest@localhost"
 CELERY_RESULT_BACKEND = "rpc://"
 
-S3_BUCKET_NAME = "concordia-staticpages"
+S3_BUCKET_NAME = "crowd-dev-content"
 
 DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 AWS_STORAGE_BUCKET_NAME = S3_BUCKET_NAME

--- a/concordia/settings_dev.py
+++ b/concordia/settings_dev.py
@@ -19,15 +19,6 @@ ALLOWED_HOSTS = ["127.0.0.1", "0.0.0.0", "*"]
 CELERY_BROKER_URL = "pyamqp://guest@localhost"
 CELERY_RESULT_BACKEND = "rpc://"
 
-S3_BUCKET_NAME = "crowd-dev-content"
-EXPORT_S3_BUCKET_NAME = "crowd-dev-export"
-
-DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
-AWS_STORAGE_BUCKET_NAME = S3_BUCKET_NAME
-AWS_DEFAULT_ACL = None  # Don't set an ACL on the files, inherit the bucket ACLs
-
-MEDIA_URL = "https://%s.s3.amazonaws.com/" % S3_BUCKET_NAME
-
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 EMAIL_FILE_PATH = "/tmp/concordia-messages"  # change this to a proper location
 DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "")

--- a/concordia/settings_prod.py
+++ b/concordia/settings_prod.py
@@ -50,6 +50,7 @@ CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "pyamqp://guest@rabbit:5672")
 CELERY_RESULT_BACKEND = "rpc://"
 
 S3_BUCKET_NAME = os.getenv("S3_BUCKET_NAME")
+EXPORT_S3_BUCKET_NAME = os.getenv("EXPORT_S3_BUCKET_NAME")
 
 DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 AWS_STORAGE_BUCKET_NAME = S3_BUCKET_NAME

--- a/exporter/tests/test_view.py
+++ b/exporter/tests/test_view.py
@@ -110,6 +110,6 @@ class ViewTest_Exporter(TestCase):
         self.assertIn("bagit.txt", zipped_file.namelist())
         self.assertIn("bag-info.txt", zipped_file.namelist())
         self.assertIn(
-            "data/test-project/testitem0123456789/mss-mal-003-0036300-002.txt",
+            "data/test-project/testitem0123456789/mss:mal:003:0036300:002.txt",
             zipped_file.namelist(),
         )

--- a/exporter/tests/test_view.py
+++ b/exporter/tests/test_view.py
@@ -1,5 +1,6 @@
 import io
 import zipfile
+from datetime import datetime
 
 from django.test import TestCase
 from django.urls import reverse
@@ -87,9 +88,14 @@ class ViewTest_Exporter(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
+
+        export_filename = "%s-%s.zip" % (
+            campaign_slug,
+            datetime.today().isoformat(timespec="minutes"),
+        )
         self.assertEquals(
             response.get("Content-Disposition"),
-            "attachment; filename=%s.zip" % campaign_slug,
+            "attachment; filename=%s" % export_filename,
         )
 
         f = io.BytesIO(response.content)

--- a/exporter/tests/test_view.py
+++ b/exporter/tests/test_view.py
@@ -47,7 +47,13 @@ class ViewTest_Exporter(TestCase):
         )
 
         # add a Transcription object
-        transcription1 = Transcription(asset=asset, user=user, text="Sample")
+        transcription1 = Transcription(
+            asset=asset,
+            user=user,
+            text="Sample",
+            submitted=datetime.now(),
+            accepted=datetime.now(),
+        )
         transcription1.full_clean()
         transcription1.save()
 

--- a/exporter/tests/test_view.py
+++ b/exporter/tests/test_view.py
@@ -72,7 +72,7 @@ class ViewTest_Exporter(TestCase):
             "b'Campaign,Project,Item,ItemId,Asset,"
             "AssetStatus,DownloadUrl,Transcription\\r\\n'"
             "b'Test Campaign,Test Project,Test Item,"
-            "testitem0123456789,TestAsset,edit,"
+            "testitem0123456789,TestAsset,completed,"
             "http://tile.loc.gov/image-services/"
             "iiif/service:mss:mal:003:0036300:002/full"
             "/pct:25/0/default.jpg,Sample\\r\\n'"

--- a/exporter/tests/test_view.py
+++ b/exporter/tests/test_view.py
@@ -27,7 +27,9 @@ class ViewTest_Exporter(TestCase):
     """
 
     def setUp(self):
-        user = User.objects.create(username="tester", email="tester@example.com")
+        user = User.objects.create(
+            username="tester", email="tester@example.com", is_staff=True
+        )
         user.set_password("top_secret")
         user.save()
 

--- a/exporter/views.py
+++ b/exporter/views.py
@@ -34,7 +34,7 @@ def get_original_asset_id(download_url):
     that identifies this image uniquely on loc.gov
     """
     if download_url.startswith("http://tile.loc.gov/"):
-        pattern = r"/service:([^/]?)/"
+        pattern = r"/service:([A-Za-z0-9:/-]?)/"
         asset_id = re.search(pattern, download_url)
         assert asset_id
         return asset_id.group(1)

--- a/exporter/views.py
+++ b/exporter/views.py
@@ -34,7 +34,7 @@ def get_original_asset_id(download_url):
     that identifies this image uniquely on loc.gov
     """
     if download_url.startswith("http://tile.loc.gov/"):
-        pattern = r"/service:([A-Za-z0-9:/-]?)/"
+        pattern = r"/service:([A-Za-z0-9:\-]*)/"
         asset_id = re.search(pattern, download_url)
         assert asset_id
         return asset_id.group(1)

--- a/exporter/views.py
+++ b/exporter/views.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import bagit
 import boto3
 from django.conf import settings
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import permission_required
 from django.db.models import OuterRef, Subquery
 from django.http import HttpResponse, HttpResponseRedirect
 from django.utils.decorators import method_decorator
@@ -47,7 +47,12 @@ class ExportCampaignToCSV(TemplateView):
     Exports the most recent transcription for each asset in a campaign
     """
 
-    @method_decorator(login_required)
+    @method_decorator(permission_required("concordia.add_campaign"))
+    @method_decorator(permission_required("concordia.change_campaign"))
+    @method_decorator(permission_required("concordia.add_project"))
+    @method_decorator(permission_required("concordia.change_project"))
+    @method_decorator(permission_required("concordia.add_item"))
+    @method_decorator(permission_required("concordia.change_item"))
     def get(self, request, *args, **kwargs):
         asset_qs = Asset.objects.filter(
             item__project__campaign__slug=self.kwargs["campaign_slug"]
@@ -94,7 +99,12 @@ class ExportCampaignToBagit(TemplateView):
     Removes all temporary directories and files.
     """
 
-    @method_decorator(login_required)
+    @method_decorator(permission_required("concordia.add_campaign"))
+    @method_decorator(permission_required("concordia.change_campaign"))
+    @method_decorator(permission_required("concordia.add_project"))
+    @method_decorator(permission_required("concordia.change_project"))
+    @method_decorator(permission_required("concordia.add_item"))
+    @method_decorator(permission_required("concordia.change_item"))
     def get(self, request, *args, **kwargs):
         campaign_slug = self.kwargs["campaign_slug"]
         asset_qs = Asset.objects.filter(

--- a/exporter/views.py
+++ b/exporter/views.py
@@ -34,11 +34,10 @@ def get_original_asset_id(download_url):
     that identifies this image uniquely on loc.gov
     """
     if download_url.startswith("http://tile.loc.gov/"):
-        # TODO: change this pattern to accept anything a POSIX filesystem would accept
-        pattern = r"/service:([A-Za-z0-9:\-]*)/"
+        pattern = r"/service:([^/]?)/"
         asset_id = re.search(pattern, download_url)
         assert asset_id
-        return asset_id.group(1).replace(":", "-")
+        return asset_id.group(1)
     else:
         return download_url
 

--- a/exporter/views.py
+++ b/exporter/views.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import bagit
 import boto3
 from django.conf import settings
-from django.contrib.auth.decorators import permission_required
+from django.contrib.admin.views.decorators import staff_member_required
 from django.db.models import OuterRef, Subquery
 from django.http import HttpResponse, HttpResponseRedirect
 from django.utils.decorators import method_decorator
@@ -47,12 +47,7 @@ class ExportCampaignToCSV(TemplateView):
     Exports the most recent transcription for each asset in a campaign
     """
 
-    @method_decorator(permission_required("concordia.add_campaign"))
-    @method_decorator(permission_required("concordia.change_campaign"))
-    @method_decorator(permission_required("concordia.add_project"))
-    @method_decorator(permission_required("concordia.change_project"))
-    @method_decorator(permission_required("concordia.add_item"))
-    @method_decorator(permission_required("concordia.change_item"))
+    @method_decorator(staff_member_required)
     def get(self, request, *args, **kwargs):
         asset_qs = Asset.objects.filter(
             item__project__campaign__slug=self.kwargs["campaign_slug"]
@@ -99,12 +94,7 @@ class ExportCampaignToBagit(TemplateView):
     Removes all temporary directories and files.
     """
 
-    @method_decorator(permission_required("concordia.add_campaign"))
-    @method_decorator(permission_required("concordia.change_campaign"))
-    @method_decorator(permission_required("concordia.add_project"))
-    @method_decorator(permission_required("concordia.change_project"))
-    @method_decorator(permission_required("concordia.add_item"))
-    @method_decorator(permission_required("concordia.change_item"))
+    @method_decorator(staff_member_required)
     def get(self, request, *args, **kwargs):
         campaign_slug = self.kwargs["campaign_slug"]
         asset_qs = Asset.objects.filter(

--- a/exporter/views.py
+++ b/exporter/views.py
@@ -1,13 +1,13 @@
-from datetime import datetime
 import os
 import re
 import shutil
+from datetime import datetime
 
 import bagit
 import boto3
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.db.models import Subquery, OuterRef
+from django.db.models import OuterRef, Subquery
 from django.http import HttpResponse
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView

--- a/exporter/views.py
+++ b/exporter/views.py
@@ -131,7 +131,7 @@ class ExportCampaignToBagit(TemplateView):
         response["Content-Disposition"] = "attachment; filename=%s.zip" % campaign_slug
 
         # Upload zip to S3 bucket
-        if settings.S3_BUCKET_NAME:
+        if "S3_BUCKET_NAME" in settings and settings.S3_BUCKET_NAME:
             s3 = boto3.resource("s3")
             s3.Bucket(settings.S3_BUCKET_NAME).upload_file(
                 "%s.zip" % export_base_dir, "exporter/%s.zip" % campaign_slug


### PR DESCRIPTION
- only export completed transcriptions in BagIt format, all transcriptions in CSV format
- upload created bags to S3 bucket
- created bags uploaded to S3 are named with campaign + timestamp
- filenames in the bag reflect the original download URL

Closes #169 