### PR TITLE
WIP: Unified transcription status filtering UI

### DIFF
--- a/concordia/forms.py
+++ b/concordia/forms.py
@@ -4,8 +4,6 @@ from django import forms
 from django.contrib.auth import get_user_model
 from django_registration.forms import RegistrationForm
 
-from .models import TranscriptionStatus
-
 User = get_user_model()
 logger = getLogger(__name__)
 
@@ -54,29 +52,6 @@ class ContactUsForm(forms.Form):
     story = forms.CharField(
         label="Let us know how we can help:", required=True, widget=forms.Textarea
     )
-
-
-class AssetFilteringForm(forms.Form):
-    transcription_status = forms.ChoiceField(
-        choices=TranscriptionStatus.CHOICES,
-        required=False,
-        label="Image Status",
-        widget=forms.Select(attrs={"class": "form-control"}),
-    )
-
-    def __init__(self, status_counts, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        asset_statuses = {
-            key: "%s (%d)" % (val, status_counts.get(key, 0))
-            for key, val in TranscriptionStatus.CHOICES
-        }
-
-        filtered_choices = [("", f"All Images ({sum(status_counts.values())})")]
-        for val, label in self.fields["transcription_status"].choices:
-            filtered_choices.append((val, asset_statuses[val]))
-
-        self.fields["transcription_status"].choices = filtered_choices
 
 
 class AdminItemImportForm(forms.Form):

--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -604,7 +604,7 @@ ul.nav-secondary {
     font-weight: inherit;
 }
 
-#progress-stats .transcription-status-key {
+.transcription-status-key {
     display: inline-block;
     height: 0.6em;
     width: 0.6em;

--- a/concordia/templates/fragments/transcription-progress-bar.html
+++ b/concordia/templates/fragments/transcription-progress-bar.html
@@ -6,11 +6,11 @@
 </div>
 
 <div id="progress-bar" class="progress">
-    <div title="Completed" class="progress-bar bg-completed" role="progressbar" style="width: {{ completed_percent }}%" aria-valuenow="{{ completed_percent }}" aria-valuemin="0" aria-valuemax="100">
+    <div title="Completed ({{ completed_count|intcomma }})" class="progress-bar bg-completed" role="progressbar" style="width: {{ completed_percent }}%" aria-valuenow="{{ completed_percent }}" aria-valuemin="0" aria-valuemax="100">
     </div>
-    <div title="Submitted for Review" class="progress-bar bg-submitted" role="progressbar" style="width: {{ submitted_percent }}%" aria-valuenow="{{ submitted_percent }}" aria-valuemin="0" aria-valuemax="100">
+    <div title="Submitted for Review ({{ submitted_count|intcomma }})" class="progress-bar bg-submitted" role="progressbar" style="width: {{ submitted_percent }}%" aria-valuenow="{{ submitted_percent }}" aria-valuemin="0" aria-valuemax="100">
     </div>
-    <div title="In Progress" class="progress-bar bg-in_progress" role="progressbar" style="width: {{ in_progress_percent }}%" aria-valuenow="{{ in_progress_percent }}" aria-valuemin="0" aria-valuemax="100">
+    <div title="In Progress ({{ in_progress_count|intcomma }})" class="progress-bar bg-in_progress" role="progressbar" style="width: {{ in_progress_percent }}%" aria-valuenow="{{ in_progress_percent }}" aria-valuemin="0" aria-valuemax="100">
     </div>
 </div>
 <div class="table-responsive-md">

--- a/concordia/templates/fragments/transcription-progress-bar.html
+++ b/concordia/templates/fragments/transcription-progress-bar.html
@@ -10,7 +10,7 @@
     </div>
     <div title="Submitted for Review" class="progress-bar bg-submitted" role="progressbar" style="width: {{ submitted_percent }}%" aria-valuenow="{{ submitted_percent }}" aria-valuemin="0" aria-valuemax="100">
     </div>
-    <div title="In Progress" class="progress-bar bg-edit" role="progressbar" style="width: {{ in_progress_percent }}%" aria-valuenow="{{ in_progress_percent }}" aria-valuemin="0" aria-valuemax="100">
+    <div title="In Progress" class="progress-bar bg-in_progress" role="progressbar" style="width: {{ in_progress_percent }}%" aria-valuenow="{{ in_progress_percent }}" aria-valuemin="0" aria-valuemax="100">
     </div>
 </div>
 <div class="table-responsive-md">

--- a/concordia/templates/fragments/transcription-progress-bar.html
+++ b/concordia/templates/fragments/transcription-progress-bar.html
@@ -6,11 +6,11 @@
 </div>
 
 <div id="progress-bar" class="progress">
-    <div title="Completed ({{ completed_count|intcomma }})" class="progress-bar bg-completed" role="progressbar" style="width: {{ completed_percent }}%" aria-valuenow="{{ completed_percent }}" aria-valuemin="0" aria-valuemax="100">
+    <div title="Completed ({{ completed_count|intcomma }} page{{ completed_count|pluralize }})" class="progress-bar bg-completed" role="progressbar" style="width: {{ completed_percent }}%" aria-valuenow="{{ completed_percent }}" aria-valuemin="0" aria-valuemax="100">
     </div>
-    <div title="Submitted for Review ({{ submitted_count|intcomma }})" class="progress-bar bg-submitted" role="progressbar" style="width: {{ submitted_percent }}%" aria-valuenow="{{ submitted_percent }}" aria-valuemin="0" aria-valuemax="100">
+    <div title="Submitted for Review ({{ submitted_count|intcomma }} page{{ submitted_count|pluralize }})" class="progress-bar bg-submitted" role="progressbar" style="width: {{ submitted_percent }}%" aria-valuenow="{{ submitted_percent }}" aria-valuemin="0" aria-valuemax="100">
     </div>
-    <div title="In Progress ({{ in_progress_count|intcomma }})" class="progress-bar bg-in_progress" role="progressbar" style="width: {{ in_progress_percent }}%" aria-valuenow="{{ in_progress_percent }}" aria-valuemin="0" aria-valuemax="100">
+    <div title="In Progress ({{ in_progress_count|intcomma }} page{{ in_progress_count|pluralize }})" class="progress-bar bg-in_progress" role="progressbar" style="width: {{ in_progress_percent }}%" aria-valuenow="{{ in_progress_percent }}" aria-valuemin="0" aria-valuemax="100">
     </div>
 </div>
 <div class="table-responsive-md">

--- a/concordia/templates/fragments/transcription-progress-bar.html
+++ b/concordia/templates/fragments/transcription-progress-bar.html
@@ -24,7 +24,11 @@
                             {{ label }}
                         </a>
                     </th>
-                    <td class="text-right"><a href="?transcription_status={{ key|urlencode }}">{{ value|intcomma }}</a></td>
+                    <td class="text-right">
+                        <a href="?transcription_status={{ key|urlencode }}">
+                            <abbr title="{{ value|intcomma }} pages">{{ value|intcomma }}</abbr>
+                        </a>
+                    </td>
                 </tr>
             {% endfor %}
         </tbody>

--- a/concordia/templates/fragments/transcription-status-filters.html
+++ b/concordia/templates/fragments/transcription-status-filters.html
@@ -1,5 +1,11 @@
 <div class="btn-group btn-group-sm btn-group-toggle">
-    {% for url, classes, label in status_choices %}
-        <a class="btn btn-outline-secondary {{ classes }}" href="{{ url|default:"?" }}">{{ label }}</a>
+    {% for url, classes, key, label in status_choices %}
+        <a class="btn btn-outline-secondary {{ classes }}" href="{{ url|default:"?" }}">
+            {% if key %}
+                <span class="transcription-status-key bg-{{ key }}"></span>
+            {% endif %}
+
+            {{ label }}
+        </a>
     {% endfor %}
 </div>

--- a/concordia/templates/fragments/transcription-status-filters.html
+++ b/concordia/templates/fragments/transcription-status-filters.html
@@ -1,0 +1,5 @@
+<div class="btn-group btn-group-sm btn-group-toggle">
+    {% for url, classes, label in status_choices %}
+        <a class="btn btn-outline-secondary {{ classes }}" href="{{ url }}">{{ label }}</a>
+    {% endfor %}
+</div>

--- a/concordia/templates/fragments/transcription-status-filters.html
+++ b/concordia/templates/fragments/transcription-status-filters.html
@@ -1,5 +1,5 @@
 <div class="btn-group btn-group-sm btn-group-toggle">
     {% for url, classes, label in status_choices %}
-        <a class="btn btn-outline-secondary {{ classes }}" href="{{ url }}">{{ label }}</a>
+        <a class="btn btn-outline-secondary {{ classes }}" href="{{ url|default:"?" }}">{{ label }}</a>
     {% endfor %}
 </div>

--- a/concordia/templates/transcriptions/campaign_detail.html
+++ b/concordia/templates/transcriptions/campaign_detail.html
@@ -29,7 +29,7 @@
             {% endif %}
         </div>
     </div>
-    <div class="row">
+    <div class="row px-3">
         <div class="col-md-6">
             {% transcription_status_filters transcription_status_counts request.GET.transcription_status %}
         </div>

--- a/concordia/templates/transcriptions/campaign_detail.html
+++ b/concordia/templates/transcriptions/campaign_detail.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load staticfiles %}
+{% load concordia_filtering_tags %}
 
 {% block title %}{{ campaign.title }}{% endblock title %}
 
@@ -16,8 +17,6 @@
             <p class="hero-text">{{ campaign.description }}</p>
         </div>
         <div class="col-md-3">
-            {% include "fragments/transcription-progress-bar.html" %}
-
             {% if campaign.resource_set.all|length %}
                 <div class="related-links mb-3 p-1 p-sm-2 p-lg-3">
                     <h4>Related Links</h4>
@@ -28,6 +27,14 @@
                     </div>
                 </div>
             {% endif %}
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-6">
+            {% transcription_status_filters transcription_status_counts request.GET.transcription_status %}
+        </div>
+        <div class="col-md-6">
+            {% include "fragments/transcription-progress-bar.html" %}
         </div>
     </div>
     <div class="row">

--- a/concordia/templates/transcriptions/campaign_detail.html
+++ b/concordia/templates/transcriptions/campaign_detail.html
@@ -50,7 +50,7 @@
                     <div class="progress w-100 my-2">
                         <div title="Completed" class="progress-bar bg-completed" role="progressbar" style="width: {{ project.completed_percent }}%" aria-valuenow="{{ project.completed_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
                         <div title="Submitted for Review" class="progress-bar bg-submitted" role="progressbar" style="width: {{ project.submitted_percent }}%" aria-valuenow="{{ project.submitted_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
-                        <div title="In Progress" class="progress-bar bg-edit" role="progressbar" style="width: {{ project.in_progress_percent }}%" aria-valuenow="{{ project.in_progress_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
+                        <div title="In Progress" class="progress-bar bg-in_progress" role="progressbar" style="width: {{ project.in_progress_percent }}%" aria-valuenow="{{ project.in_progress_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
                     </div>
 
                     <h6 class="text-center primary-text">

--- a/concordia/templates/transcriptions/item_detail.html
+++ b/concordia/templates/transcriptions/item_detail.html
@@ -31,7 +31,7 @@
             </div>
         </div>
     </div>
-    <div class="row py-3">
+    <div class="row p-3">
         <div class="col-md-6">
             {% transcription_status_filters transcription_status_counts request.GET.transcription_status %}
         </div>

--- a/concordia/templates/transcriptions/item_detail.html
+++ b/concordia/templates/transcriptions/item_detail.html
@@ -3,6 +3,7 @@
 {% load humanize %}
 {% load staticfiles %}
 {% load concordia_media_tags %}
+{% load concordia_filtering_tags %}
 
 {% block title %}
 {{ item.title }} ({{ campaign.title }}: {{ project.title }})
@@ -31,20 +32,10 @@
         </div>
     </div>
     <div class="row py-3">
-        <form method="get" class="col-md-4 mx-auto">
-            <div class="form-group row">
-                <div class="input-group input-group-sm">
-                    <div class="input-group-prepend">
-                        <label for="id_transcription_status" class="input-group-text">Filter:</label>
-                    </div>
-                    {{ filter_form.transcription_status }}
-                    <div class="input-group-append">
-                        <button type="submit" class="btn btn-sm btn-outline-primary">Go</button>
-                    </div>
-                </div>
-            </div>
-        </form>
-        <div class="col-md-4 mx-auto">
+        <div class="col-md-6">
+            {% transcription_status_filters transcription_status_counts request.GET.transcription_status %}
+        </div>
+        <div class="col-md-6">
             {% include "fragments/transcription-progress-bar.html" %}
         </div>
     </div>

--- a/concordia/templates/transcriptions/project_detail.html
+++ b/concordia/templates/transcriptions/project_detail.html
@@ -24,7 +24,7 @@
             <p class="m-3 hero-text">{{ project.description }}</p>
         </div>
     </div>
-    <div class="row">
+    <div class="row px-3">
         <div class="col-md-6">
             {% transcription_status_filters transcription_status_counts request.GET.transcription_status %}
         </div>

--- a/concordia/templates/transcriptions/project_detail.html
+++ b/concordia/templates/transcriptions/project_detail.html
@@ -43,7 +43,7 @@
                     <div class="progress w-100 my-2">
                         <div title="Completed" class="progress-bar bg-completed" role="progressbar" style="width: {{ item.completed_percent }}%" aria-valuenow="{{ item.completed_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
                         <div title="Submitted for Review" class="progress-bar bg-submitted" role="progressbar" style="width: {{ item.submitted_percent }}%" aria-valuenow="{{ item.submitted_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
-                        <div title="In Progress" class="progress-bar bg-edit" role="progressbar" style="width: {{ item.in_progress_percent }}%" aria-valuenow="{{ item.in_progress_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
+                        <div title="In Progress" class="progress-bar bg-in_progress" role="progressbar" style="width: {{ item.in_progress_percent }}%" aria-valuenow="{{ item.in_progress_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
                     </div>
 
                     <h6 class="text-center primary-text">

--- a/concordia/templates/transcriptions/project_detail.html
+++ b/concordia/templates/transcriptions/project_detail.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% load staticfiles %}
+{% load concordia_filtering_tags %}
 
 {% block title %}{{ project.title }} ({{ campaign.title }}){% endblock title %}
 
