### PR TITLE
Preserve linebreaks in descriptions

### DIFF
--- a/concordia/templates/transcriptions/campaign_detail.html
+++ b/concordia/templates/transcriptions/campaign_detail.html
@@ -18,7 +18,7 @@
     <div class="row">
         <div class="col-md-9">
             <h1>{{ campaign.title }}</h1>
-            <p class="hero-text">{{ campaign.description }}</p>
+            <p class="hero-text">{{ campaign.description|linebreaksbr }}</p>
         </div>
         <div class="col-md-3">
             {% if campaign.resource_set.all|length %}

--- a/concordia/templates/transcriptions/campaign_list.html
+++ b/concordia/templates/transcriptions/campaign_list.html
@@ -23,7 +23,7 @@
                             <a href="{% url 'transcriptions:campaign-detail' campaign.slug %}">
                                 <h1 class="campaign-title">{{ campaign.title }}</h1>
                             </a>
-                            {{ campaign.short_description }}
+                            {{ campaign.short_description|linebreaksbr }}
                         </div>
                         <div class="col-12 col-md-4">
                             <a href="{% url 'transcriptions:campaign-detail' campaign.slug %}">

--- a/concordia/templates/transcriptions/item_detail.html
+++ b/concordia/templates/transcriptions/item_detail.html
@@ -24,7 +24,7 @@
     <div class="row">
         <div class="col-md-10">
             <h1 class="m-3">{{ item.title }}</h1>
-            <p class="m-3 hero-text">{{ item.description }}</p>
+            <p class="m-3 hero-text">{{ item.description|linebreaksbr }}</p>
         </div>
         <div class="col-md-2 align-bottom">
             <div class="m-3">

--- a/concordia/templates/transcriptions/project_detail.html
+++ b/concordia/templates/transcriptions/project_detail.html
@@ -21,7 +21,7 @@
     <div class="row">
         <div class="col-12">
             <h1 class="m-3">{{ project.title }}</h1>
-            <p class="m-3 hero-text">{{ project.description }}</p>
+            <p class="m-3 hero-text">{{ project.description|linebreaksbr }}</p>
         </div>
     </div>
     {% include "fragments/transcription-progress-row.html" %}


### PR DESCRIPTION
See #474 — this just preserves linebreaks in the description and short description fields on the campaign list and detail, project detail, and item detail pages:
 
![image](https://user-images.githubusercontent.com/46565/49158599-91622000-f2f0-11e8-9423-d64dde448dd2.png)
