### PR TITLE
Update find-next-page ranking logic

### DIFF
--- a/concordia/views.py
+++ b/concordia/views.py
@@ -1167,7 +1167,7 @@ def redirect_to_next_transcribable_asset(request, *, campaign_slug):
         next_asset=Case(
             When(pk__gt=asset_id, then=1), default=0, output_field=IntegerField()
         ),
-    ).order_by("-unstarted", "-next_asset", "-same_item", "-same_project", "sequence")
+    ).order_by("-next_asset", "-unstarted", "-same_project", "-same_item", "sequence")
 
     asset = potential_assets.first()
     if asset:


### PR DESCRIPTION
This changes the rules slightly but was mostly intended to add test coverage for  the selection rules for the find-next-page feature: favoring an asset which is ahead of the current one, unstarted, in the same item, or in the same project, in that order.

The ranking changes are relative weights: staying within the same item counts more than just same project and moving forward counts more than finding an unstarted item so it will try to move you to a different page even if you happen to be on the only remaining unstarted page.