@@ -18,11 +19,16 @@
 {% block main_content %}
 <div class="container py-3">
     <div class="row">
-        <div class="col-md-9">
+        <div class="col-12">
             <h1 class="m-3">{{ project.title }}</h1>
             <p class="m-3 hero-text">{{ project.description }}</p>
         </div>
-        <div class="col-md-3">
+    </div>
+    <div class="row">
+        <div class="col-md-6">
+            {% transcription_status_filters transcription_status_counts request.GET.transcription_status %}
+        </div>
+        <div class="col-md-6">
             {% include "fragments/transcription-progress-bar.html" %}
         </div>
     </div>

--- a/concordia/templatetags/concordia_filtering_tags.py
+++ b/concordia/templatetags/concordia_filtering_tags.py
@@ -11,20 +11,16 @@ register = template.Library()
 def transcription_status_filters(status_counts, active_value):
     ctx = {}
 
-    status_count_map = {key: count for key, label, count in status_counts}
-    total_count = sum(status_count_map.values())
-
     ctx["status_choices"] = status_choices = [
-        ("", "active" if not active_value else "", f"All ({total_count})")
+        ("", "active" if not active_value else "", f"All")
     ]
 
     for key, label in TranscriptionStatus.CHOICES:
-        asset_count = status_count_map.get(key, 0)
         status_choices.append(
             (
                 "?transcription_status=%s" % urlquote(key),
                 "active" if active_value == key else "",
-                f"{label} ({asset_count})",
+                label,
             )
         )
 

