### PR TITLE
Scale homepage carousel controls down for mobile

### DIFF
--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -719,6 +719,23 @@ ul.nav-secondary {
     .homepage-activity p {
         font-size: 85%;
     }
+
+    .view-homepage .carousel-control-next,
+    .view-homepage .carousel-control-prev {
+        /*
+            the background images are all 1200x480 sized with width: 100% so
+            we'll set our height to maintain that aspect ratio so the arrows
+            will be centered on the image rather than the total carousel height
+            which includes the overlay
+        */
+        height: calc(100vw / (1200 / 480));
+    }
+
+    .view-homepage .carousel-control-next-icon,
+    .view-homepage .carousel-control-prev-icon {
+        height: 36.5px;
+        width: 22px;
+    }
 }
 
 @media screen and (min-width: 720px) {

--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -625,10 +625,6 @@ ul.nav-secondary {
     line-height: 125%;
 }
 
-.view-homepage .carousel-overlay h1 {
-    text-transform: uppercase;
-}
-
 .view-homepage .carousel-indicators li {
     width: 12px;
     height: 12px;

--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -730,6 +730,7 @@ ul.nav-secondary {
     .view-homepage .carousel-control-prev-icon {
         height: 36.5px;
         width: 22px;
+        filter: invert(1);
     }
 
     .view-homepage .carousel-overlay .title {

--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -719,18 +719,21 @@ ul.nav-secondary {
     .view-homepage .carousel-control-next,
     .view-homepage .carousel-control-prev {
         /*
-            the background images are all 1200x480 sized with width: 100% so
-            we'll set our height to maintain that aspect ratio so the arrows
-            will be centered on the image rather than the total carousel height
-            which includes the overlay
+            the background images are all 1200x480 sized with width:100% so
+            we'll set our height to match that aspect ratio plus the control icon height and a bit of padding
         */
-        height: calc(100vw / (1200 / 480));
+        height: calc((100vw / (1200 / 480)) + 36px + 8px);
+        align-items: flex-end;
     }
 
     .view-homepage .carousel-control-next-icon,
     .view-homepage .carousel-control-prev-icon {
         height: 36.5px;
         width: 22px;
+    }
+
+    .view-homepage .carousel-overlay .title {
+        max-width: 70%;
     }
 }
 

--- a/concordia/templates/home.html
+++ b/concordia/templates/home.html
@@ -11,7 +11,7 @@
     <div class="row no-gutters px-sm-3">
         <div class="col-12">
             <div id="homepage-carousel" class="carousel slide" data-ride="carousel" data-pause="hover">
-                <ol class="carousel-indicators d-none d-md-flex">
+                <ol class="carousel-indicators d-none d-lg-flex">
                     <li data-target="#homepage-carousel" data-slide-to="0" class="active"></li>
                     <li data-target="#homepage-carousel" data-slide-to="1"></li>
                     <li data-target="#homepage-carousel" data-slide-to="2"></li>


### PR DESCRIPTION
Two of the titles added in #680 were wide enough that the homepage
carousel controls could overlap the text. This commit changes the sizing
rules for screens below the small breakpoint to keep the arrows centered
over the image rather than the combined image + overlay.

## Before

“By the People” is fine on most devices:
![simulator screen shot - iphone xr - 2018-12-13 at 10 35 30](https://user-images.githubusercontent.com/46565/49951605-58b56f80-fec8-11e8-8857-f4f5c612d8bd.png)

… but “Letters to Lincoln” is not:

![simulator screen shot - iphone xr - 2018-12-13 at 10 35 32](https://user-images.githubusercontent.com/46565/49951612-5ce18d00-fec8-11e8-8fab-112e42677e62.png)

## After

![simulator screen shot - iphone xr - 2018-12-13 at 11 12 16](https://user-images.githubusercontent.com/46565/49951613-5ce18d00-fec8-11e8-80e8-337d4b94ab78.png)
