### PR TITLE
Simplify running Docker with DEBUG=true

### DIFF
--- a/concordia/settings_docker.py
+++ b/concordia/settings_docker.py
@@ -13,6 +13,7 @@ LOGGING["handlers"]["celery"]["filename"] = "./logs/concordia-celery.log"
 LOGGING["loggers"]["django"]["level"] = "INFO"
 LOGGING["loggers"]["celery"]["level"] = "INFO"
 
+DEBUG = os.getenv("DEBUG", "").lower() == "true"
 
 DJANGO_SECRET_KEY = os.getenv("DJANGO_SECRET_KEY", get_random_secret_key())
 

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -88,7 +88,11 @@ def default_cache_control(view_function):
 
 @never_cache
 def healthz(request):
-    status = {"current_time": time.time(), "load_average": os.getloadavg()}
+    status = {
+        "current_time": time.time(),
+        "load_average": os.getloadavg(),
+        "debug": settings.DEBUG,
+    }
 
     # We don't want to query a large table but we do want to hit the database
     # at last once:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
             CONCORDIA_ENVIRONMENT: development
             S3_BUCKET_NAME: crowd-dev-content
             DJANGO_SETTINGS_MODULE: concordia.settings_docker
+            DEBUG: ${DEBUG:-}
         depends_on:
             - db
         volumes:
@@ -79,5 +80,5 @@ services:
             - db
 
 volumes:
-    ? db_volume
-    ? images_volume
+    db_volume:
+    images_volume:

--- a/docs/for-developers.md
+++ b/docs/for-developers.md
@@ -17,6 +17,15 @@ $ docker-compose up
 
 Browse to [localhost](http://localhost)
 
+If you're intending to edit static resources, templates, etc. and would like to
+enable Django's DEBUG mode ensure that your environment has `DEBUG=true` set
+before you run `docker-compose up` for the `app` container. The easiest way to
+do this permanently is to add it to the `.env` file:
+
+```bash
+$ echo DEBUG=true >> .env
+```
+
 ### Local Development Environment
 
 You will likely want to run the Django development server on your localhost


### PR DESCRIPTION
This changes `settings_docker` to set the `DEBUG` setting based on the environment and `docker-compose` will now pass that value through.