### PR TITLE
WIP: Enable unicode support for slug fields

### DIFF
--- a/cloudformation/infrastructure/elasticache-feature.yaml
+++ b/cloudformation/infrastructure/elasticache-feature.yaml
@@ -1,6 +1,6 @@
 Description: >
     This template deploys an elasticache cluster to the provided VPC and subnets
-    
+
 Parameters:
 
     EnvironmentName:
@@ -10,7 +10,7 @@ Parameters:
     SecurityGroup:
         Description: Select the Security Group to use for the ECS cluster hosts
         Type: AWS::EC2::SecurityGroup::Id
-      
+
     CacheNodeType:
         Type: String
         Default: cache.m1.small

--- a/cloudformation/infrastructure/network-acl.yaml
+++ b/cloudformation/infrastructure/network-acl.yaml
@@ -4,11 +4,11 @@ Description: >
     by all of the other nested templates.
 
 Parameters:
-    
+
     EnvironmentName:
         Description: An environment name that will be prefixed to resource names
         Type: String
-    
+
     VPC:
         Type: AWS::EC2::VPC::Id
         Description: Choose which VPC the security groups should be deployed to
@@ -17,7 +17,7 @@ Parameters:
         Description: A reference to the public subnet in the 1st Availability Zone
         Type: AWS::EC2::Subnet::Id
 
-    PublicSubnet2: 
+    PublicSubnet2:
         Description: A reference to the public subnet in the 2nd Availability Zone
         Type: AWS::EC2::Subnet::Id
 
@@ -25,7 +25,7 @@ Parameters:
         Description: A reference to the private subnet in the 1st Availability Zone
         Type: AWS::EC2::Subnet::Id
 
-    PrivateSubnet2: 
+    PrivateSubnet2:
         Description: A reference to the private subnet in the 2nd Availability Zone
         Type: AWS::EC2::Subnet::Id
 

--- a/cloudformation/infrastructure/rds.yaml
+++ b/cloudformation/infrastructure/rds.yaml
@@ -8,7 +8,7 @@ Parameters:
         Description: A reference to the private subnet in the 1st Availability Zone
         Type: AWS::EC2::Subnet::Id
 
-    PrivateSubnet2: 
+    PrivateSubnet2:
         Description: A reference to the private subnet in the 2nd Availability Zone
         Type: AWS::EC2::Subnet::Id
 
@@ -34,7 +34,7 @@ Resources:
       AutoMinorVersionUpgrade: true
       DBInstanceClass: db.t2.medium
       Port: '5432'
-      PubliclyAccessible: false      
+      PubliclyAccessible: false
       StorageType: gp2
       BackupRetentionPeriod: '7'
       MasterUsername: concordia
@@ -57,4 +57,3 @@ Outputs:
     DatabaseHostName:
         Description : "Hostname for the relational database service"
         Value : !GetAtt PostgresService.Endpoint.Address
-    

--- a/cloudformation/infrastructure/security-groups.yaml
+++ b/cloudformation/infrastructure/security-groups.yaml
@@ -4,11 +4,11 @@ Description: >
     by all of the other nested templates.
 
 Parameters:
-    
+
     EnvironmentName:
         Description: An environment name that will be prefixed to resource names
         Type: String
-    
+
     VPC:
         Type: AWS::EC2::VPC::Id
         Description: Choose which VPC the security groups should be deployed to
@@ -16,21 +16,21 @@ Parameters:
 Resources:
 
     # This security group defines who/where is allowed to access the ECS hosts directly.
-    # By default we're just allowing access from the load balancer.  If you want to SSH 
+    # By default we're just allowing access from the load balancer.  If you want to SSH
     # into the hosts, or expose non-load balanced services you can open their ports here.
     ECSHostSecurityGroup:
         Type: AWS::EC2::SecurityGroup
-        Properties: 
+        Properties:
             VpcId: !Ref VPC
             GroupDescription: Access to the ECS hosts and the tasks/containers that run on them
             SecurityGroupIngress:
-                - SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup 
+                - SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup
                   IpProtocol: '-1'
                 - SourceSecurityGroupId: !Ref BastionHostSecurityGroup
                   IpProtocol: tcp
                   FromPort: 22
                   ToPort: 22
-            Tags: 
+            Tags:
                 - Key: Name
                   Value: !Sub ${EnvironmentName}-ECS-Hosts
 
@@ -96,11 +96,11 @@ Resources:
                 - SourceSecurityGroupId: !Ref 'ECSHostSecurityGroup'
                   IpProtocol: tcp
                   FromPort: 11211
-                  ToPort: 11211    
+                  ToPort: 11211
 
 Outputs:
 
-    ECSHostSecurityGroup: 
+    ECSHostSecurityGroup:
         Description: A reference to the security group for ECS hosts
         Value: !Ref ECSHostSecurityGroup
 
@@ -115,7 +115,7 @@ Outputs:
     BastionHostSecurityGroup:
         Description: A reference to the security group for bastion hosts
         Value: !Ref BastionHostSecurityGroup
