### PR TITLE
Homepage: remove stale CSS color for browse all campaigns

### DIFF
--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -654,10 +654,6 @@ ul.nav-secondary {
     display: block;
 }
 
-#homepage-campaign-list a {
-    color: inherit;
-}
-
 #homepage-campaign-list .campaign {
     width: 380px;
 }


### PR DESCRIPTION
This rule became obsolete at some point during the rebuild. Beyond
matching the default usage elsewhere, it improves the color contrast
ratio in the accessibility report.

Before and after:
![screen shot 2018-12-11 at 14 33 58](https://user-images.githubusercontent.com/46565/49825410-5a5d2700-fd52-11e8-92c9-ae1f517840a7.png)
![screen shot 2018-12-11 at 14 34 42](https://user-images.githubusercontent.com/46565/49825411-5af5bd80-fd52-11e8-8658-eb052a8b831d.png)
