### PR TITLE
Pass current status filter to other levels

### DIFF
--- a/concordia/templates/fragments/transcription-progress-bar.html
+++ b/concordia/templates/fragments/transcription-progress-bar.html
@@ -17,7 +17,7 @@
     <table id="progress-stats" class="table table-sm font-weight-light">
         <tbody>
             {% for key, label, value in transcription_status_counts reversed %}
-                <tr>
+                <tr class="{% if filters.transcription_status == key %}table-secondary{% endif %}">
                     <th class="text-nowrap">
                         <a href="?transcription_status={{ key|urlencode }}">
                             <span class="transcription-status-key bg-{{ key }}"></span>

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -9,6 +9,7 @@
 {% endblock title %}
 
 {% block head_content %}
+    <link rel="canonical" href="https://{{ request.get_host }}{{ request.path }}">
 {% endblock head_content %}
 
 {% block breadcrumbs %}

--- a/concordia/templates/transcriptions/campaign_detail.html
+++ b/concordia/templates/transcriptions/campaign_detail.html
@@ -4,6 +4,10 @@
 
 {% block title %}{{ campaign.title }}{% endblock title %}
 
+{% block head_content %}
+    <link rel="canonical" href="https://{{ request.get_host }}{{ request.path }}">
+{% endblock head_content %}
+
 {% block breadcrumbs %}
     <li class="breadcrumb-item"><a class="primary-text" href="{% url 'transcriptions:campaign-list' %}">Campaigns</a></li>
     <li class="breadcrumb-item active" aria-current="page" title="{{ campaign.title }}">{{ campaign.title }}</li>

--- a/concordia/templates/transcriptions/campaign_detail.html
+++ b/concordia/templates/transcriptions/campaign_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+
 {% load staticfiles %}
 
 {% block title %}{{ campaign.title }}{% endblock title %}
@@ -35,7 +36,7 @@
                 <div class="col-12 col-md-4 col-lg-3 m-2 p-1 concordia-object-card card bg-lightest-gray shadow-regular align-items-center" data-transcription-status="{{ project.lowest_transcription_status }}">
                     {% url 'transcriptions:project-detail' campaign.slug project.slug as project_url %}
 
-                    <a href="{{ project_url }}" aria-hidden="true">
+                    <a href="{{ project_url }}?{{ sublevel_querystring }}" aria-hidden="true">
                         <img class="card-img card-img-campaign" src="{{ MEDIA_URL }}{{ project.thumbnail_image }}" alt="{{ project.title }}">
                     </a>
 
@@ -46,7 +47,7 @@
                     </div>
 
                     <h6 class="text-center primary-text">
-                        <a href="{{ project_url }}">{{ project.title }}</a>
+                        <a href="{{ project_url }}?{{ sublevel_querystring }}">{{ project.title }}</a>
                     </h6>
                 </div>
             {% endfor %}

--- a/concordia/templates/transcriptions/campaign_list.html
+++ b/concordia/templates/transcriptions/campaign_list.html
@@ -4,6 +4,10 @@
 
 {% block title %}Campaigns{% endblock title %}
 
+{% block head_content %}
+    <link rel="canonical" href="https://{{ request.get_host }}{{ request.path }}">
+{% endblock head_content %}
+
 {% block breadcrumbs %}
     <li class="breadcrumb-item active" aria-current="page">Campaigns</li>
 {% endblock breadcrumbs %}

--- a/concordia/templates/transcriptions/item_detail.html
+++ b/concordia/templates/transcriptions/item_detail.html
@@ -12,8 +12,8 @@
 
 {% block breadcrumbs %}
     <li class="breadcrumb-item"><a class="primary-text" href="{% url 'transcriptions:campaign-list' %}">Campaigns</a></li>
