### PR TITLE
Greater opacity for disabled buttons

### DIFF
--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -352,6 +352,11 @@ ul.nav-secondary {
     left: -5rem;
 }
 
+.btn.disabled,
+.btn:disabled {
+    opacity: 0.25 !important;
+}
+
 .btn-secondary {
     background-color: var(--secondary-color);
     border-color: var(--secondary-color);


### PR DESCRIPTION
This increases the distinction between enabled and disabled buttons (closes #657) to be more obvious on lower-contrast displays.

![image](https://user-images.githubusercontent.com/46565/49095569-c14ced00-f236-11e8-9ad1-a52a0609a174.png)
