### PR TITLE
Admin site report filtered exports

### DIFF
--- a/concordia/admin/__init__.py
+++ b/concordia/admin/__init__.py
@@ -410,17 +410,19 @@ class SimplePageAdmin(admin.ModelAdmin):
 class SiteReportAdmin(admin.ModelAdmin):
     list_display = ("created_on", "campaign")
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    list_filter = ("campaign",)
 
-        self.readonly_fields = [
-            i.name for i in self.model._meta.fields if i.name != "id"
-        ]
+    def export_to_csv(self, request, queryset):
+        return export_to_csv_action(
+            self, request, queryset, field_names=SiteReport.DEFAULT_EXPORT_FIELDNAMES
+        )
 
-    def get_fields(self, *args, **kwargs):
-        fields = super().get_fields(*args, **kwargs)
-        fields.sort(key=self.fieldname_sort_key)
-        return fields
+    def export_to_excel(self, request, queryset):
+        return export_to_excel_action(
+            self, request, queryset, field_names=SiteReport.DEFAULT_EXPORT_FIELDNAMES
+        )
+
+    actions = (export_to_csv, export_to_excel)
 
     FIELDNAME_SORT_KEYS = [
         "created",

--- a/concordia/admin/views.py
+++ b/concordia/admin/views.py
@@ -167,29 +167,7 @@ def admin_site_report_view(request):
 
     headers, data = flatten_queryset(
         site_reports,
-        field_names=[
-            "created_on",
-            "campaign__title",
-            "assets_total",
-            "assets_published",
-            "assets_not_started",
-            "assets_in_progress",
-            "assets_waiting_review",
-            "assets_completed",
-            "assets_unpublished",
-            "items_published",
-            "items_unpublished",
-            "projects_published",
-            "projects_unpublished",
-            "anonymous_transcriptions",
-            "transcriptions_saved",
-            "distinct_tags",
-            "tag_uses",
-            "campaigns_published",
-            "campaigns_unpublished",
-            "users_registered",
-            "users_activated",
-        ],
+        field_names=SiteReport.DEFAULT_EXPORT_FIELDNAMES,
         extra_verbose_names={"created_on": "Date", "campaign__title": "Campaign"},
     )
 

--- a/concordia/models.py
+++ b/concordia/models.py
@@ -353,3 +353,6 @@ class SiteReport(models.Model):
     campaigns_unpublished = models.IntegerField(blank=True, null=True)
     users_registered = models.IntegerField(blank=True, null=True)
     users_activated = models.IntegerField(blank=True, null=True)
+
+    class Meta:
+        ordering = ("created_on",)

--- a/concordia/models.py
+++ b/concordia/models.py
@@ -356,3 +356,29 @@ class SiteReport(models.Model):
 
     class Meta:
         ordering = ("created_on",)
+
+    # We have several places where these are exported as CSV/Excel. By default
+    # the ORM will be told to retrieve these fields & lookups:
+    DEFAULT_EXPORT_FIELDNAMES = [
+        "created_on",
+        "campaign__title",
+        "assets_total",
+        "assets_published",
+        "assets_not_started",
+        "assets_in_progress",
+        "assets_waiting_review",
+        "assets_completed",
+        "assets_unpublished",
+        "items_published",
+        "items_unpublished",
+        "projects_published",
+        "projects_unpublished",
+        "anonymous_transcriptions",
+        "transcriptions_saved",
+        "distinct_tags",
+        "tag_uses",
+        "campaigns_published",
+        "campaigns_unpublished",
+        "users_registered",
+        "users_activated",
+    ]


### PR DESCRIPTION
This enables list filtering and exporting for the site reports in the admin as an alternative to filtering in Excel (see #720).

![screenshot 2018-12-14 13 23 05](https://user-images.githubusercontent.com/46565/50020635-95569900-ffa4-11e8-8418-d922cdf0e595.png)
