### PR TITLE
ARIA updates

### DIFF
--- a/concordia/templates/base.html
+++ b/concordia/templates/base.html
@@ -90,16 +90,18 @@
             </nav>
         </header>
     {% endblock site-header %}
+
+    {% block breadcrumbs-container %}
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb bg-offwhite my-0">
+                <li class="breadcrumb-item"><a class="primary-text" href="/">Home</a></li>
+                {% block breadcrumbs %}{% endblock breadcrumbs %}
+            </ol>
+        </nav>
+    {% endblock breadcrumbs-container %}
+
     {% block site-main %}
         <main class="{% block extra_main_classes %}{% endblock %} d-print-block">
-            {% block breadcrumbs-container %}
-                <nav aria-label="breadcrumb">
-                    <ol class="breadcrumb bg-offwhite my-0">
-                        <li class="breadcrumb-item"><a class="primary-text" href="/">Home</a></li>
-                        {% block breadcrumbs %}{% endblock breadcrumbs %}
-                    </ol>
-                </nav>
-            {% endblock breadcrumbs-container %}
 
             {% block messages-container %}
                 <div id="messages" class="row" hidden>

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -457,23 +457,29 @@
             </div>
         </div>
     </div>
-    <div id="captcha-modal" class="modal" tabindex="-1" role="dialog">
+    <div id="captcha-modal" class="modal" tabindex="-1" role="alertdialog" aria-labeledby="captcha-modal-title" aria-describedby="captcha-modal-description">
         <form action="{% url 'ajax-captcha' %}" class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Please confirm you are not a robot</h5>
+                    <h5 id="captcha-modal-title" class="modal-title">Please confirm you are not a robot</h5>
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>
                 </div>
                 <div class="modal-body">
                     <div class="form-row">
-                        <div class="help-text">
+                        <div id="captcha-modal-description" class="help-text">
+                            <p class="sr-only">
+                                To prevent abuse non-logged in users are
+                                required to solve a captcha periodically. An
+                                audio alternative is under development. You may
+                                also avoid this challenge by
+                                <a href="{% url 'login' %}?next={{ request.path|urlencode }}" rel="nofollow">logging in</a>.
+                            </p>
                             Before continuing please enter the letters in the image
                             below so we know you are a human:
                         </div>
                         <img id="captcha-image" class="d-block my-3 mx-auto border rounded">
-
                     </div>
                     <div class="form-row">
                         <input name="response" class="form-control" autocomplete="off">

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -458,7 +458,7 @@
         </div>
     </div>
     <div id="captcha-modal" class="modal" tabindex="-1" role="dialog">
-        <form action="{% url 'ajax-captcha' %}" class="modal-dialog modal-dialog-centered" role="document">
+        <form action="{% url 'ajax-captcha' %}" class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Please confirm you are not a robot</h5>


### PR DESCRIPTION
This pull request makes several changes which improved navigation in Safari using VoiceOver. This might be a good chance to test the feature-branch deployment option, too, since that would allow real-world testing using tools such as JAWS.

## Summary of changes

* Pagination adds the `aria-current=page` attribute for the current page number element.
* Pagination sets `aria-hidden=true` on the disabled elements used to visually represent the range of omitted pages between the displayed page window and the first/last page links.
* The login form set `aria-role=dialog` on the form itself but the [HTML spec only allows a couple of roles for `form` elements](https://w3c.github.io/html/sec-forms.html#the-form-element) so that has been hoisted to the container.