### PR TITLE
Improve the AJAX message displayed to rate-limited users

### DIFF
--- a/concordia/static/js/asset-reservation.js
+++ b/concordia/static/js/asset-reservation.js
@@ -7,7 +7,8 @@ function attemptToReserveAsset(reservationURL) {
     jQuery
         .ajax({
             url: reservationURL,
-            type: 'POST'
+            type: 'POST',
+            dataType: 'json'
         })
         .done(function() {
             $transcriptionEditor

--- a/concordia/static/js/base.js
+++ b/concordia/static/js/base.js
@@ -161,31 +161,36 @@ if (screenfull.enabled) {
         });
 }
 
-$.ajax({url: '/account/ajax-status/', method: 'GET', cache: true}).done(
-    function(data) {
-        if (!data.username) {
-            return;
-        }
+$.ajax({
+    url: '/account/ajax-status/',
+    method: 'GET',
+    dataType: 'json',
+    cache: true
+}).done(function(data) {
+    if (!data.username) {
+        return;
+    }
 
-        $('.anonymous-only').remove();
-        $('.authenticated-only').removeAttr('hidden');
-        if (data.links) {
-            var $accountMenu = $('#topnav-account-dropdown .dropdown-menu');
-            data.links.forEach(function(i) {
-                $('<a>')
-                    .addClass('dropdown-item')
-                    .attr('href', i.url)
-                    .text(i.title)
-                    .prependTo($accountMenu);
+    $('.anonymous-only').remove();
+    $('.authenticated-only').removeAttr('hidden');
+    if (data.links) {
+        var $accountMenu = $('#topnav-account-dropdown .dropdown-menu');
+        data.links.forEach(function(i) {
+            $('<a>')
+                .addClass('dropdown-item')
+                .attr('href', i.url)
+                .text(i.title)
+                .prependTo($accountMenu);
+        });
+    }
+});
+
+$.ajax({url: '/account/ajax-messages/', method: 'GET', dataType: 'json'}).done(
+    function(data) {
+        if (data.messages) {
+            data.messages.forEach(function(message) {
+                displayMessage(message.level, message.message);
             });
         }
     }
 );
-
-$.ajax({url: '/account/ajax-messages/', method: 'GET'}).done(function(data) {
-    if (data.messages) {
-        data.messages.forEach(function(message) {
-            displayMessage(message.level, message.message);
-        });
-    }
-});

--- a/concordia/static/js/contribute.js
+++ b/concordia/static/js/contribute.js
@@ -51,6 +51,7 @@ var $captchaForm = $captchaModal.find('form').on('submit', function(evt) {
     $.ajax({
         url: $captchaForm.attr('action'),
         method: 'POST',
+        dataType: 'json',
         data: $.param(formData)
     })
         .done(function() {
@@ -95,6 +96,7 @@ $('form.ajax-submission').each(function(idx, formElement) {
         $.ajax({
             url: $form.attr('action'),
             method: 'POST',
+            dataType: 'json',
             data: $.param(formData)
         })
             .done(function(data, textStatus) {
@@ -257,7 +259,8 @@ $submitButton.on('click', function(evt) {
 
     $.ajax({
         url: $transcriptionEditor.data('submitUrl'),
-        method: 'POST'
+        method: 'POST',
+        dataType: 'json'
     })
         .done(function() {
             $('.tx-status-display')
@@ -296,6 +299,7 @@ function submitReview(status) {
     $.ajax({
         url: reviewUrl,
         method: 'POST',
+        dataType: 'json',
         data: {
             action: status
         }

--- a/concordia/templates/429.html
+++ b/concordia/templates/429.html
@@ -25,13 +25,13 @@
 </head>
 <body class="d-flex justify-content-center align-items-center text-center">
     <div id="error-message">
-        <h1>HTTP 429 Error</h1>
+        <h1>HTTP 429: Too Many Requests</h1>
 
         <p>
             {% if exception %}
                 {{ exception }}
-            {% else %} 
-                Please wait a bit, then try again.
+            {% else %}
+                {{ error|default:'Please wait a bit, then try again.' }}
             {% endif %}
 
         </p>

--- a/concordia/utils.py
+++ b/concordia/utils.py
@@ -15,6 +15,6 @@ def get_anonymous_user():
 
 
 def request_accepts_json(request):
-    accept_header = request.META["HTTP_ACCEPT"]
+    accept_header = request.META.get("HTTP_ACCEPT", "*/*")
 
     return "application/json" in accept_header

--- a/concordia/utils.py
+++ b/concordia/utils.py
@@ -12,3 +12,9 @@ def get_anonymous_user():
         return User.objects.get(username="anonymous")
     except User.DoesNotExist:
         return User.objects.create_user(username="anonymous")
+
+
+def request_accepts_json(request):
+    accept_header = request.META["HTTP_ACCEPT"]
+
+    return "application/json" in accept_header


### PR DESCRIPTION
This improves the experience which @colefemeno reported when mixing activity as logged-in and anonymous users:

* Let Django provide the default reason phrase
* The same context is used to generate the HTML and JSON responses for consistent messaging
* The JSON format is selected when the request  is XHR or when the `Accept` header contains
  `application/json`
* jQuery.ajax() calls now explicitly request JSON responses so the `Accept` header will have `application/json` rather than just `*/*`
