### PR TITLE
Docker: run APT dist-upgrade on build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,14 @@ FROM ubuntu:18.04
 ENV DEBIAN_FRONTEND="noninteractive"
 
 # Pillow/Imaging: https://pillow.readthedocs.io/en/latest/installation.html#external-libraries
-RUN apt-get update -qy && apt-get install -o Dpkg::Options::='--force-confnew' -qy \
+RUN apt-get update -qy && apt-get dist-upgrade -qy && apt-get install -o Dpkg::Options::='--force-confnew' -qy \
     git curl \
     python3 python3-dev python3-pip \
     libz-dev libfreetype6-dev \
     libmemcached-dev \
     libtiff-dev libjpeg-dev libopenjp2-7-dev libwebp-dev zlib1g-dev \
     graphviz \
-    locales
+    locales && apt-get -qy autoremove && apt-get -qy autoclean
 
 RUN locale-gen en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8


### PR DESCRIPTION
This ensures that we always get any updates released in the interval between when the base image is updated and when the container is built