### PR TITLE
Optimize site report admin display

### DIFF
--- a/concordia/admin/__init__.py
+++ b/concordia/admin/__init__.py
@@ -409,3 +409,10 @@ class SimplePageAdmin(admin.ModelAdmin):
 @admin.register(SiteReport)
 class SiteReportAdmin(admin.ModelAdmin):
     list_display = ("created_on", "campaign")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.readonly_fields = [
+            i.name for i in self.model._meta.fields if i.name != "id"
+        ]

--- a/concordia/admin/__init__.py
+++ b/concordia/admin/__init__.py
@@ -416,3 +416,26 @@ class SiteReportAdmin(admin.ModelAdmin):
         self.readonly_fields = [
             i.name for i in self.model._meta.fields if i.name != "id"
         ]
+
+    def get_fields(self, *args, **kwargs):
+        fields = super().get_fields(*args, **kwargs)
+        fields.sort(key=self.fieldname_sort_key)
+        return fields
+
+    FIELDNAME_SORT_KEYS = [
+        "created",
+        "user",
+        "campaign",
+        "project",
+        "item",
+        "asset",
+        "transcription",
+        "tag",
+    ]
+
+    def fieldname_sort_key(self, key):
+        for i, prefix in enumerate(self.FIELDNAME_SORT_KEYS):
+            if prefix in key:
+                return (i, key)
+        else:
+            return (1024, key)


### PR DESCRIPTION
A couple of minor changes to the `SiteReport` admin change form: it now displays the fields read-only (which saves the repeated controls) and sorts the fields.