-    
+
     CacheServiceSecurityGroup:
         Description: A reference to the security group for cache services
         Value: !Ref CacheServiceSecurityGroup

--- a/concordia/admin/views.py
+++ b/concordia/admin/views.py
@@ -6,7 +6,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import permission_required
 from django.core.exceptions import ValidationError
 from django.shortcuts import render
-from django.template.defaultfilters import slugify
+from django.utils.text import slugify
 from django.views.decorators.cache import never_cache
 from tabular_export.core import export_to_csv_response, flatten_queryset
 
@@ -74,7 +74,7 @@ def admin_bulk_import_view(request):
                         Campaign,
                         title=campaign_title,
                         defaults={
-                            "slug": slugify(campaign_title),
+                            "slug": slugify(campaign_title, allow_unicode=True),
                             "description": row["Campaign Long Description"] or "",
                             "short_description": row["Campaign Short Description"]
                             or "",
@@ -100,7 +100,7 @@ def admin_bulk_import_view(request):
                         title=project_title,
                         campaign=campaign,
                         defaults={
-                            "slug": slugify(project_title),
+                            "slug": slugify(project_title, allow_unicode=True),
                             "description": row["Project Description"] or "",
                             "campaign": campaign,
                         },

--- a/concordia/converters.py
+++ b/concordia/converters.py
@@ -1,0 +1,7 @@
+from django.urls.converters import SlugConverter
+
+
+class UnicodeSlugConverter(SlugConverter):
+    # This is similar to the slug_unicode_re pattern but is not anchored to the
+    # start of the string:
+    regex = r"[-\w+]+"

--- a/concordia/models.py
+++ b/concordia/models.py
@@ -67,7 +67,7 @@ class Campaign(MetricsModelMixin("campaign"), models.Model):
     display_on_homepage = models.BooleanField(default=True)
 
     title = models.CharField(max_length=80)
-    slug = models.SlugField(max_length=80, unique=True)
+    slug = models.SlugField(max_length=80, unique=True, allow_unicode=True)
     description = models.TextField(blank=True)
     thumbnail_image = models.ImageField(
         upload_to="campaign-thumbnails", blank=True, null=True
@@ -106,7 +106,7 @@ class Project(MetricsModelMixin("project"), models.Model):
     published = models.BooleanField(default=False, blank=True)
 
     title = models.CharField(max_length=80)
-    slug = models.SlugField(max_length=80)
+    slug = models.SlugField(max_length=80, allow_unicode=True)
     thumbnail_image = models.ImageField(
         upload_to="project-thumbnails", blank=True, null=True
     )
@@ -175,7 +175,7 @@ class Asset(MetricsModelMixin("asset"), models.Model):
     published = models.BooleanField(default=False, blank=True)
 
     title = models.CharField(max_length=100)
-    slug = models.SlugField(max_length=100)
+    slug = models.SlugField(max_length=100, allow_unicode=True)
 
     description = models.TextField(blank=True)
     # TODO: do we really need this given that we import in lock-step sequence

--- a/concordia/tests/test_view.py
+++ b/concordia/tests/test_view.py
@@ -120,6 +120,17 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
         )
         self.assertContains(response, c.title)
 
+    def test_campaign_unicode_slug(self):
+        """Confirm that Unicode characters are usable in Campaign URLs"""
+
+        campaign = create_campaign(title="你好 World")
+
+        self.assertEqual(campaign.slug, "你好-world")
+
+        response = self.client.get(campaign.get_absolute_url())
+
+        self.assertEqual(response.status_code, 200)
+
     def test_concordiaCampaignView_get_page2(self):
         """
         Test GET on route /campaigns/<slug-value>/ (campaign) on page 2
@@ -209,6 +220,17 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
         self.assertEqual(20, response.context["submitted_percent"])
         self.assertEqual(10, response.context["completed_percent"])
 
+    def test_asset_unicode_slug(self):
+        """Confirm that Unicode characters are usable in Asset URLs"""
+
+        asset = create_asset(title="你好 World")
+
+        self.assertEqual(asset.slug, "你好-world")
+
+        response = self.client.get(asset.get_absolute_url())
+
+        self.assertEqual(response.status_code, 200)
+
     def test_asset_detail_view(self):
         """
         This unit test test the GET route /campaigns/<campaign>/asset/<Asset_name>/
@@ -254,6 +276,17 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
         self.assertTemplateUsed(
             response, template_name="transcriptions/project_detail.html"
         )
+
+    def test_project_unicode_slug(self):
+        """Confirm that Unicode characters are usable in Project URLs"""
+
+        project = create_project(title="你好 World")
+
+        self.assertEqual(project.slug, "你好-world")
+
+        response = self.client.get(project.get_absolute_url())
+
+        self.assertEqual(response.status_code, 200)
 
     def test_campaign_report(self):
         """

--- a/concordia/tests/utils.py
+++ b/concordia/tests/utils.py
@@ -1,7 +1,7 @@
 import json
 from functools import wraps
 
-from django.template.defaultfilters import slugify
+from django.utils.text import slugify
 
 from concordia.models import Campaign, MediaType
 
@@ -12,7 +12,7 @@ def ensure_slug(original_function):
         title = kwargs.get("title")
         slug = kwargs.get("slug")
         if title and slug is None:
-            kwargs["slug"] = slugify(title)
+            kwargs["slug"] = slugify(title, allow_unicode=True)
 
         return original_function(*args, **kwargs)
 

--- a/concordia/urls.py
+++ b/concordia/urls.py
@@ -3,67 +3,70 @@ from django.conf.urls import url
 from django.contrib import admin
 from django.http import Http404, HttpResponseForbidden
 from django.urls import include, path
+from django.urls.converters import register_converter
 from django.views.defaults import page_not_found, permission_denied, server_error
 from django.views.generic import RedirectView
 
 from exporter import views as exporter_views
 
-from . import views
+from . import converters, views
+
+register_converter(converters.UnicodeSlugConverter, "uslug")
 
 tx_urlpatterns = (
     [
         path("", views.CampaignListView.as_view(), name="campaign-list"),
         path(
-            "<slug:slug>/", views.CampaignDetailView.as_view(), name="campaign-detail"
+            "<uslug:slug>/", views.CampaignDetailView.as_view(), name="campaign-detail"
         ),
         path(
-            "<slug:campaign_slug>/export/csv/",
+            "<uslug:campaign_slug>/export/csv/",
             exporter_views.ExportCampaignToCSV.as_view(),
             name="campaign-export-csv",
         ),
         path(
-            "<slug:campaign_slug>/export/bagit/",
+            "<uslug:campaign_slug>/export/bagit/",
             exporter_views.ExportCampaignToBagit.as_view(),
             name="campaign-export-bagit",
         ),
         path(
-            "<slug:campaign_slug>/<slug:project_slug>/export/bagit/",
+            "<uslug:campaign_slug>/<uslug:project_slug>/export/bagit/",
             exporter_views.ExportProjectToBagIt.as_view(),
             name="project-export-bagit",
         ),
         path(
-            "<slug:campaign_slug>/<slug:project_slug>/<slug:item_id>/export/bagit/",
+            "<uslug:campaign_slug>/<uslug:project_slug>/<slug:item_id>/export/bagit/",
             exporter_views.ExportItemToBagIt.as_view(),
             name="item-export-bagit",
         ),
         path(
-            "<slug:campaign_slug>/report/",
+            "<uslug:campaign_slug>/report/",
             views.ReportCampaignView.as_view(),
             name="campaign-report",
         ),
         path(
-            "<slug:campaign_slug>/<slug:project_slug>/<slug:item_id>/<slug:slug>/",
+            "<uslug:campaign_slug>/<uslug:project_slug>/<slug:item_id>/<uslug:slug>/",
             views.AssetDetailView.as_view(),
             name="asset-detail",
         ),
         # n.b. this must be above project-detail to avoid being seen as a project slug:
         path(
-            "<slug:campaign_slug>/next-transcribable-asset/",
+            "<uslug:campaign_slug>/next-transcribable-asset/",
             views.redirect_to_next_transcribable_asset,
             name="redirect-to-next-transcribable-asset",
         ),
         path(
-            "<slug:campaign_slug>/next-reviewable-asset/",
+            "<uslug:campaign_slug>/next-reviewable-asset/",
             views.redirect_to_next_reviewable_asset,
             name="redirect-to-next-reviewable-asset",
         ),
         path(
-            "<slug:campaign_slug>/<slug:slug>/",
+            "<uslug:campaign_slug>/<uslug:slug>/",
             views.ProjectDetailView.as_view(),
             name="project-detail",
         ),
         path(
-            "<slug:campaign_slug>/<slug:project_slug>/<slug:item_id>/",
+            "<uslug:campaign_slug>/<uslug:project_slug>/<slug:item_id>/",
             views.ItemDetailView.as_view(),
             name="item-detail",
         ),

--- a/importer/tasks.py
+++ b/importer/tasks.py
@@ -12,7 +12,7 @@ from urllib.parse import parse_qsl, urlencode, urljoin, urlparse, urlsplit, urlu
 import requests
 from celery import group, task
 from django.db.transaction import atomic
-from django.template.defaultfilters import slugify
+from django.utils.text import slugify
 from django.utils.timezone import now
 from requests.exceptions import HTTPError
 
@@ -329,7 +329,7 @@ def import_item(self, import_item):
         item_asset = Asset(
             item=import_item.item,
             title=asset_title,
-            slug=slugify(asset_title),
+            slug=slugify(asset_title, allow_unicode=True),
             sequence=idx,
             media_url=f"{idx}.jpg",
             media_type=MediaType.IMAGE,


### PR DESCRIPTION
This sets allow_unicode=True on all slug creation/validation calls. It still needs to work around the lack of a Unicode-compatible URL path converter (https://docs.djangoproject.com/en/2.1/_modules/django/urls/converters/) which breaks URL routing.

Closes #214 