### PR TITLE
Improved user profile contribution history

### DIFF
--- a/concordia/templates/account/profile.html
+++ b/concordia/templates/account/profile.html
@@ -66,26 +66,28 @@
                         </tr>
                     </thead>
 
-                    {% for campaign, project, item, asset in object_list %}
-                        {% ifchanged campaign.title project.title %}
-                            <tr>
-                                <th colspan="5">
-                                    <h3>
-                                        <a href="{{ campaign.get_absolute_url }}">{{ campaign.title }}</a>:
-                                        <a href="{{ project.get_absolute_url }}">{{ project.title }}</a>
-                                    </h3>
-                                </th>
-                            </tr>
-                        {% endifchanged %}
+                    <tbody>
+                        {% for campaign, project, item, asset in object_list %}
+                            {% ifchanged campaign.title project.title %}
+                                <tr>
+                                    <th colspan="5">
+                                        <h3>
+                                            <a href="{{ campaign.get_absolute_url }}">{{ campaign.title }}</a>:
+                                            <a href="{{ project.get_absolute_url }}">{{ project.title }}</a>
+                                        </h3>
+                                    </th>
+                                </tr>
+                            {% endifchanged %}
 
-                        <tr>
-                            <td><abbr title="{{ asset.last_interaction_time|date:'SHORT_DATE_FORMAT' }}">{{ asset.last_interaction_time|naturaltime }}</abbr></td>
-                            <td>{{ asset.last_interaction_type.title }}</td>
-                            <td><a href="{{ item.get_absolute_url }}">{{ item.title }}</a></td>
-                            <td class="text-right"><a href="{{ asset.get_absolute_url }}">{{ asset.sequence }}</a></td>
-                            <td>{{ asset.get_transcription_status_display }}</td>
-                        </tr>
-                    {% endfor %}
+                            <tr>
+                                <td><abbr title="{{ asset.last_interaction_time|date:'SHORT_DATE_FORMAT' }}">{{ asset.last_interaction_time|naturaltime }}</abbr></td>
+                                <td>{{ asset.last_interaction_type.title }}</td>
+                                <td><a href="{{ item.get_absolute_url }}">{{ item.title }}</a></td>
+                                <td class="text-right"><a href="{{ asset.get_absolute_url }}">{{ asset.sequence }}</a></td>
+                                <td>{{ asset.get_transcription_status_display }}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
                 </table>
             </div>
         </div>

--- a/concordia/templates/account/profile.html
+++ b/concordia/templates/account/profile.html
@@ -9,14 +9,15 @@
 {% block main_content %}
 <div class="container bg-main">
     <div class="row justify-content-center">
-        <div class="col-12 col-md-8">
-            <form class="form-horizontal" action="{% url 'user-profile' %}" method="POST" enctype="multipart/form-data">
+        <div class="col-12 col-md-10">
+            <h2>Account Information</h2>
+            <form class="form col-md-8" action="{% url 'user-profile' %}" method="POST" enctype="multipart/form-data">
                 {% csrf_token %}
 
                 {% comment %} We want to list the username but it's not an editable field {% endcomment %}
 
-                <div class="form-group">
-                    <label>Username</label>
+                <div class="form-group ">
+                    <label><b>Username</b></label>
                     <input type="text" readonly class="form-control-plaintext" value="{{ user.username }}">
                     <small class="form-text text-muted">
                         Member since {{ user.date_joined|date:"SHORT_DATE_FORMAT" }}
@@ -34,7 +35,7 @@
         </div>
     </div>
     <div class="row justify-content-center">
-        <div class="col-6 mx-auto">
+        <div class="col-8">
             <hr>
         </div>
     </div>
@@ -44,17 +45,17 @@
         </div>
     </div>
     <div class="row justify-content-center">
-        <div class="col-6 mx-auto">
+        <div class="col-8">
             <hr>
         </div>
     </div>
 
     {% if contributions %}
         <div class="row justify-content-center">
-            <div class="col-12 col-md-8">
+            <div class="col-12 col-md-10">
                 <h2>My Contributions</h2>
 
-                <table class="table table-striped">
+                <table class="table table-striped table-responsive-sm">
                     <thead>
                         <tr>
                             <th>Most Recent Contribution</th>

--- a/concordia/templates/account/profile.html
+++ b/concordia/templates/account/profile.html
@@ -8,8 +8,8 @@
 
 {% block main_content %}
 <div class="container bg-main">
