### PR TITLE
Update homepage “Let's Go” target

### DIFF
--- a/concordia/templates/home.html
+++ b/concordia/templates/home.html
@@ -19,7 +19,7 @@
                 <div class="carousel-overlay text-center py-md-3">
                     <h1>Get Involved:</h1>
                     <p class="hero-text mx-auto">Volunteer to uncover our shared history and make documents more searchable for everyone.</p>
-                    <a class="btn btn-primary btn-lg" href="{% url 'transcriptions:campaign-list' %}">LET'S GO!</a>
+                    <a class="btn btn-primary btn-lg" href="{% url "transcriptions:redirect-to-next-transcribable-asset" 'letters-to-lincoln' %}">LET'S GO!</a>
                 </div>
             </div>
         </div>

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -68,7 +68,7 @@
             </div>
 
             <div class="btn-group btn-group-sm align-self-end" role="navigation" aria-label="Link to the next editable page">
-                <a class="btn btn-default" title="Move to the next page in this item that needs help" href="{% url "transcriptions:redirect-to-next-transcribable-asset" campaign.slug project.slug %}">Find a new page &rarr;</a>
+                <a class="btn btn-default" title="Move to the next page in this item that needs help" href="{{ next_open_asset_url }}">Find a new page &rarr;</a>
           </div>
         </nav>
     </div>
@@ -335,7 +335,7 @@
                     <p>You can help by transcribing a new page, adding tags to this page, or coming back later to review this page's transcription.</p>
                 </div>
                 <div class="modal-footer">
-                    <a class="btn btn-primary" href="{% url "transcriptions:redirect-to-next-transcribable-asset" campaign.slug project.slug %}">
+                    <a class="btn btn-primary" href="{{ next_open_asset_url }}">
                         Find a new page
                     </a>
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
@@ -364,7 +364,7 @@
                     <button type="button" class="btn btn-default" data-dismiss="modal">
                         Add Tags
                     </button>
-                    <a class="btn btn-primary" href="{% url "transcriptions:redirect-to-next-transcribable-asset" campaign.slug project.slug %}">
+                    <a class="btn btn-primary" href="{{ next_open_asset_url }}">
                         Find a new page
                     </a>
                 </div>
@@ -392,7 +392,7 @@
                     <button type="button" class="btn btn-default" data-dismiss="modal">
                         Add Tags
                     </button>
-                    <a class="btn btn-primary" href="{% url "transcriptions:redirect-to-next-transcribable-asset" campaign.slug project.slug %}">
+                    <a class="btn btn-primary" href="{{ next_open_asset_url }}">
                         Find a new page
                     </a>
                 </div>

--- a/concordia/tests/test_view.py
+++ b/concordia/tests/test_view.py
@@ -5,7 +5,12 @@ from django.test import TestCase, TransactionTestCase
 from django.urls import reverse
 from django.utils.timezone import now
 