-    <li class="breadcrumb-item"><a class="primary-text" href="{% url 'transcriptions:campaign-detail' campaign.slug %}" title="{{ campaign.title }}">{{ campaign.title }}</a></li>
-    <li class="breadcrumb-item"><a class="primary-text" href="{% url 'transcriptions:project-detail' campaign.slug project.slug %}" title="{{ project.title }}">{{ project.title }}</a></li>
+    <li class="breadcrumb-item"><a class="primary-text" href="{% url 'transcriptions:campaign-detail' campaign.slug %}?{{ sublevel_querystring }}" title="{{ campaign.title }}">{{ campaign.title }}</a></li>
+    <li class="breadcrumb-item"><a class="primary-text" href="{% url 'transcriptions:project-detail' campaign.slug project.slug %}?{{ sublevel_querystring }}" title="{{ project.title }}">{{ project.title }}</a></li>
     <li class="breadcrumb-item active" aria-current="page" title="{{ item.title }}">{{ item.title|truncatechars:40 }}</li>
 {% endblock breadcrumbs%}
 

--- a/concordia/templates/transcriptions/item_detail.html
+++ b/concordia/templates/transcriptions/item_detail.html
@@ -8,7 +8,9 @@
 {{ item.title }} ({{ campaign.title }}: {{ project.title }})
 {% endblock title %}
 
-{% block head_content %}{% endblock head_content %}
+{% block head_content %}
+    <link rel="canonical" href="https://{{ request.get_host }}{{ request.path }}">
+{% endblock head_content %}
 
 {% block breadcrumbs %}
     <li class="breadcrumb-item"><a class="primary-text" href="{% url 'transcriptions:campaign-list' %}">Campaigns</a></li>

--- a/concordia/templates/transcriptions/project_detail.html
+++ b/concordia/templates/transcriptions/project_detail.html
@@ -5,6 +5,7 @@
 {% block title %}{{ project.title }} ({{ campaign.title }}){% endblock title %}
 
 {% block head_content %}
+    <link rel="canonical" href="https://{{ request.get_host }}{{ request.path }}">
 {% endblock head_content %}
 
 {% block breadcrumbs %}

--- a/concordia/templates/transcriptions/project_detail.html
+++ b/concordia/templates/transcriptions/project_detail.html
@@ -10,7 +10,7 @@
 {% block breadcrumbs %}
     <li class="breadcrumb-item"><a class="primary-text" href="{% url 'transcriptions:campaign-list' %}">Campaigns</a></li>
     <li class="breadcrumb-item">
-        <a class="primary-text" href="{% url 'transcriptions:campaign-detail' campaign.slug %}" title="{{ campaign.title }}">{{ campaign.title }}</a>
+        <a class="primary-text" href="{% url 'transcriptions:campaign-detail' campaign.slug %}?{{ sublevel_querystring }}" title="{{ campaign.title }}">{{ campaign.title }}</a>
     </li>
     <li class="breadcrumb-item active" aria-current="page" title="{{ project.title }}">{{ project.title }}</li>
 {% endblock breadcrumbs %}
@@ -28,7 +28,7 @@
         <div class="card-deck w-100 flex-column flex-sm-row justify-content-center align-items-center align-items-sm-stretch">
             {% for item in items %}
                 <div class="col-12 col-md-4 col-lg-3 m-2 p-1 concordia-object-card card bg-lightest-gray shadow-regular align-items-center" data-transcription-status="{{ item.lowest_transcription_status }}">
-                    <a href="{% url 'transcriptions:item-detail' campaign.slug project.slug item.item_id %}">
+                    <a href="{% url 'transcriptions:item-detail' campaign.slug project.slug item.item_id %}?{{ sublevel_querystring }}">
                         <img class="card-img card-img-campaign" alt="{{ item.title }}" src="{{ item.thumbnail_url }}">
                     </a>
 
@@ -39,7 +39,7 @@
                     </div>
 
                     <h6 class="text-center primary-text">
-                        <a href="{% url 'transcriptions:item-detail' campaign.slug project.slug item.item_id %}" class="campaign-image-link">
+                        <a href="{% url 'transcriptions:item-detail' campaign.slug project.slug item.item_id %}?{{ sublevel_querystring }}" class="campaign-image-link">
                             {{ item.title }}
                         </a>
                     </h6>


### PR DESCRIPTION
This preserves the active status filters as you navigate between levels so e.g. if you filter the campaign list for campaigns with submitted assets the links to that campaign's projects will include that filter. This also changes the progress bar's summary table slightly to add the table-secondary background class when applicable so the active filter, if any, will be highlighted there along with the filter button:

![image](https://user-images.githubusercontent.com/46565/48715424-faf07900-ebe2-11e8-9009-283907242a80.png)


See #321
See #633
See #647