-    <div class="row">
-        <div class="col-12 col-md-10 bg-offwhite mx-auto mt-3 pxy-3 rounded">
+    <div class="row justify-content-center">
+        <div class="col-12 col-md-8">
             <form class="form-horizontal" action="{% url 'user-profile' %}" method="POST" enctype="multipart/form-data">
                 {% csrf_token %}
 
@@ -33,49 +33,56 @@
             </form>
         </div>
     </div>
-    <div class="col-10 my-3 mx-auto">
-        <hr>
+    <div class="row justify-content-center">
+        <div class="col-6 mx-auto">
+            <hr>
+        </div>
     </div>
     <div class="row justify-content-center">
         <div class="btn-row">
             <a class="btn btn-secondary" href="{% url 'password_change' %}">Change Password</a>
         </div>
     </div>
-    <div class="col-10 my-3 mx-auto">
-        <hr>
+    <div class="row justify-content-center">
+        <div class="col-6 mx-auto">
+            <hr>
+        </div>
     </div>
-    {% if transcriptions %}
-        <div class="col-12 col-md-10 bg-offwhite mx-auto pxy-3 mb-3 rounded">
-            <h2 class="mb-3">My Contributions</h2>
-            <table class="table mb-3">
-                <thead class="bg-lightest-gray">
-                    <tr>
-                        <th>Campaign</th>
-                        <th>Project</th>
-                        <th>Item</th>
-                        <th>Asset Name</th>
-                        <th>Current Status</th>
-                        <th>Date</th>
-                    </tr>
-                </thead>
 
-                {% for t in transcriptions %}
-                    {% with asset=t.asset item=t.asset.item project=t.asset.item.project campaign=t.asset.item.project.campaign %}
+    {% if contributions %}
+        <div class="row justify-content-center">
+            <div class="col-12 col-md-8">
+                <h2>My Contributions</h2>
+
+                <table class="table table-striped">
+                    <thead>
                         <tr>
-                            <td>{{ campaign.title }}</td>
-                            <td>{{ project.title }}</td>
-                            <td>{{ item.title }}</td>
-                            <td>
-                                <a class="primary-text" href="{% url 'transcriptions:asset-detail' campaign.slug project.slug item.item_id asset.slug %}">
-                                    {{ asset.title }}
-                                </a>
-                            </td>
-                            <td>{{ t.status }}</td>
-                            <td>{{ t.updated_on|date:'SHORT_DATE_FORMAT' }}</td>
+                            <th>Most Recent Contribution</th>
+                            <th>Item</th>
+                            <th>Current Status</th>
                         </tr>
-                    {% endwith %}
-                {% endfor %}
-            </table>
+                    </thead>
+
+                    {% for campaign, project, item in contributions %}
+                        {% ifchanged campaign.title project.title %}
+                            <tr>
+                                <th colspan="3">
+                                    <h3>
+                                        <a href="{{ campaign.get_absolute_url }}">{{ campaign.title }}</a>:
+                                        <a href="{{ project.get_absolute_url }}">{{ project.title }}</a>
+                                    </h3>
+                                </th>
+                            </tr>
+                        {% endifchanged %}
+
+                        <tr>
+                            <td>{{ item.last_user_contribution|date:'SHORT_DATE_FORMAT' }}</td>
+                            <td><a href="{{ item.get_absolute_url }}">{{ item.title }}</a></td>
+                            <td class="text-right">{{ item.percentage_completed }}%</td>
+                        </tr>
+                    {% endfor %}
+                </table>
+            </div>
         </div>
     {% endif %}
 </div>

--- a/concordia/templates/account/profile.html
+++ b/concordia/templates/account/profile.html
@@ -55,6 +55,25 @@
             <div class="col-12 col-md-10">
                 <h2>My Contributions</h2>
 
+                <table class="table table-striped table-sm table-responsive-sm">
+                    <thead>
+                        <tr>
+                            <th>Campaign</th>
+                            <th><abbr title="Total number of times you saved, submitted, or reviewed a transcription">Actions</abbr></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for campaign in contributed_campaigns %}
+                            <tr>
+                                <th>
+                                    <a href="{{ campaign.get_absolute_url }}">{{ campaign.title }}</a>
+                                </th>
+                                <td class="text-right">{{ campaign.action_count|intcomma }}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+
                 <table class="table table-striped table-responsive-sm">
                     <thead>
                         <tr class="text-center">

--- a/concordia/templates/account/profile.html
+++ b/concordia/templates/account/profile.html
@@ -89,12 +89,10 @@
                         {% endfor %}
                     </tbody>
                 </table>