-from concordia.models import AssetTranscriptionReservation, Transcription, User
+from concordia.models import (
+    AssetTranscriptionReservation,
+    Transcription,
+    TranscriptionStatus,
+    User,
+)
 from concordia.views import get_anonymous_user
 
 from .utils import (
@@ -736,3 +741,71 @@ class TransactionalViewTests(JSONAssertMixin, TransactionTestCase):
         # values, they should not be stored:
         self.assertEqual(["bar", "foo", "quux"], data["user_tags"])
         self.assertEqual(["baaz", "bar", "foo", "quux"], data["all_tags"])
+
+    def test_find_next_transcribable(self):
+        asset1 = create_asset(slug="test-asset-1")
+        asset2 = create_asset(item=asset1.item, slug="test-asset-2")
+        campaign = asset1.item.project.campaign
+
+        resp = self.client.get(
+            reverse(
+                "transcriptions:redirect-to-next-transcribable-asset",
+                kwargs={"campaign_slug": campaign.slug},
+            )
+        )
+
+        self.assertRedirects(resp, expected_url=asset2.get_absolute_url())
+
+    def test_find_next_transcribable_single_asset(self):
+        asset = create_asset()
+        campaign = asset.item.project.campaign
+
+        resp = self.client.get(
+            reverse(
+                "transcriptions:redirect-to-next-transcribable-asset",
+                kwargs={"campaign_slug": campaign.slug},
+            )
+        )
+
+        self.assertRedirects(resp, expected_url=asset.get_absolute_url())
+
+    def test_find_next_transcribable_in_singleton_campaign(self):
+        asset = create_asset(transcription_status=TranscriptionStatus.SUBMITTED)
+        campaign = asset.item.project.campaign
+
+        resp = self.client.get(
+            reverse(
+                "transcriptions:redirect-to-next-transcribable-asset",
+                kwargs={"campaign_slug": campaign.slug},
+            )
+        )
+
+        self.assertRedirects(
+            resp,
+            expected_url=reverse(
+                "transcriptions:campaign-detail", args=(campaign.slug,)
+            ),
+        )
+
+    def test_find_next_transcribable_project_redirect(self):
+        asset = create_asset(transcription_status=TranscriptionStatus.SUBMITTED)
+        project = asset.item.project
+        campaign = project.campaign
+
+        resp = self.client.get(
+            "%s?project=%s"
+            % (
+                reverse(
+                    "transcriptions:redirect-to-next-transcribable-asset",
+                    kwargs={"campaign_slug": campaign.slug},
+                ),
+                project.slug,
+            )
+        )
+
+        self.assertRedirects(
+            resp,
+            expected_url=reverse(
+                "transcriptions:project-detail", args=(campaign.slug, project.slug)
+            ),
+        )

--- a/concordia/urls.py
+++ b/concordia/urls.py
@@ -40,15 +40,16 @@ tx_urlpatterns = (
             views.AssetDetailView.as_view(),
             name="asset-detail",
         ),
+        # n.b. this must be above project-detail to avoid being seen as a project slug:
+        path(
+            "<slug:campaign_slug>/next-transcribable-asset/",
+            views.redirect_to_next_transcribable_asset,
+            name="redirect-to-next-transcribable-asset",
+        ),
         path(
             "<slug:campaign_slug>/<slug:slug>/",
             views.ProjectDetailView.as_view(),
             name="project-detail",
-        ),
-        path(
-            "<slug:campaign_slug>/<slug:project_slug>/next-transcribable-asset/",
-            views.redirect_to_next_transcribable_asset,
-            name="redirect-to-next-transcribable-asset",
         ),
         path(
             "<slug:campaign_slug>/<slug:project_slug>/<slug:item_id>/",

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -984,9 +984,9 @@ def reserve_asset_transcription(request, *, asset_pk):
 @atomic
 def redirect_to_next_transcribable_asset(request, *, campaign_slug):
     campaign = get_object_or_404(Campaign.objects.published(), slug=campaign_slug)
-    project_slug = request.GET.get("project")
-    item_id = request.GET.get("item")
-    asset_id = request.GET.get("asset")
+    project_slug = request.GET.get("project", "")
+    item_id = request.GET.get("item", "")
+    asset_id = request.GET.get("asset", 0)
 
     if not request.user.is_authenticated:
         user = get_anonymous_user()

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from functools import wraps
 from logging import getLogger
 from smtplib import SMTPException
+from urllib.parse import urlencode
 
 import markdown
 from captcha.helpers import captcha_image_url
@@ -21,7 +22,7 @@ from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
 from django.core.paginator import Paginator
 from django.db import connection
-from django.db.models import Count, Q
+from django.db.models import Case, Count, IntegerField, Q, When
 from django.db.transaction import atomic
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import Http404, get_object_or_404, redirect, render
@@ -477,6 +478,14 @@ class AssetDetailView(DetailView):
 
         transcription = asset.transcription_set.order_by("-pk").first()
         ctx["transcription"] = transcription
+
+        ctx["next_open_asset_url"] = "%s?%s" % (
+            reverse(
+                "transcriptions:redirect-to-next-transcribable-asset",
+                kwargs={"campaign_slug": project.campaign.slug},
+            ),
+            urlencode({"project": project.slug, "item": item.item_id}),
+        )
 
         # We'll handle the case where an item with no transcriptions should be
         # shown as status=edit here so the logic doesn't need to be repeated in
@@ -971,10 +980,10 @@ def reserve_asset_transcription(request, *, asset_pk):
 
 @never_cache
 @atomic
-def redirect_to_next_transcribable_asset(request, *, campaign_slug, project_slug):
-    project = get_object_or_404(
-        Project.objects.published(), campaign__slug=campaign_slug, slug=project_slug
-    )
+def redirect_to_next_transcribable_asset(request, *, campaign_slug):
+    campaign = get_object_or_404(Campaign.objects.published(), slug=campaign_slug)
+    project_slug = request.GET.get("project")
+    item_id = request.GET.get("item")
 
     if not request.user.is_authenticated:
         user = get_anonymous_user()
@@ -983,25 +992,48 @@ def redirect_to_next_transcribable_asset(request, *, campaign_slug, project_slug
 
     potential_assets = Asset.objects.select_for_update(skip_locked=True, of=("self",))
     potential_assets = potential_assets.filter(
-        item__project=project, transcription_status=TranscriptionStatus.EDIT
+        item__project__campaign=campaign,
+        transcription_status=TranscriptionStatus.EDIT,
+        item__project__published=True,
+        item__published=True,
+        published=True,
     )
-    potential_assets = potential_assets.filter(assettranscriptionreservation=None)
 
-    for potential_asset in potential_assets:
-        res = AssetTranscriptionReservation(user=user, asset=potential_asset)
+    potential_assets = potential_assets.filter(assettranscriptionreservation=None)
+    potential_assets = potential_assets.select_related("item", "item__project")
+
+    # We'll favor assets which are in the same item or project as the original:
+    potential_assets = potential_assets.annotate(
+        same_project=Case(
+            When(item__project__slug=project_slug, then=1),
+            default=0,
+            output_field=IntegerField(),
+        ),
+        same_item=Case(
+            When(item__item_id=item_id, then=1), default=0, output_field=IntegerField()
+        ),
+    ).order_by("-same_project", "-same_item")
+
+    asset = potential_assets.first()
+    if asset:
+        res = AssetTranscriptionReservation(user=user, asset=asset)
         res.full_clean()
         res.save()
         return redirect(
             "transcriptions:asset-detail",
-            project.campaign.slug,
-            project.slug,
-            potential_asset.item.item_id,
-            potential_asset.slug,
+            campaign.slug,
+            asset.item.project.slug,
+            asset.item.item_id,
+            asset.slug,
         )
     else:
         messages.info(
             request, "There are no remaining pages to be transcribed in this project!"
         )
-        return redirect(
-            "transcriptions:project-detail", project.campaign.slug, project.slug
-        )
+
+        if project_slug:
+            return redirect(
+                "transcriptions:project-detail", campaign_slug, project_slug
+            )
+        else:
+            return redirect("transcriptions:campaign-detail", campaign_slug)


### PR DESCRIPTION
This makes two changes:

* The homepage “Let's Go” button is now treated as a “find next transcribable page” request for the Letters to Lincoln campaign
* The redirect view now requires only the campaign slug and uses database sorting to favor finding an asset which is later than the current asset, within the same item, within the same project in that order.