### PR TITLE
Customize username help text on registration form

### DIFF
--- a/concordia/forms.py
+++ b/concordia/forms.py
@@ -19,7 +19,7 @@ class UserRegistrationForm(RegistrationForm):
         help_texts = {
             "username": (
                 "Required. 150 characters or fewer. Usernames can contain"
-                " letters, digits and any of these punctuation symbols:"
+                " letters, numbers, and any of these punctuation symbols:"
                 " <kbd>@</kbd>, <kbd>.</kbd>, <kbd>+</kbd>, <kbd>-</kbd>,"
                 " or <kbd>_</kbd>"
             )

--- a/concordia/forms.py
+++ b/concordia/forms.py
@@ -18,8 +18,8 @@ class UserRegistrationForm(RegistrationForm):
     class Meta(RegistrationForm.Meta):
         help_texts = {
             "username": (
-                "Required. 150 characters or fewer. Usernames can contain"
-                " letters, numbers, and any of these punctuation symbols:"
+                "150 characters or fewer. Can only contain letters, numbers,"
+                " and any of these symbols:"
                 " <kbd>@</kbd>, <kbd>.</kbd>, <kbd>+</kbd>, <kbd>-</kbd>,"
                 " or <kbd>_</kbd>"
             )

--- a/concordia/forms.py
+++ b/concordia/forms.py
@@ -15,6 +15,16 @@ class UserRegistrationForm(RegistrationForm):
         help_text="Email me about campaign updates, upcoming events, and new features.",
     )
 
+    class Meta(RegistrationForm.Meta):
+        help_texts = {
+            "username": (
+                "Required. 150 characters or fewer. Usernames can contain"
+                " letters, digits and any of these punctuation symbols:"
+                " <kbd>@</kbd>, <kbd>.</kbd>, <kbd>+</kbd>, <kbd>-</kbd>,"
+                " or <kbd>_</kbd>"
+            )
+        }
+
 
 class UserProfileForm(forms.Form):
     email = forms.CharField(

--- a/concordia/forms.py
+++ b/concordia/forms.py
@@ -18,10 +18,10 @@ class UserRegistrationForm(RegistrationForm):
     class Meta(RegistrationForm.Meta):
         help_texts = {
             "username": (
-                "150 characters or fewer. Can only contain letters, numbers,"
-                " and any of these symbols:"
+                "Can only contain letters, numbers, and any of these symbols:"
                 " <kbd>@</kbd>, <kbd>.</kbd>, <kbd>+</kbd>, <kbd>-</kbd>,"
-                " or <kbd>_</kbd>"
+                " or <kbd>_</kbd>."
+                " 150 characters or fewer."
             )
         }
 


### PR DESCRIPTION
This makes the list of allowed punctuation easier to parse — see
https://github.com/LibraryOfCongress/concordia/issues/507#issuecomment-443840209 for the motivation.

Using the default Bootstrap styles for `<kbd>` here's what this looks like: 

![image](https://user-images.githubusercontent.com/46565/49671677-a0ef1080-fa36-11e8-9a74-e33e8a91be2d.png)