--- a/concordia/templatetags/concordia_filtering_tags.py
+++ b/concordia/templatetags/concordia_filtering_tags.py
@@ -1,0 +1,31 @@
+from urllib.parse import quote as urlquote
+
+from django import template
+
+from ..models import TranscriptionStatus
+
+register = template.Library()
+
+
+@register.inclusion_tag("fragments/transcription-status-filters.html")
+def transcription_status_filters(status_counts, active_value):
+    ctx = {}
+
+    status_count_map = {key: count for key, label, count in status_counts}
+    total_count = sum(status_count_map.values())
+
+    ctx["status_choices"] = status_choices = [
+        ("", "active" if not active_value else "", f"All ({total_count})")
+    ]
+
+    for key, label in TranscriptionStatus.CHOICES:
+        asset_count = status_count_map.get(key, 0)
+        status_choices.append(
+            (
+                "?transcription_status=%s" % urlquote(key),
+                "active" if active_value == key else "",
+                f"{label} ({asset_count})",
+            )
+        )
+
+    return ctx

--- a/concordia/templatetags/concordia_filtering_tags.py
+++ b/concordia/templatetags/concordia_filtering_tags.py
@@ -12,7 +12,7 @@ def transcription_status_filters(status_counts, active_value):
     ctx = {}
 
     ctx["status_choices"] = status_choices = [
-        ("", "active" if not active_value else "", f"All")
+        ("", "active" if not active_value else "", "", "All")
     ]
 
     for key, label in TranscriptionStatus.CHOICES:
