### PR TITLE
Update transcription review control display

### DIFF
--- a/concordia/static/js/contribute.js
+++ b/concordia/static/js/contribute.js
@@ -301,11 +301,15 @@ function submitReview(status) {
         }
     })
         .done(function() {
-            $('#successful-review-modal')
-                .modal()
-                .on('hidden.bs.modal', function() {
-                    window.location.reload(true);
-                });
+            if (status == 'reject') {
+                window.location.reload(true);
+            } else {
+                $('#review-accepted-modal')
+                    .modal()
+                    .on('hidden.bs.modal', function() {
+                        window.location.reload(true);
+                    });
+            }
         })
         .fail(function(jqXHR, textStatus, errorThrown) {
             displayMessage(

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -172,9 +172,20 @@
 
                                 <button id="save-transcription-button" disabled type="submit" class="btn btn-primary" title="Save the text you entered above">Save</button>
                                 <button id="submit-transcription-button" disabled type="button" class="btn btn-primary" title="Request another volunteer to review the text you entered above">Submit for Review</button>
-                            {% elif transcription_status == 'submitted' and user.is_authenticated and transcription.user.pk != user.pk %}
-                                <button id="reject-transcription-button" disabled type="button" class="btn btn-primary" title="Correct errors you see in the text">Edit</button>
-                                <button id="accept-transcription-button" disabled type="button" class="btn btn-primary" title="Confirm that the text is accurately transcribed">Accept</button>
+                            {% elif transcription_status == 'submitted' %}
+                                {% if not user.is_authenticated %}
+                                    <p class="help-text">
+                                        <a href="{% url 'registration_register' %}">Register</a>
+                                            or
+                                        <a href="{% url 'login' %}?next={{ request.path|urlencode }}">login</a>
+                                        to help review
+                                    </p>
+                                {% elif transcription.user.pk == user.pk %}
+                                    <p class="help-text">You submitted this transcription for review by another user.</p>
+                                {% else %}
+                                    <button id="reject-transcription-button" disabled type="button" class="btn btn-primary" title="Correct errors you see in the text">Edit</button>
+                                    <button id="accept-transcription-button" disabled type="button" class="btn btn-primary" title="Confirm that the text is accurately transcribed">Accept</button>
+                                {% endif %}
                             {% endif %}
                         </div>
                     {% endspaceless %}

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -376,7 +376,7 @@
             </div>
         </div>
     </div>
-    <div id="successful-review-modal" class="modal" tabindex="-1" role="dialog">
+    <div id="review-accepted-modal" class="modal" tabindex="-1" role="dialog">
         <div class="modal-dialog modal-dialog-centered" role="document">
             <div class="modal-content">
                 <div class="modal-header">


### PR DESCRIPTION
Some followup from #688:

This changes the previous logic where the review buttons were only
display when you were eligible to review with nothing otherwise to the
following:

* Anonymous users get the login / register prompt
* Logged-in users who are seeing a transcription which they submitted
see “You submitted this transcription for review by another user.”
* Logged-in users who are seeing a transcription which they can submit
get the review buttons

Anonymous:
![screenshot_2018-12-06 crowd mal0221200-1 letters to lincoln 1860 elected first republican president and south carolina sec 1](https://user-images.githubusercontent.com/46565/49599681-97d74400-f94f-11e8-85fa-8739ef68966d.png)

Logged-in, self-review:

![screenshot_2018-12-06 crowd mal0221200-1 letters to lincoln 1860 elected first republican president and south carolina sec](https://user-images.githubusercontent.com/46565/49599700-a45b9c80-f94f-11e8-81e7-dee559a09407.png)

Logged-in (unchanged, but for completeness):

![image](https://user-images.githubusercontent.com/46565/49599767-c3f2c500-f94f-11e8-8e22-5cea39dad53a.png)
