### PR TITLE
Update homepage carousel control design

### DIFF
--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -674,6 +674,22 @@ ul.nav-secondary {
     max-width: 360px;
 }
 
+.view-homepage .carousel-control-next-icon {
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23fff' viewBox='0 0 8 8'%3E%3Cpath stroke='%23333333' stroke-width='.25' d='M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z'/%3E%3C/svg%3E");
+}
+
+.view-homepage .carousel-control-next:hover .carousel-control-next-icon {
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23fc4c02' viewBox='0 0 8 8'%3E%3Cpath stroke='%23ffffff' stroke-width='.25' d='M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z'/%3E%3C/svg%3E");
+}
+
+.carousel-control-prev-icon {
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23fff' viewBox='0 0 8 8'%3E%3Cpath stroke='%23333333' stroke-width='.25' d='M5.25 0l-4 4 4 4 1.5-1.5-2.5-2.5 2.5-2.5-1.5-1.5z'/%3E%3C/svg%3E");
+}
+
+.view-homepage .carousel-control-prev:hover .carousel-control-prev-icon {
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23fc4c02' viewBox='0 0 8 8'%3E%3Cpath stroke='%23ffffff' stroke-width='.25' d='M5.25 0l-4 4 4 4 1.5-1.5-2.5-2.5 2.5-2.5-1.5-1.5z'/%3E%3C/svg%3E");
+}
+
 @media screen and (max-width: 575px) {
     .view-homepage h1 {
         font-size: 2rem;


### PR DESCRIPTION
This builds on #680 to improve contrast with the black/white-heavy backgrounds by adding a border and colored hover state.

Screenshots:

![screenshot_2018-12-11 crowd home](https://user-images.githubusercontent.com/46565/49818609-2f1e0c00-fd41-11e8-819c-4895360ebf04.jpg)
![screen shot 2018-12-11 at 12 34 06](https://user-images.githubusercontent.com/46565/49818614-3218fc80-fd41-11e8-900d-c104c5558e6e.png)
![screen shot 2018-12-11 at 12 34 27](https://user-images.githubusercontent.com/46565/49818620-3513ed00-fd41-11e8-8fee-88876a87e2c7.png)
![screen shot 2018-12-11 at 12 34 15](https://user-images.githubusercontent.com/46565/49818624-37764700-fd41-11e8-82c4-5717442d47ac.png)
