### PR TITLE
WIP: more progress indicators

### DIFF
--- a/concordia/forms.py
+++ b/concordia/forms.py
@@ -68,14 +68,13 @@ class AssetFilteringForm(forms.Form):
         super().__init__(*args, **kwargs)
 
         asset_statuses = {
-            status: "%s (%d)" % (TranscriptionStatus.CHOICE_MAP[status], count)
-            for status, count in status_counts.items()
+            key: "%s (%d)" % (val, status_counts.get(key, 0))
+            for key, val in TranscriptionStatus.CHOICES
         }
 
         filtered_choices = [("", f"All Images ({sum(status_counts.values())})")]
         for val, label in self.fields["transcription_status"].choices:
-            if val in asset_statuses:
-                filtered_choices.append((val, asset_statuses[val]))
+            filtered_choices.append((val, asset_statuses[val]))
 
         self.fields["transcription_status"].choices = filtered_choices
 

--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -520,6 +520,10 @@ ul.nav-secondary {
     }
 }
 
+.concordia-object-card[data-transcription-status='completed']:not(:hover) {
+    opacity: 0.5;
+}
+
 .concordia-object-card .card-title,
 .concordia-object-card .card-actions {
     position: absolute;

--- a/concordia/templates/fragments/transcription-progress-bar.html
+++ b/concordia/templates/fragments/transcription-progress-bar.html
@@ -11,10 +11,10 @@
 <div class="table-responsive-md">
     <table id="progress-stats" class="table table-sm font-weight-light">
         <tbody>
-            {% for label, value in transcription_status_counts %}
+            {% for key, label, value in transcription_status_counts %}
                 <tr>
-                    <th class="text-nowrap">{{ label }}</th>
-                    <td class="text-right">{{ value|intcomma }}</td>
+                    <th class="text-nowrap"><a href="?transcription_status={{ key|urlencode }}">{{ label }}</a></th>
+                    <td class="text-right"><a href="?transcription_status={{ key|urlencode }}">{{ value|intcomma }}</a></td>
                 </tr>
             {% endfor %}
         </tbody>

--- a/concordia/templates/fragments/transcription-progress-bar.html
+++ b/concordia/templates/fragments/transcription-progress-bar.html
@@ -10,19 +10,19 @@
 </div>
 <div class="table-responsive-md">
     <table id="progress-stats" class="table table-sm font-weight-light">
-        <tr>
-            <th class="text-nowrap">Complete:</th>
-            <td class="text-right">{{ completed_percent }}%</td>
-        </tr>
-        <tr>
-            <th class="text-nowrap">In progress:</th>
-            <td class="text-right">
-                {{ edit_percent|add:submitted_percent }}%
-            </td>
-        </tr>
-        <tr>
-            <th class="text-nowrap">Contributors:</th>
-            <td class="text-right">{{ contributor_count|intcomma }}</td>
-        <tr>
+        <tbody>
+            {% for label, value in transcription_status_counts %}
+                <tr>
+                    <th class="text-nowrap">{{ label }}</th>
+                    <td class="text-right">{{ value|intcomma }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+        <tbody>
+            <tr>
+                <th class="text-nowrap">Contributors:</th>
+                <td class="text-right">{{ contributor_count|intcomma }}</td>
+            <tr>
+        </tbody>
     </table>
 </div>

--- a/concordia/templates/transcriptions/project_detail.html
+++ b/concordia/templates/transcriptions/project_detail.html
@@ -29,7 +29,7 @@
     <div class="row">
         <div class="card-deck w-100 flex-column flex-sm-row justify-content-center align-items-center align-items-sm-stretch">
             {% for item in items %}
-                <div class="col-12 col-md-4 col-lg-3 m-2 p-1 concordia-object-card card bg-lightest-gray shadow-regular justify-content-between align-items-center">
+                <div class="col-12 col-md-4 col-lg-3 m-2 p-1 concordia-object-card card bg-lightest-gray shadow-regular justify-content-between align-items-center" data-transcription-status="{{ item.lowest_transcription_status }}">
                     <a href="{% url 'transcriptions:item-detail' campaign.slug project.slug item.item_id %}">
                         <img class="card-img card-img-campaign" alt="{{ item.title }}" src="{{ item.thumbnail_url }}">
                     </a>

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -302,21 +302,24 @@ def calculate_asset_stats(asset_qs, ctx):
 
     asset_state_qs = asset_qs.values_list("transcription_status")
     asset_state_qs = asset_state_qs.annotate(Count("transcription_status")).order_by()
-    state_counts = dict(asset_state_qs)
+    status_counts_by_key = dict(asset_state_qs)
 
-    if "edit" in state_counts:
+    if "edit" in status_counts_by_key:
         # Correct semantic difference between our normal “open for edit”
         # including assets with no progress at all:
-        state_counts["edit"] -= asset_qs.filter(transcription=None).count()
+        status_counts_by_key["edit"] -= asset_qs.filter(transcription=None).count()
 
-    for state in TranscriptionStatus.CHOICE_MAP.keys():
-        value = state_counts.get(state, 0)
+    ctx["transcription_status_counts"] = labeled_status_counts = []
+
+    for status_key, status_label in TranscriptionStatus.CHOICES:
+        value = status_counts_by_key.get(status_key, 0)
         if value:
             pct = round(100 * (value / asset_count))
         else:
             pct = 0
 
-        ctx[f"{state}_percent"] = pct
+        ctx[f"{status_key}_percent"] = pct
+        labeled_status_counts.append((status_label, value))
 
 
 @method_decorator(default_cache_control, name="dispatch")

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -319,7 +319,7 @@ def calculate_asset_stats(asset_qs, ctx):
             pct = 0
 
         ctx[f"{status_key}_percent"] = pct
-        labeled_status_counts.append((status_label, value))
+        labeled_status_counts.append((status_key, status_label, value))
 
 
 @method_decorator(default_cache_control, name="dispatch")


### PR DESCRIPTION
* [x] De-emphasize completed items in list views by making them partially transparent until they're hovered over:
  ![image](https://user-images.githubusercontent.com/46565/48513711-7a202e80-e82a-11e8-8da4-7fc70800d791.png)
* [x] Show state counts on the progress bar's text summary table:  ![image](https://user-images.githubusercontent.com/46565/48514506-72fa2000-e82c-11e8-9483-a4bccf43350c.png)
* [ ] Show item completion on progress detail page's item list
* [ ] Show project completion on campaign detail page's project list