### PR TITLE
Homepage: remove colons from overlay titles

### DIFF
--- a/concordia/templates/home.html
+++ b/concordia/templates/home.html
@@ -17,13 +17,13 @@
                     <li data-target="#homepage-carousel" data-slide-to="2"></li>
                 </ol>
                 <div class="carousel-inner">
-                    <div class="carousel-item active" data-title="By the People:" data-hero-text="Volunteer to uncover our shared history and make documents more searchable for everyone." data-link-url="{% url 'transcriptions:redirect-to-next-transcribable-asset' 'letters-to-lincoln' %}">
+                    <div class="carousel-item active" data-title="By the People" data-hero-text="Volunteer to uncover our shared history and make documents more searchable for everyone." data-link-url="{% url 'transcriptions:redirect-to-next-transcribable-asset' 'letters-to-lincoln' %}">
                         <img class="d-block w-100" src="{% static 'img/homepage-carousel/crowd-home.jpg' %}" alt="a crowd of girls waving handkerchiefs and smiling; possibly cheering">
                     </div>
-                    <div class="carousel-item" data-overlay-position="top-right" data-title="Letters to Lincoln:" data-hero-text="Help us transcribe and review Letters to Lincoln: husband, father, postmaster, lawyer, politician, President." data-link-url="{% url 'transcriptions:redirect-to-next-transcribable-asset' 'letters-to-lincoln' %}">
+                    <div class="carousel-item" data-overlay-position="top-right" data-title="Letters to Lincoln" data-hero-text="Help us transcribe and review Letters to Lincoln: husband, father, postmaster, lawyer, politician, President." data-link-url="{% url 'transcriptions:redirect-to-next-transcribable-asset' 'letters-to-lincoln' %}">
                         <img class="d-block w-100" src="{% static 'img/homepage-carousel/letters-to-lincoln.jpg' %}" alt="Image of letters sent to Abraham Lincoln">
                     </div>
-                    <div class="carousel-item" data-title="Welcome Center:" data-hero-text="Learn how to transcribe, review, and tag." data-link-url="{% url 'welcome-guide' %}">
+                    <div class="carousel-item" data-title="Welcome Center" data-hero-text="Learn how to transcribe, review, and tag." data-link-url="{% url 'welcome-guide' %}">
                         <img class="d-block w-100" src="{% static 'img/homepage-carousel/welcome-guide.jpg' %}" alt="">
                     </div>
                 </div>
@@ -36,7 +36,7 @@
                     <span class="sr-only">Next</span>
                 </a>
                 <div class="carousel-overlay text-center d-flex flex-column justify-content-around align-items-center">
-                    <h1 class="title">By the People:</h1>
+                    <h1 class="title">By the People</h1>
                     <p class="hero-text mx-auto">Volunteer to uncover our shared history and make documents more searchable for everyone.</p>
                     <a class="btn btn-primary btn-lg" href="{% url "transcriptions:redirect-to-next-transcribable-asset" 'letters-to-lincoln' %}">LET'S GO!</a>
                 </div>


### PR DESCRIPTION
These have been there for awhile but when we were discussing #680 it became apparently that nobody on the team is a fan so:

![screen shot 2018-12-11 at 14 57 08](https://user-images.githubusercontent.com/46565/49826593-44049a80-fd55-11e8-9c36-718641590f31.png)
![screen shot 2018-12-11 at 14 57 12](https://user-images.githubusercontent.com/46565/49826594-44049a80-fd55-11e8-9cbb-aee495344c60.png)
![screen shot 2018-12-11 at 14 57 17](https://user-images.githubusercontent.com/46565/49826595-44049a80-fd55-11e8-8ae4-6bf691185ffa.png)

