### PR TITLE
Search-engine metadata for campaign and project detail pages

### DIFF
--- a/concordia/templates/transcriptions/campaign_detail.html
+++ b/concordia/templates/transcriptions/campaign_detail.html
@@ -8,6 +8,8 @@
 {% block head_content %}
     <link rel="canonical" href="https://{{ request.get_host }}{{ request.path }}">
     <meta name="description" content="{{ campaign.description|normalize_whitespace }}">
+    <meta name="thumbnail" content="{{ MEDIA_URL }}{{ campaign.thumbnail_image }}">
+    <meta property="og:image" content="{{ MEDIA_URL }}{{ campaign.thumbnail_image }}">
 {% endblock head_content %}
 
 {% block breadcrumbs %}

--- a/concordia/templates/transcriptions/campaign_detail.html
+++ b/concordia/templates/transcriptions/campaign_detail.html
@@ -1,11 +1,13 @@
 {% extends "base.html" %}
 
 {% load staticfiles %}
+{% load concordia_text_tags %}
 
 {% block title %}{{ campaign.title }}{% endblock title %}
 
 {% block head_content %}
     <link rel="canonical" href="https://{{ request.get_host }}{{ request.path }}">
+    <meta name="description" content="{{ campaign.description|normalize_whitespace }}">
 {% endblock head_content %}
 
 {% block breadcrumbs %}

--- a/concordia/templates/transcriptions/project_detail.html
+++ b/concordia/templates/transcriptions/project_detail.html
@@ -8,6 +8,8 @@
 {% block head_content %}
     <link rel="canonical" href="https://{{ request.get_host }}{{ request.path }}">
     <meta name="description" content="{{ project.description|normalize_whitespace }}">
+    <meta name="thumbnail" content="{{ MEDIA_URL }}{{ project.thumbnail_image }}">
+    <meta property="og:image" content="{{ MEDIA_URL }}{{ project.thumbnail_image }}">
 {% endblock head_content %}
 
 {% block breadcrumbs %}

--- a/concordia/templates/transcriptions/project_detail.html
+++ b/concordia/templates/transcriptions/project_detail.html
@@ -1,11 +1,13 @@
 {% extends "base.html" %}
 
 {% load staticfiles %}
+{% load concordia_text_tags %}
 
 {% block title %}{{ project.title }} ({{ campaign.title }}){% endblock title %}
 
 {% block head_content %}
     <link rel="canonical" href="https://{{ request.get_host }}{{ request.path }}">
+    <meta name="description" content="{{ project.description|normalize_whitespace }}">
 {% endblock head_content %}
 
 {% block breadcrumbs %}

--- a/concordia/templatetags/concordia_text_tags.py
+++ b/concordia/templatetags/concordia_text_tags.py
@@ -1,0 +1,16 @@
+import re
+
+from django import template
+
+register = template.Library()
+
+WHITESPACE_NORMALIZER = re.compile(r"\s+")
+
+
+@register.filter
+def normalize_whitespace(text):
+    """
+    Return the provided text after with all consecutive whitespace replaced with
+    a single space
+    """
+    return WHITESPACE_NORMALIZER.sub(" ", text)


### PR DESCRIPTION
This was requested by the loc.gov search team and will help outside spiders and social sharing.

Note that I did not add a separate og:title meta tag since it would have the same value as `<title>`. If we want to customize that to have a different value we can discuss how that would be useful.