### PR TITLE
Fix asset transcription status calculation for rejections

### DIFF
--- a/concordia/signals/handlers.py
+++ b/concordia/signals/handlers.py
@@ -23,7 +23,9 @@ def add_user_to_newsletter(sender, user, request, **kwargs):
 def update_asset_status(sender, *, instance, **kwargs):
     new_status = TranscriptionStatus.IN_PROGRESS
 
-    if instance.accepted:
+    if instance.rejected:
+        new_status = TranscriptionStatus.IN_PROGRESS
+    elif instance.accepted:
         new_status = TranscriptionStatus.COMPLETED
     elif instance.submitted:
         new_status = TranscriptionStatus.SUBMITTED


### PR DESCRIPTION
The calculation for the denormalized `Asset.transcription_status` field wasn’t correct for the rejection path so views such as the asset listing would display the status as reviewed but the actual asset detail page would display the correct value.

Closes #705 