@@ -20,6 +20,7 @@ def transcription_status_filters(status_counts, active_value):
             (
                 "?transcription_status=%s" % urlquote(key),
                 "active" if active_value == key else "",
+                key,
                 label,
             )
         )

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -310,6 +310,7 @@ def calculate_asset_stats(asset_qs, ctx):
             pct = 0
 
         ctx[f"{status_key}_percent"] = pct
+        ctx[f"{status_key}_count"] = value
         labeled_status_counts.append((status_key, status_label, value))
 
 

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -39,12 +39,7 @@ from django_registration.backends.activation.views import RegistrationView
 from ratelimit.decorators import ratelimit
 from ratelimit.mixins import RatelimitMixin
 
-from concordia.forms import (
-    AssetFilteringForm,
-    ContactUsForm,
-    UserProfileForm,
-    UserRegistrationForm,
-)
+from concordia.forms import ContactUsForm, UserProfileForm, UserRegistrationForm
 from concordia.models import (
     Asset,
     AssetTranscriptionReservation,
@@ -425,8 +420,6 @@ class ItemDetailView(ListView):
     context_object_name = "assets"
     paginate_by = 10
 
-    form_class = AssetFilteringForm
-
     http_method_names = ["get", "options", "head"]
 
     def get_queryset(self):
@@ -446,21 +439,7 @@ class ItemDetailView(ListView):
     def apply_asset_filters(self, asset_qs):
         """Use optional GET parameters to filter the asset list"""
 
-        # We want to get a list of all of the available asset states in this
-        # item's assets and will return that with the preferred display labels
-        # including the asset count to be displayed in the filter UI
-        asset_state_qs = asset_qs.values_list("transcription_status")
-        asset_state_qs = asset_state_qs.annotate(
-            Count("transcription_status")
-        ).order_by()
-
-        self.transcription_status_counts = status_counts = dict(asset_state_qs)
-
-        self.filter_form = form = self.form_class(status_counts, self.request.GET)
-        if form.is_valid():
-            asset_qs = asset_qs.filter(
-                **{k: v for k, v in form.cleaned_data.items() if v}
-            )
+        # FIXME: re-implement filtering
 
         return asset_qs
 
@@ -472,8 +451,6 @@ class ItemDetailView(ListView):
                 "campaign": self.item.project.campaign,
                 "project": self.item.project,
                 "item": self.item,
-                "filter_form": self.filter_form,
-                "transcription_status_counts": self.transcription_status_counts,
             }
         )
 


### PR DESCRIPTION
This changes the transcription status filter to be a group of radio-style buttons on the campaign, project, and item detail pages.

Campaign detail:

![image](https://user-images.githubusercontent.com/46565/48578660-4c012400-e8e8-11e8-979f-9fbb53d7d838.png)

Project detail:

![image](https://user-images.githubusercontent.com/46565/48578682-591e1300-e8e8-11e8-87ff-93ca39ff0027.png)

Item detail:

![image](https://user-images.githubusercontent.com/46565/48578693-5fac8a80-e8e8-11e8-92d0-f8be4bf1f120.png)
