### PR TITLE
Call `raven test` on startup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,9 @@ echo Running migrations
 echo "Ensuring our base configuration is present in the database"
 ./manage.py ensure_initial_site_configuration
 
+echo "Testing Sentry configuration"
+./manage.py raven test
+
 echo Running collectstatic
 ./manage.py collectstatic --clear --noinput -v0
 


### PR DESCRIPTION
This ensures that starting a container will trigger an error if the Sentry configuration is incorrect

Closes #418