### PR TITLE
Apply published filters to campaign progress bars on list view

### DIFF
--- a/concordia/views.py
+++ b/concordia/views.py
@@ -445,7 +445,12 @@ class CampaignDetailView(DetailView):
             .annotate(
                 **{
                     f"{key}_count": Count(
-                        "item__asset", filter=Q(item__asset__transcription_status=key)
+                        "item__asset",
+                        filter=Q(
+                            item__published=True,
+                            item__asset__published=True,
+                            item__asset__transcription_status=key,
+                        ),
                     )
                     for key in TranscriptionStatus.CHOICE_MAP.keys()
                 }


### PR DESCRIPTION
This ensures that the progress bars displayed on the campaign detail page apply the item and asset published check as well:

## Before

![screenshot_2019-01-02 crowd letters to lincoln 1](https://user-images.githubusercontent.com/46565/50612751-24bae200-0ea9-11e9-8e72-c6a4a5c251fe.png)

## After

![screenshot_2019-01-02 crowd letters to lincoln](https://user-images.githubusercontent.com/46565/50612755-2ab0c300-0ea9-11e9-8f2a-121dc5f5a70e.png)


Closes #738 