+
+                <div>{% include "fragments/standard-pagination.html" %}</div>
             </div>
         </div>
     {% endif %}
-
-    <div class="row">
-        {% include "fragments/standard-pagination.html" %}
-    </div>
 </div>
 {% endblock main_content %}

--- a/concordia/templates/account/profile.html
+++ b/concordia/templates/account/profile.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% load staticfiles %}
-
+{% load humanize %}
 {% load bootstrap4 %}
 
 {% block title %}User Profile{% endblock title %}
@@ -50,24 +50,26 @@
         </div>
     </div>
 
-    {% if contributions %}
+    {% if object_list %}
         <div class="row justify-content-center">
             <div class="col-12 col-md-10">
                 <h2>My Contributions</h2>
 
                 <table class="table table-striped table-responsive-sm">
                     <thead>
-                        <tr>
-                            <th>Most Recent Contribution</th>
+                        <tr class="text-center">
+                            <th>Time</th>
+                            <th>Action</th>
                             <th>Item</th>
+                            <th>Page</th>
                             <th>Current Status</th>
                         </tr>
                     </thead>
 
-                    {% for campaign, project, item in contributions %}
+                    {% for campaign, project, item, asset in object_list %}
                         {% ifchanged campaign.title project.title %}
                             <tr>
-                                <th colspan="3">
+                                <th colspan="5">
                                     <h3>
                                         <a href="{{ campaign.get_absolute_url }}">{{ campaign.title }}</a>:
                                         <a href="{{ project.get_absolute_url }}">{{ project.title }}</a>
@@ -77,15 +79,20 @@
                         {% endifchanged %}
 
                         <tr>
-                            <td>{{ item.last_user_contribution|date:'SHORT_DATE_FORMAT' }}</td>
+                            <td><abbr title="{{ asset.last_interaction_time|date:'SHORT_DATE_FORMAT' }}">{{ asset.last_interaction_time|naturaltime }}</abbr></td>
+                            <td>{{ asset.last_interaction_type.title }}</td>
                             <td><a href="{{ item.get_absolute_url }}">{{ item.title }}</a></td>
-                            <td class="text-right">{{ item.percentage_completed }}%</td>
+                            <td class="text-right"><a href="{{ asset.get_absolute_url }}">{{ asset.sequence }}</a></td>
+                            <td>{{ asset.get_transcription_status_display }}</td>
                         </tr>
                     {% endfor %}
                 </table>
             </div>
         </div>
     {% endif %}
+
+    <div class="row">
+        {% include "fragments/standard-pagination.html" %}
+    </div>
 </div>
 {% endblock main_content %}
-

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -283,6 +283,10 @@ class AccountProfileView(LoginRequiredMixin, FormView, ListView):
     ordering = ("-updated_on",)
     paginate_by = 12
 
+    def post(self, *args, **kwargs):
+        self.object_list = self.get_queryset()
+        return super().post(*args, **kwargs)
+
     def get_queryset(self):
         transcriptions = Transcription.objects.filter(
             Q(user=self.request.user) | Q(reviewed_by=self.request.user)

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -321,6 +321,19 @@ class AccountProfileView(LoginRequiredMixin, FormView, ListView):
                 (asset.item.project.campaign, asset.item.project, asset.item, asset)
             )
 
+        user = self.request.user
+        ctx["contributed_campaigns"] = (
+            Campaign.objects.annotate(
+                action_count=Count(
+                    "project__item__asset__transcription",
+                    filter=Q(project__item__asset__transcription__user=user)
+                    | Q(project__item__asset__transcription__reviewed_by=user),
+                )
+            )
+            .exclude(action_count=0)
+            .order_by("title")
+        )
+
         return ctx
 
     def get_initial(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [pycodestyle]
 exclude = .venv,docs/conf.py
-ignore = 
+ignore =
 max-line-length = 88
 
 [tool:pytest]
@@ -13,6 +13,8 @@ known_first_party = concordia,importer,exporter
 default_section = THIRDPARTY
 not_skip = __init__.py
 skip = .venv
+use_parentheses = True
+multi_line_output = 3
 
 [flake8]
 exclude = .venv


### PR DESCRIPTION
This makes the contribution section of the profile page work more like how people believed it was working all along. Now it takes the transcription and review activities which the user has participated in and displays the user’s last action and the asset’s current status.

![screenshot_2018-11-30 crowd user profile 1](https://user-images.githubusercontent.com/46565/49305053-23f2f280-f49c-11e8-9edf-1ca6ab6d7730.png)

Closes #532 
Closes #676