### PR TITLE
Campaign UI updates

### DIFF
--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -357,17 +357,6 @@ ul.nav-secondary {
     opacity: 0.3 !important;
 }
 
-.btn-primary-alternative {
-    background-color: var(--primary-color);
-    border-color: var(--primary-color);
-    color: var(--text-color-offwhite);
-}
-.btn-primary-alternative:hover {
-    background-color: var(--primary-color-hover);
-    border-color: var(--primary-color-hover);
-    color: var(--text-color-offwhite);
-}
-
 .btn-secondary {
     background-color: var(--secondary-color);
     border-color: var(--secondary-color);

--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -1,317 +1,319 @@
 :root {
-  --primary-color: #f05129;
-  --primary-color-hover: rgba(188, 57, 1, 1); /* #BC3901 */
-  --secondary-color: rgba(0, 167, 228, 1); /* #00A7E4 */
-  --secondary-color-hover: rgba(0, 35, 71, 1); /* #002347 */
-  --color-success: rgba(22, 201, 74, 1); /* #16C94A */
-  --color-danger: rgba(254, 12, 11, 1); /* #FE0C0B */
-  --color-warning: rgba(254, 153, 11, 1); /* #FE990B */
-  --color-info: rgba(2, 252, 216, 1); /* #02FCD8 */
-  --text-color-primary: rgba(38, 50, 56, 1); /* #263238 */
-  --text-color-offwhite: rgba(250, 250, 250, 1); /* #FAFAFA */
-  --text-nav-current: #f05129;
+    --primary-color: #f05129;
+    --primary-color-hover: rgba(188, 57, 1, 1); /* #BC3901 */
+    --secondary-color: rgba(0, 167, 228, 1); /* #00A7E4 */
+    --secondary-color-hover: rgba(0, 35, 71, 1); /* #002347 */
+    --color-success: rgba(22, 201, 74, 1); /* #16C94A */
+    --color-danger: rgba(254, 12, 11, 1); /* #FE0C0B */
+    --color-warning: rgba(254, 153, 11, 1); /* #FE990B */
+    --color-info: rgba(2, 252, 216, 1); /* #02FCD8 */
+    --text-color-primary: rgba(38, 50, 56, 1); /* #263238 */
+    --text-color-offwhite: rgba(250, 250, 250, 1); /* #FAFAFA */
+    --text-nav-current: #f05129;
 
-  --bg-offwhite: rgba(250, 250, 250, 1); /* #FAFAFA */
-  --bg-lightest-gray: rgba(245, 245, 245, 1); /* #F5F5F5 */
-  --bg-darkest-gray: rgba(51, 51, 51, 1); /* #333333 */
-  --bg-offblack: rgba(38, 50, 56, 1); /* #263238 */
-  --bg-dark-gray: rgba(102, 102, 102, 1); /* #666666 */
-  --bg-medium-gray: rgba(153, 153, 153, 1); /* #999999 */
-  --bg-footer: rgba(238, 238, 238, 1); /* #EEEEEE */
-  --bg-divider: rgba(189, 189, 189, 1); /* #BDBDBD */
-  --bg-card-title: rgba(51, 51, 51, 0.7); /* #333333 */
-  --bg-loading: rgba(51, 51, 51, 0.5); /* #333333 */
-  --bg-completed: #00618e;
-  --bg-submitted: #2e91bf;
-  --bg-in_progress: #80cef3;
-  --bg-not_started: #e9ecef;
+    --bg-offwhite: rgba(250, 250, 250, 1); /* #FAFAFA */
+    --bg-lightest-gray: rgba(245, 245, 245, 1); /* #F5F5F5 */
+    --bg-darkest-gray: rgba(51, 51, 51, 1); /* #333333 */
+    --bg-offblack: rgba(38, 50, 56, 1); /* #263238 */
+    --bg-dark-gray: rgba(102, 102, 102, 1); /* #666666 */
+    --bg-medium-gray: rgba(153, 153, 153, 1); /* #999999 */
+    --bg-footer: rgba(238, 238, 238, 1); /* #EEEEEE */
+    --bg-divider: rgba(189, 189, 189, 1); /* #BDBDBD */
+    --bg-card-title: rgba(51, 51, 51, 0.7); /* #333333 */
+    --bg-loading: rgba(51, 51, 51, 0.5); /* #333333 */
+    --bg-completed: #00618e;
+    --bg-submitted: #2e91bf;
+    --bg-in_progress: #80cef3;
+    --bg-not_started: #e9ecef;
 
-  --shadow-color: rgba(51, 51, 51, 0.8); /* #333333 */
-  --light-shadow-color: rgba(51, 51, 51, 0.4); /* #333333 */
-  --footer-links-color: #00618e;
+    --shadow-color: rgba(51, 51, 51, 0.8); /* #333333 */
+    --light-shadow-color: rgba(51, 51, 51, 0.4); /* #333333 */
+    --footer-links-color: #00618e;
 
-  /* Colors used to build complex interface widgets */
-  --control-bg-light: #efefef;
-  --control-bg-default: #d8d8d8;
-  --control-label-color: #333333;
+    /* Colors used to build complex interface widgets */
+    --control-bg-light: #efefef;
+    --control-bg-default: #d8d8d8;
+    --control-label-color: #333333;
 
-  --height-top-nav: 113px; /* Height of logo image plus padding */
-  --height-footer: 149px;
-  --height-main: calc(100vh - (var(--height-top-nav) + var(--height-footer)));
+    --height-top-nav: 113px; /* Height of logo image plus padding */
+    --height-footer: 149px;
+    --height-main: calc(100vh - (var(--height-top-nav) + var(--height-footer)));
 
-  /* Making room for instructions button on bottom and breadcrumb and nav on top */
-  --height-contribute-image: calc(100vh - (8.0625rem + 1.59375rem + 2.375rem));
+    /* Making room for instructions button on bottom and breadcrumb and nav on top */
+    --height-contribute-image: calc(
+        100vh - (8.0625rem + 1.59375rem + 2.375rem)
+    );
 
-  /* Subtract height of navbar, breadcrumbs, and nav pills */
-  --height-contribute-input: calc(50vh - 5.96875rem);
-  --height-tags-input: calc(50vh - 2.625rem);
-  --top-tags-input: calc(50vh - 0.75rem);
+    /* Subtract height of navbar, breadcrumbs, and nav pills */
+    --height-contribute-input: calc(50vh - 5.96875rem);
+    --height-tags-input: calc(50vh - 2.625rem);
+    --top-tags-input: calc(50vh - 0.75rem);
 }
 
 body {
-  color: var(--text-color-primary);
-  border-top: 0.25rem solid var(--primary-color);
-  background-color: var(--bg-offwhite);
+    color: var(--text-color-primary);
+    border-top: 0.25rem solid var(--primary-color);
+    background-color: var(--bg-offwhite);
 }
 
 main {
-  min-height: var(--height-main);
+    min-height: var(--height-main);
 }
 
 h1,
 .h1 {
-  font-family: "Roboto Slab", serif;
-  font-weight: bold;
-  color: var(--text-color-primary);
+    font-family: 'Roboto Slab', serif;
+    font-weight: bold;
+    color: var(--text-color-primary);
 }
 
 h1.header-text {
-  font-family: "Open Sans", sans-serif;
-  font-size: 2.5rem;
-  font-weight: normal;
-  color: black;
-  text-transform: uppercase;
+    font-family: 'Open Sans', sans-serif;
+    font-size: 2.5rem;
+    font-weight: normal;
+    color: black;
+    text-transform: uppercase;
 }
 
 .header-text .beta-label {
-  font-size: x-small;
-  color: var(--primary-color);
+    font-size: x-small;
+    color: var(--primary-color);
 }
 
 h2 {
-  font-size: 1.5rem;
-  line-height: 125%;
-  font-weight: bold;
-  color: var(--text-color-primary);
+    font-size: 1.5rem;
+    line-height: 125%;
+    font-weight: bold;
+    color: var(--text-color-primary);
 }
 
 h2.offwhite {
-  color: var(--text-color-offwhite);
+    color: var(--text-color-offwhite);
 }
 
 h2 small {
-  color: var(--text-color-primary);
+    color: var(--text-color-primary);
 }
 
 h3 {
-  font-size: 1.25rem;
-  line-height: 125%;
-  font-weight: bold;
-  color: var(--text-color-primary);
+    font-size: 1.25rem;
+    line-height: 125%;
+    font-weight: bold;
+    color: var(--text-color-primary);
 }
 
 h4 {
-  font-family: "Open Sans", sans-serif;
-  font-size: 1.125rem;
-  line-height: 125%;
-  font-weight: bold;
-  color: var(--text-color-primary);
+    font-family: 'Open Sans', sans-serif;
+    font-size: 1.125rem;
+    line-height: 125%;
+    font-weight: bold;
+    color: var(--text-color-primary);
 }
 
 h5 {
-  font-family: "Open Sans", sans-serif;
-  font-size: 1rem;
-  line-height: 125%;
-  font-weight: bold;
-  font-weight: normal;
+    font-family: 'Open Sans', sans-serif;
+    font-size: 1rem;
+    line-height: 125%;
+    font-weight: bold;
+    font-weight: normal;
 }
 
 h6 {
-  font-family: "Open Sans", sans-serif;
-  font-size: 0.875rem;
-  line-height: 125%;
-  font-weight: bold;
-  color: var(--text-color-primary);
+    font-family: 'Open Sans', sans-serif;
+    font-size: 0.875rem;
+    line-height: 125%;
+    font-weight: bold;
+    color: var(--text-color-primary);
 }
 
 .offwhite-text {
-  color: var(--text-color-offwhite);
+    color: var(--text-color-offwhite);
 }
 
 .primary-text {
-  color: var(--primary-color);
+    color: var(--primary-color);
 }
 
 .secondary-text {
-  color: var(--secondary-color);
+    color: var(--secondary-color);
 }
 
 .gray-text {
-  color: var(--text-color-primary);
+    color: var(--text-color-primary);
 }
 
 a:hover {
-  color: var(--text-color-primary);
+    color: var(--text-color-primary);
 }
 
 a.primary-text {
-  color: var(--primary-color);
-  text-decoration: none;
+    color: var(--primary-color);
+    text-decoration: none;
 }
 
 a.primary-text:hover {
-  color: var(--primary-color-hover);
-  text-decoration: underline;
+    color: var(--primary-color-hover);
+    text-decoration: underline;
 }
 
 a.secondary-text {
-  color: var(--secondary-color);
-  text-decoration: none;
+    color: var(--secondary-color);
+    text-decoration: none;
 }
 
 a.secondary-text:hover {
-  color: var(--secondary-color-hover);
-  text-decoration: underline;
+    color: var(--secondary-color-hover);
+    text-decoration: underline;
 }
 
 a.offwhite-text {
-  color: var(--text-color-offwhite);
-  text-decoration: none;
+    color: var(--text-color-offwhite);
+    text-decoration: none;
 }
 
 a.offwhite-text:hover {
-  color: var(--primary-color);
-  text-decoration: underline;
+    color: var(--primary-color);
+    text-decoration: underline;
 }
 
 a.gray-text {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 a.gray-text:hover {
-  color: var(--primary-color);
-  text-decoration: none;
+    color: var(--primary-color);
+    text-decoration: none;
 }
 
 a.nav-secondary {
-  font-family: "Open Sans", sans-serif;
-  font-weight: normal;
-  font-size: 0.875rem;
-  color: var(--text-color-primary);
+    font-family: 'Open Sans', sans-serif;
+    font-weight: normal;
+    font-size: 0.875rem;
+    color: var(--text-color-primary);
 }
 
 a.nav-secondary:hover {
-  opacity: 70%;
-  text-decoration: none;
+    opacity: 70%;
+    text-decoration: none;
 }
 
 a .campaign-title:hover,
 .hero-text a:hover {
-  color: var(--text-color-primary);
-  text-decoration: underline;
+    color: var(--text-color-primary);
+    text-decoration: underline;
 }
 
 ul.nav-secondary li:first-of-type {
-  border-right: solid 0.0675rem var(--bg-darkest-gray);
+    border-right: solid 0.0675rem var(--bg-darkest-gray);
 }
 
 p.hero-secondary {
-  font-family: "Open Sans", sans-serif;
-  font-size: 1.125rem;
-  color: var(--text-color-primary);
+    font-family: 'Open Sans', sans-serif;
+    font-size: 1.125rem;
+    color: var(--text-color-primary);
 }
 
 p.hero-secondary.offwhite-text {
-  font-family: "Open Sans", sans-serif;
-  font-size: 1.125rem;
-  color: var(--text-color-offwhite);
+    font-family: 'Open Sans', sans-serif;
+    font-size: 1.125rem;
+    color: var(--text-color-offwhite);
 }
 
 .bg-offwhite {
-  background-color: var(--bg-offwhite);
+    background-color: var(--bg-offwhite);
 }
 
 .bg-lightest-gray {
-  background-color: var(--bg-lightest-gray);
+    background-color: var(--bg-lightest-gray);
 }
 
 .bg-medium-gray {
-  background-color: var(--bg-medium-gray);
+    background-color: var(--bg-medium-gray);
 }
 
 .bg-darkest-gray {
-  background-color: var(--bg-darkest-gray);
+    background-color: var(--bg-darkest-gray);
 }
 
 .bg-dark-gray {
-  background-color: var(--bg-darkest-gray);
+    background-color: var(--bg-darkest-gray);
 }
 
 .bg-footer {
-  background-color: var(--bg-footer);
+    background-color: var(--bg-footer);
 }
 
 .bg-card-title {
-  background-color: var(--bg-card-title);
+    background-color: var(--bg-card-title);
 }
 
 .bg-home-contribute {
-  /* For browsers that do not support gradients */
-  background-color: var(--bg-darkest-gray);
+    /* For browsers that do not support gradients */
+    background-color: var(--bg-darkest-gray);
 
-  background-image: linear-gradient(
-      rgba(250, 250, 250, 0.25),
-      rgba(38, 50, 56, 0.25)
-    ),
-    linear-gradient(rgba(51, 51, 51, 1), rgba(51, 51, 51, 1));
+    background-image: linear-gradient(
+            rgba(250, 250, 250, 0.25),
+            rgba(38, 50, 56, 0.25)
+        ),
+        linear-gradient(rgba(51, 51, 51, 1), rgba(51, 51, 51, 1));
 }
 
 .bg-img-placeholder {
-  background-color: var(--bg-divider);
+    background-color: var(--bg-divider);
 }
 
 .bg-img-placeholder:hover {
-  background-image: linear-gradient(
-      rgba(252, 76, 2, 0.5),
-      rgba(252, 76, 2, 0.1)
-    ),
-    linear-gradient(rgba(189, 189, 189, 1), rgba(189, 189, 189, 1));
+    background-image: linear-gradient(
+            rgba(252, 76, 2, 0.5),
+            rgba(252, 76, 2, 0.1)
+        ),
+        linear-gradient(rgba(189, 189, 189, 1), rgba(189, 189, 189, 1));
 }
 
 .bg-primary-color {
-  background-color: var(--primary-color);
+    background-color: var(--primary-color);
 }
 
 .bg-completed {
-  background-color: var(--bg-completed);
+    background-color: var(--bg-completed);
 }
 
 .bg-submitted {
-  background-color: var(--bg-submitted);
+    background-color: var(--bg-submitted);
 }
 
 .bg-in_progress {
-  background-color: var(--bg-in_progress);
+    background-color: var(--bg-in_progress);
 }
 
 .bg-not_started {
-  background-color: var(--bg-not_started);
+    background-color: var(--bg-not_started);
 }
 
 input {
-  color: var(--text-color-primary);
-  background-color: var(--bg-offwhite);
+    color: var(--text-color-primary);
+    background-color: var(--bg-offwhite);
 }
 
 hr {
-  color: var(--bg-dark-gray);
+    color: var(--bg-dark-gray);
 }
 
 .navbar-brand {
-  padding-top: 0;
-  padding-bottom: 0;
-  margin-right: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    margin-right: 0;
 }
 
 .navbar-brand img {
-  width: 10.625rem;
-  height: auto;
+    width: 10.625rem;
+    height: auto;
 }
 
 ul.nav-secondary {
-  position: absolute;
-  right: 1.5rem;
-  top: 1.5rem;
+    position: absolute;
+    right: 1.5rem;
+    top: 1.5rem;
 }
 
 /*
@@ -319,181 +321,181 @@ ul.nav-secondary {
 */
 
 .navbar-brand .vl {
-  height: 6rem;
-  background-color: var(--bg-dark-gray);
-  width: 0.0675rem;
+    height: 6rem;
+    background-color: var(--bg-dark-gray);
+    width: 0.0675rem;
 }
 
 .border-login-register {
-  border-left: solid 0.0675 var(--bg-darkest-gray);
+    border-left: solid 0.0675 var(--bg-darkest-gray);
 }
 
 .border-left-home-contribute {
-  border-left: solid 0.0675rem var(--bg-offwhite);
+    border-left: solid 0.0675rem var(--bg-offwhite);
 }
 
 .navbar-offwhite .navbar-nav .active > .nav-link,
 .navbar-offwhite .navbar-nav .nav-link.active,
 .navbar-offwhite .navbar-nav .nav-link.show,
 .navbar-offwhite .navbar-nav .show > .nav-link {
-  color: var(--text-nav-current);
+    color: var(--text-nav-current);
 }
 
 .navbar-offwhite .navbar-nav .nav-link {
-  font-family: "Open Sans", sans-serif;
-  font-weight: bold;
-  color: var(--text-color-primary);
+    font-family: 'Open Sans', sans-serif;
+    font-weight: bold;
+    color: var(--text-color-primary);
 }
 
 #topnav-account-dropdown .dropdown-menu {
-  /* Our custom styling conflicts with the Bootstrap defaults */
-  top: 2.8rem;
-  left: -5rem;
+    /* Our custom styling conflicts with the Bootstrap defaults */
+    top: 2.8rem;
+    left: -5rem;
 }
 
 .btn.disabled,
 .btn:disabled {
-  opacity: 0.3 !important;
+    opacity: 0.3 !important;
 }
 
 .btn-secondary {
-  background-color: var(--secondary-color);
-  border-color: var(--secondary-color);
-  color: var(--text-color-offwhite);
+    background-color: var(--secondary-color);
+    border-color: var(--secondary-color);
+    color: var(--text-color-offwhite);
 }
 
 .btn-secondary:hover {
-  background-color: var(--secondary-color-hover);
-  border-color: var(--secondary-color-hover);
-  color: var(--text-color-offwhite);
+    background-color: var(--secondary-color-hover);
+    border-color: var(--secondary-color-hover);
+    color: var(--text-color-offwhite);
 }
 
 .btn-outline-secondary {
-  border-color: var(--secondary-color);
-  color: var(--secondary-color);
+    border-color: var(--secondary-color);
+    color: var(--secondary-color);
 }
 
 .btn-outline-secondary:hover {
-  border-color: var(--secondary-color-hover);
-  background-color: transparent;
-  color: var(--secondary-color-hover);
+    border-color: var(--secondary-color-hover);
+    background-color: transparent;
+    color: var(--secondary-color-hover);
 }
 
 .btn-minimal-secondary {
-  background-color: transparent;
-  border-color: transparent;
-  color: var(--secondary-color);
+    background-color: transparent;
+    border-color: transparent;
+    color: var(--secondary-color);
 }
 
 .btn-minimal-secondary:hover {
-  background-color: var(--secondary-color);
-  border-color: transparent;
-  color: var(--text-color-offwhite);
+    background-color: var(--secondary-color);
+    border-color: transparent;
+    color: var(--text-color-offwhite);
 }
 
 .btn-secondary.disabled,
 .btn-secondary:disabled {
-  background-color: var(--secondary-color) !important;
-  border-color: var(--secondary-color) !important;
-  color: var(--text-color-offwhite) !important;
+    background-color: var(--secondary-color) !important;
+    border-color: var(--secondary-color) !important;
+    color: var(--text-color-offwhite) !important;
 }
 
 .btn-default {
-  background-color: rgba(158, 158, 158, 1);
-  border-color: rgba(158, 158, 158, 1);
-  color: var(--text-color-primary);
+    background-color: rgba(158, 158, 158, 1);
+    border-color: rgba(158, 158, 158, 1);
+    color: var(--text-color-primary);
 }
 
 .btn-default.disabled,
 .btn-default:disabled {
-  background-color: rgba(158, 158, 158, 1) !important;
-  border-color: rgba(158, 158, 158, 1) !important;
-  color: var(--text-color-primary) !important;
+    background-color: rgba(158, 158, 158, 1) !important;
+    border-color: rgba(158, 158, 158, 1) !important;
+    color: var(--text-color-primary) !important;
 }
 
 .btn-default:hover {
-  background-color: var(--bg-darkest-gray);
-  border-color: var(--bg-darkest-gray);
-  color: var(--text-color-offwhite);
+    background-color: var(--bg-darkest-gray);
+    border-color: var(--bg-darkest-gray);
+    color: var(--text-color-offwhite);
 }
 
 .btn-outline-default {
-  border-color: var(--bg-medium-gray);
-  color: var(--bg-medium-gray);
+    border-color: var(--bg-medium-gray);
+    color: var(--bg-medium-gray);
 }
 
 .btn-outline-default:hover {
-  border-color: var(--bg-darkest-gray);
-  background-color: transparent;
-  color: var(--bg-darkest-gray);
+    border-color: var(--bg-darkest-gray);
+    background-color: transparent;
+    color: var(--bg-darkest-gray);
 }
 
 .btn-row .btn {
-  width: 9.875rem !important;
+    width: 9.875rem !important;
 }
 
 .btn-dark {
-  background-color: var(--bg-offblack);
-  border-color: var(--bg-offblack);
-  color: var(--text-color-offwhite);
+    background-color: var(--bg-offblack);
+    border-color: var(--bg-offblack);
+    color: var(--text-color-offwhite);
 }
 
 .btn-dark.disabled,
 .btn-dark:disabled {
-  background-color: var(--bg-darkest-gray) !important;
-  border-color: var(--bg-darkest-gray) !important;
-  color: var(--text-color-offwhite) !important;
+    background-color: var(--bg-darkest-gray) !important;
+    border-color: var(--bg-darkest-gray) !important;
+    color: var(--text-color-offwhite) !important;
 }
 
 /* Forms */
 
 .form-group-required label {
-  font-weight: bold;
+    font-weight: bold;
 }
 
 /* Cards */
 
 .card-body {
-  padding: 1rem 0.5rem;
+    padding: 1rem 0.5rem;
 }
 
 .card-img-campaign {
-  object-position: center top;
-  object-fit: cover;
-  height: 13.25rem;
+    object-position: center top;
+    object-fit: cover;
+    height: 13.25rem;
 }
 
 .card-img-overlay {
-  left: 0;
-  right: 0;
-  bottom: 0;
-  margin-bottom: 3.0675rem;
-  padding: 0.5rem 1.25rem;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    margin-bottom: 3.0675rem;
+    padding: 0.5rem 1.25rem;
 }
 
 .card-img-overlay.img-campaign {
-  padding: 0;
+    padding: 0;
 }
 
 .card-title {
-  margin-bottom: 0.5rem;
+    margin-bottom: 0.5rem;
 }
 
 .img-project {
-  min-height: 13.125rem;
+    min-height: 13.125rem;
 }
 
 .round-corners-bottom {
-  border-radius: 0 0 0.5rem 0.5rem;
+    border-radius: 0 0 0.5rem 0.5rem;
 }
 
 .img-fluid.rounded-circle {
-  max-height: 15rem;
-  width: auto;
+    max-height: 15rem;
+    width: auto;
 }
 
 .shadow-regular {
-  box-shadow: 0 0 0.25rem var(--shadow-color);
+    box-shadow: 0 0 0.25rem var(--shadow-color);
 }
 
 /*
@@ -501,18 +503,18 @@ ul.nav-secondary {
  */
 
 .breadcrumb {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  justify-content: start;
-  align-items: start;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: start;
+    align-items: start;
 }
 
 .breadcrumb-item {
-  max-width: 20em;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
+    max-width: 20em;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }
 
 /*
@@ -520,75 +522,75 @@ ul.nav-secondary {
  */
 
 .card-deck .card.concordia-object-card {
-  position: relative;
-  flex-grow: 0;
-  flex-basis: 200px;
+    position: relative;
+    flex-grow: 0;
+    flex-basis: 200px;
 
-  width: 200px;
-  min-height: 300px;
+    width: 200px;
+    min-height: 300px;
 
-  margin: 0.25rem;
+    margin: 0.25rem;
 
-  justify-content: start;
-  align-items: center;
+    justify-content: start;
+    align-items: center;
 
-  background-color: var(--bg-lightest-gray);
+    background-color: var(--bg-lightest-gray);
 }
 
 .card-deck .card.concordia-object-card > * {
-  /* This is only necessary for IE11 */
-  max-width: 100%;
+    /* This is only necessary for IE11 */
+    max-width: 100%;
 }
 
 @media screen and (max-width: 576px) {
-  .card-deck .card.concordia-object-card {
-    flex-basis: auto;
-  }
+    .card-deck .card.concordia-object-card {
+        flex-basis: auto;
+    }
 }
 
-.concordia-object-card[data-transcription-status="completed"]:not(:hover) {
-  opacity: 0.5;
+.concordia-object-card[data-transcription-status='completed']:not(:hover) {
+    opacity: 0.5;
 }
 
 .concordia-object-card .card-title,
 .concordia-object-card .card-actions {
-  position: absolute;
-  left: 0;
-  right: 0;
+    position: absolute;
+    left: 0;
+    right: 0;
 
-  color: var(--text-color-offwhite);
+    color: var(--text-color-offwhite);
 }
 
 .concordia-object-card .card-title {
-  top: 0;
-  padding: 2px;
+    top: 0;
+    padding: 2px;
 
-  font-weight: bold;
-  color: var(--text-color-offwhite);
-  background-color: var(--light-shadow-color);
+    font-weight: bold;
+    color: var(--text-color-offwhite);
+    background-color: var(--light-shadow-color);
 }
 
 .concordia-object-card .card-title:hover {
-  background-color: var(--shadow-color);
+    background-color: var(--shadow-color);
 }
 
 .concordia-object-card .card-actions {
-  bottom: 0;
+    bottom: 0;
 }
 
 .concordia-object-card .card-actions .btn-default:not(:hover) {
-  background-color: var(--light-shadow-color);
+    background-color: var(--light-shadow-color);
 }
 
 .concordia-object-card .card-img-container {
-  display: block;
-  height: 100%;
-  width: 100%;
+    display: block;
+    height: 100%;
+    width: 100%;
 }
 
 .card.concordia-object-card .progress {
-  height: 1em;
-  border-radius: 0;
+    height: 1em;
+    border-radius: 0;
 }
 
 /*
@@ -596,23 +598,23 @@ ul.nav-secondary {
  */
 
 #progress-bar {
-  height: 2rem;
+    height: 2rem;
 }
 
 #progress-stats {
-  font-size: smaller;
+    font-size: smaller;
 }
 
 #progress-stats th {
-  font-size: inherit;
-  font-weight: inherit;
+    font-size: inherit;
+    font-weight: inherit;
 }
 
 .transcription-status-key {
-  display: inline-block;
-  height: 0.6em;
-  width: 0.6em;
-  vertical-align: baseline;
+    display: inline-block;
+    height: 0.6em;
+    width: 0.6em;
+    vertical-align: baseline;
 }
 
 /*
@@ -620,158 +622,158 @@ ul.nav-secondary {
  */
 
 .view-homepage h1 {
-  font-size: 2rem;
-  line-height: 125%;
+    font-size: 2rem;
+    line-height: 125%;
 }
 
 .view-homepage .carousel-indicators li {
-  width: 12px;
-  height: 12px;
+    width: 12px;
+    height: 12px;
 
-  background: url("data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2212%22%20viewBox%3D%220%200%2012%2012%22%20width%3D%2212%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Ccircle%20cx%3D%226%22%20cy%3D%226%22%20fill%3D%22%23fff%22%20fill-rule%3D%22evenodd%22%20r%3D%225.5%22%20stroke%3D%22%23333%22/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
+    background: url('data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2212%22%20viewBox%3D%220%200%2012%2012%22%20width%3D%2212%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Ccircle%20cx%3D%226%22%20cy%3D%226%22%20fill%3D%22%23fff%22%20fill-rule%3D%22evenodd%22%20r%3D%225.5%22%20stroke%3D%22%23333%22/%3E%3C/svg%3E');
+    background-repeat: no-repeat;
 }
 
 .view-homepage .carousel-indicators .active {
-  background: url("data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2212%22%20viewBox%3D%220%200%2012%2012%22%20width%3D%2212%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Ccircle%20cx%3D%226%22%20cy%3D%226%22%20fill%3D%22%23F05129%22%20fill-rule%3D%22evenodd%22%20r%3D%225.5%22%20stroke%3D%22%23fff%22/%3E%3C/svg%3E");
+    background: url('data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2212%22%20viewBox%3D%220%200%2012%2012%22%20width%3D%2212%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Ccircle%20cx%3D%226%22%20cy%3D%226%22%20fill%3D%22%23F05129%22%20fill-rule%3D%22evenodd%22%20r%3D%225.5%22%20stroke%3D%22%23fff%22/%3E%3C/svg%3E');
 }
 
 .view-homepage .carousel-control-next,
 .view-homepage .carousel-control-prev {
-  opacity: 1;
+    opacity: 1;
 }
 
 .view-homepage .carousel-control-next-icon,
 .view-homepage .carousel-control-prev-icon {
-  height: 55px;
-  width: 33px;
+    height: 55px;
+    width: 33px;
 }
 
 .view-homepage .carousel-control-next-icon {
-  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2255%22%20viewBox%3D%220%200%2033%2055%22%20width%3D%2233%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22m1221.23218%20395.14282c0%20.428572-.21429.910716-.53571%201.232145l-24.96432%2024.964315c-.32143.321429-.80357.535715-1.23214.535715-.42858%200-.91072-.214286-1.23215-.535715l-2.67857-2.678574c-.32143-.321429-.53572-.750001-.53572-1.232145%200-.428572.21429-.910715.53572-1.232144l21.05359-21.053597-21.05359-21.053596c-.32143-.321429-.53572-.803573-.53572-1.232144%200-.428572.21429-.910716.53572-1.232145l2.67857-2.678574c.32143-.321429.80357-.535715%201.23215-.535715.42857%200%20.91071.214286%201.23214.535715l24.96432%2024.964315c.32142.321429.53571.803572.53571%201.232144z%22%20fill%3D%22%23fff%22%20fill-rule%3D%22evenodd%22%20stroke%3D%22%23333%22%20stroke-width%3D%22.5%22%20transform%3D%22translate%28-1189%20-368%29%22/%3E%3C/svg%3E");
+    background-image: url('data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2255%22%20viewBox%3D%220%200%2033%2055%22%20width%3D%2233%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22m1221.23218%20395.14282c0%20.428572-.21429.910716-.53571%201.232145l-24.96432%2024.964315c-.32143.321429-.80357.535715-1.23214.535715-.42858%200-.91072-.214286-1.23215-.535715l-2.67857-2.678574c-.32143-.321429-.53572-.750001-.53572-1.232145%200-.428572.21429-.910715.53572-1.232144l21.05359-21.053597-21.05359-21.053596c-.32143-.321429-.53572-.803573-.53572-1.232144%200-.428572.21429-.910716.53572-1.232145l2.67857-2.678574c.32143-.321429.80357-.535715%201.23215-.535715.42857%200%20.91071.214286%201.23214.535715l24.96432%2024.964315c.32142.321429.53571.803572.53571%201.232144z%22%20fill%3D%22%23fff%22%20fill-rule%3D%22evenodd%22%20stroke%3D%22%23333%22%20stroke-width%3D%22.5%22%20transform%3D%22translate%28-1189%20-368%29%22/%3E%3C/svg%3E');
 }
 
 .view-homepage .carousel-control-next:hover .carousel-control-next-icon {
-  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2255%22%20viewBox%3D%220%200%2033%2055%22%20width%3D%2233%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22m1221.23218%20395.14282c0%20.428572-.21429.910716-.53571%201.232145l-24.96432%2024.964315c-.32143.321429-.80357.535715-1.23214.535715-.42858%200-.91072-.214286-1.23215-.535715l-2.67857-2.678574c-.32143-.321429-.53572-.750001-.53572-1.232145%200-.428572.21429-.910715.53572-1.232144l21.05359-21.053597-21.05359-21.053596c-.32143-.321429-.53572-.803573-.53572-1.232144%200-.428572.21429-.910716.53572-1.232145l2.67857-2.678574c.32143-.321429.80357-.535715%201.23215-.535715.42857%200%20.91071.214286%201.23214.535715l24.96432%2024.964315c.32142.321429.53571.803572.53571%201.232144z%22%20fill%3D%22%23F05129%22%20fill-rule%3D%22evenodd%22%20stroke%3D%22%23fff%22%20stroke-width%3D%22.5%22%20transform%3D%22translate%28-1189%20-368%29%22/%3E%3C/svg%3E");
+    background-image: url('data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2255%22%20viewBox%3D%220%200%2033%2055%22%20width%3D%2233%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22m1221.23218%20395.14282c0%20.428572-.21429.910716-.53571%201.232145l-24.96432%2024.964315c-.32143.321429-.80357.535715-1.23214.535715-.42858%200-.91072-.214286-1.23215-.535715l-2.67857-2.678574c-.32143-.321429-.53572-.750001-.53572-1.232145%200-.428572.21429-.910715.53572-1.232144l21.05359-21.053597-21.05359-21.053596c-.32143-.321429-.53572-.803573-.53572-1.232144%200-.428572.21429-.910716.53572-1.232145l2.67857-2.678574c.32143-.321429.80357-.535715%201.23215-.535715.42857%200%20.91071.214286%201.23214.535715l24.96432%2024.964315c.32142.321429.53571.803572.53571%201.232144z%22%20fill%3D%22%23F05129%22%20fill-rule%3D%22evenodd%22%20stroke%3D%22%23fff%22%20stroke-width%3D%22.5%22%20transform%3D%22translate%28-1189%20-368%29%22/%3E%3C/svg%3E');
 }
 
 .carousel-control-prev-icon {
-  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2255%22%20viewBox%3D%220%200%2033%2055%22%20width%3D%2233%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22m100.946469%20372.85708c0%20.428571-.214286.910715-.535715%201.232144l-21.0535968%2021.053596%2021.0535968%2021.053597c.321429.321429.535715.803572.535715%201.232144s-.214286.910716-.535715%201.232145l-2.6785749%202.678574c-.321429.321429-.8035724.535715-1.2321444.535715-.4285719%200-.9107153-.214286-1.2321443-.535715l-24.9643155-24.964315c-.3214289-.321429-.5357149-.803573-.5357149-1.232145s.214286-.910715.5357149-1.232144l24.9643155-24.964315c.321429-.321429.8035724-.535715%201.2321443-.535715.428572%200%20.9107154.214286%201.2321444.535715l2.6785749%202.678574c.321429.321429.535715.750001.535715%201.232145z%22%20fill%3D%22%23fff%22%20fill-rule%3D%22evenodd%22%20stroke%3D%22%23333%22%20stroke-width%3D%22.5%22%20transform%3D%22translate%28-69%20-368%29%22/%3E%3C/svg%3E");
+    background-image: url('data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2255%22%20viewBox%3D%220%200%2033%2055%22%20width%3D%2233%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22m100.946469%20372.85708c0%20.428571-.214286.910715-.535715%201.232144l-21.0535968%2021.053596%2021.0535968%2021.053597c.321429.321429.535715.803572.535715%201.232144s-.214286.910716-.535715%201.232145l-2.6785749%202.678574c-.321429.321429-.8035724.535715-1.2321444.535715-.4285719%200-.9107153-.214286-1.2321443-.535715l-24.9643155-24.964315c-.3214289-.321429-.5357149-.803573-.5357149-1.232145s.214286-.910715.5357149-1.232144l24.9643155-24.964315c.321429-.321429.8035724-.535715%201.2321443-.535715.428572%200%20.9107154.214286%201.2321444.535715l2.6785749%202.678574c.321429.321429.535715.750001.535715%201.232145z%22%20fill%3D%22%23fff%22%20fill-rule%3D%22evenodd%22%20stroke%3D%22%23333%22%20stroke-width%3D%22.5%22%20transform%3D%22translate%28-69%20-368%29%22/%3E%3C/svg%3E');
 }
 
 .view-homepage .carousel-control-prev:hover .carousel-control-prev-icon {
-  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2255%22%20viewBox%3D%220%200%2033%2055%22%20width%3D%2233%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22m100.946469%20372.85708c0%20.428571-.214286.910715-.535715%201.232144l-21.0535968%2021.053596%2021.0535968%2021.053597c.321429.321429.535715.803572.535715%201.232144s-.214286.910716-.535715%201.232145l-2.6785749%202.678574c-.321429.321429-.8035724.535715-1.2321444.535715-.4285719%200-.9107153-.214286-1.2321443-.535715l-24.9643155-24.964315c-.3214289-.321429-.5357149-.803573-.5357149-1.232145s.214286-.910715.5357149-1.232144l24.9643155-24.964315c.321429-.321429.8035724-.535715%201.2321443-.535715.428572%200%20.9107154.214286%201.2321444.535715l2.6785749%202.678574c.321429.321429.535715.750001.535715%201.232145z%22%20fill%3D%22%23F05129%22%20fill-rule%3D%22evenodd%22%20stroke%3D%22%23fff%22%20stroke-width%3D%22.5%22%20transform%3D%22translate%28-69%20-368%29%22/%3E%3C/svg%3E");
+    background-image: url('data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2255%22%20viewBox%3D%220%200%2033%2055%22%20width%3D%2233%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22m100.946469%20372.85708c0%20.428571-.214286.910715-.535715%201.232144l-21.0535968%2021.053596%2021.0535968%2021.053597c.321429.321429.535715.803572.535715%201.232144s-.214286.910716-.535715%201.232145l-2.6785749%202.678574c-.321429.321429-.8035724.535715-1.2321444.535715-.4285719%200-.9107153-.214286-1.2321443-.535715l-24.9643155-24.964315c-.3214289-.321429-.5357149-.803573-.5357149-1.232145s.214286-.910715.5357149-1.232144l24.9643155-24.964315c.321429-.321429.8035724-.535715%201.2321443-.535715.428572%200%20.9107154.214286%201.2321444.535715l2.6785749%202.678574c.321429.321429.535715.750001.535715%201.232145z%22%20fill%3D%22%23F05129%22%20fill-rule%3D%22evenodd%22%20stroke%3D%22%23fff%22%20stroke-width%3D%22.5%22%20transform%3D%22translate%28-69%20-368%29%22/%3E%3C/svg%3E');
 }
 
 .view-homepage .hero-text {
-  font-family: "Open Sans", sans-serif;
-  max-width: 30em;
+    font-family: 'Open Sans', sans-serif;
+    max-width: 30em;
 }
 
 #homepage-contribute-activities {
-  max-width: 100%;
-  margin: auto;
+    max-width: 100%;
+    margin: auto;
 }
 
 .homepage-activity {
-  width: calc(33% - 8px);
-  flex-shrink: 0;
-  flex-grow: 0;
+    width: calc(33% - 8px);
+    flex-shrink: 0;
+    flex-grow: 0;
 }
 
 .homepage-activity a {
-  display: block;
+    display: block;
 }
 
 #homepage-campaign-list .campaign {
-  width: 380px;
+    width: 380px;
 }
 
 #homepage-campaign-list img {
-  width: 368px;
-  height: 262px;
-  display: block;
-  object-fit: cover;
+    width: 368px;
+    height: 262px;
+    display: block;
+    object-fit: cover;
 }
 
 #homepage-campaign-list h3 {
-  /* avoid the text below the images overhanging the image */
-  max-width: 360px;
+    /* avoid the text below the images overhanging the image */
+    max-width: 360px;
 }
 
 @media screen and (max-width: 575px) {
-  .view-homepage h1 {
-    font-size: 2rem;
-  }
+    .view-homepage h1 {
+        font-size: 2rem;
+    }
 
-  .view-homepage p.hero-text {
-    font-size: 95%;
-  }
+    .view-homepage p.hero-text {
+        font-size: 95%;
+    }
 
-  .homepage-activity h4 {
-    font-size: 95%;
-  }
-  .homepage-activity p {
-    font-size: 85%;
-  }
+    .homepage-activity h4 {
+        font-size: 95%;
+    }
+    .homepage-activity p {
+        font-size: 85%;
+    }
 
-  .view-homepage .carousel-control-next,
-  .view-homepage .carousel-control-prev {
-    /*
+    .view-homepage .carousel-control-next,
+    .view-homepage .carousel-control-prev {
+        /*
             the background images are all 1200x480 sized with width:100% so
             we'll set our height to match that aspect ratio plus the control icon height and a bit of padding
         */
-    height: calc((100vw / (1200 / 480)) + 36px + 8px);
-    align-items: flex-end;
-  }
+        height: calc((100vw / (1200 / 480)) + 36px + 8px);
+        align-items: flex-end;
+    }
 
-  .view-homepage .carousel-control-next-icon,
-  .view-homepage .carousel-control-prev-icon {
-    height: 36.5px;
-    width: 22px;
-    filter: invert(1);
-  }
+    .view-homepage .carousel-control-next-icon,
+    .view-homepage .carousel-control-prev-icon {
+        height: 36.5px;
+        width: 22px;
+        filter: invert(1);
+    }
 
-  .view-homepage .carousel-overlay .title {
-    max-width: 70%;
-  }
+    .view-homepage .carousel-overlay .title {
+        max-width: 70%;
+    }
 }
 
 @media screen and (min-width: 720px) {
-  #homepage-carousel {
-    position: relative;
-  }
+    #homepage-carousel {
+        position: relative;
+    }
 
-  #homepage-carousel img {
-    cursor: pointer;
-  }
+    #homepage-carousel img {
+        cursor: pointer;
+    }
 
-  .carousel-overlay {
-    position: absolute;
-    top: 50px;
-    left: 120px;
-    width: 420px;
-    height: 232px;
-    background-color: var(--bg-offwhite);
-    padding: 1rem 1rem 1.3rem 1rem;
-  }
+    .carousel-overlay {
+        position: absolute;
+        top: 50px;
+        left: 120px;
+        width: 420px;
+        height: 232px;
+        background-color: var(--bg-offwhite);
+        padding: 1rem 1rem 1.3rem 1rem;
+    }
 
-  #homepage-carousel[data-overlay-position="top-right"] .carousel-overlay {
-    left: unset;
-    right: 120px;
-  }
+    #homepage-carousel[data-overlay-position='top-right'] .carousel-overlay {
+        left: unset;
+        right: 120px;
+    }
 
-  #homepage-campaign-list .campaign {
-    max-width: 30%;
-  }
+    #homepage-campaign-list .campaign {
+        max-width: 30%;
+    }
 
-  .view-homepage .carousel-control-next {
-    padding-left: 50px;
-  }
+    .view-homepage .carousel-control-next {
+        padding-left: 50px;
+    }
 
-  .view-homepage .carousel-control-prev {
-    padding-right: 50px;
-  }
+    .view-homepage .carousel-control-prev {
+        padding-right: 50px;
+    }
 }
 
 /*
@@ -781,146 +783,146 @@ ul.nav-secondary {
  */
 
 body.view-transcriptions--asset-detail main {
-  min-height: 740px;
-  height: var(--height-main);
-  background-color: inherit;
+    min-height: 740px;
+    height: var(--height-main);
+    background-color: inherit;
 }
 
 #contribute-main-content {
-  position: relative;
+    position: relative;
 }
 
 body.view-transcriptions--asset-detail main,
 #contribute-main-content {
-  /* This avoids browser inconsistencies when using the fullscreen API */
-  background-color: inherit;
+    /* This avoids browser inconsistencies when using the fullscreen API */
+    background-color: inherit;
 }
 
 #contribute-main-content h2 {
-  font-size: inherit;
+    font-size: inherit;
 }
 
 #navigation-container {
-  background-color: var(--control-bg-light);
-  border: solid var(--control-bg-default) 1px;
-  border-bottom: unset;
+    background-color: var(--control-bg-light);
+    border: solid var(--control-bg-default) 1px;
+    border-bottom: unset;
 }
 
 #contribute-container {
-  border: solid var(--control-bg-default) 1px;
+    border: solid var(--control-bg-default) 1px;
 }
 
 .gutter.gutter-horizontal {
-  display: block;
+    display: block;
 
-  position: relative;
+    position: relative;
 
-  cursor: ew-resize;
-  background-color: var(--control-bg-default);
+    cursor: ew-resize;
+    background-color: var(--control-bg-default);
 }
 
 .gutter.gutter-horizontal::after {
-  display: block;
+    display: block;
 
-  position: absolute;
-  top: calc(50% - 40px);
-  left: -4px;
+    position: absolute;
+    top: calc(50% - 40px);
+    left: -4px;
 
-  content: "";
+    content: '';
 
-  height: 40px;
-  width: 16px;
+    height: 40px;
+    width: 16px;
 
-  background: url(../img/handle.svg) no-repeat;
+    background: url(../img/handle.svg) no-repeat;
 }
 
 #transcription-editor textarea {
-  resize: none;
+    resize: none;
 }
 
 #help-container {
-  display: flex;
-  justify-content: end;
-  align-items: center;
+    display: flex;
+    justify-content: end;
+    align-items: center;
 }
 
 #help-container > * {
-  margin: 0.6rem;
+    margin: 0.6rem;
 }
 
 /* Help Center */
 
 .help-center-card {
-  color: #fff;
-  width: 300px;
-  height: 225px;
-  background-color: var(--primary-color);
+    color: #fff;
+    width: 300px;
+    height: 225px;
+    background-color: var(--primary-color);
 }
 
 .help-center-card a {
-  color: #fff;
+    color: #fff;
 }
 
 #faqAccordion {
-  padding-bottom: 20px;
+    padding-bottom: 20px;
 }
 
 #faqAccordion button {
-  color: #333;
+    color: #333;
 }
 
 #faqAccordion .card {
-  border-left: 0;
-  border-right: 0;
+    border-left: 0;
+    border-right: 0;
 }
 
 #faqAccordion .card-header {
-  padding-left: 0;
+    padding-left: 0;
 }
 
 #faqAccordion .card-header button {
-  padding-left: 0;
+    padding-left: 0;
 }
 
 .help-center .nav-link {
-  padding: 0.5rem 0.5rem;
+    padding: 0.5rem 0.5rem;
 }
 
 .help-center a.nav-link {
-  color: #333;
-  font-weight: bold;
+    color: #333;
+    font-weight: bold;
 }
 
 .help-center a.nav-link.active {
-  color: var(--primary-color);
+    color: var(--primary-color);
 }
 
 /* End of help center stuff */
 
 #instruction-window {
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  left: 0;
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    left: 0;
 
-  z-index: 10;
+    z-index: 10;
 
-  background-color: rgba(250, 250, 250, 0.8);
-  border-top: 1pt solid var(--bg-darkest-gray);
-  transition: height 1s linear 0;
+    background-color: rgba(250, 250, 250, 0.8);
+    border-top: 1pt solid var(--bg-darkest-gray);
+    transition: height 1s linear 0;
 }
 
 #instruction-window.collapse {
-  display: none;
+    display: none;
 }
 
 #instruction-window.collapse.show {
-  display: block;
+    display: block;
 }
 
 #instruction-window p {
-  max-width: 40em;
-  margin: auto;
+    max-width: 40em;
+    margin: auto;
 }
 
 /*
@@ -928,45 +930,45 @@ body.view-transcriptions--asset-detail main,
  */
 
 #current-tags {
-  border: 0px solid #ccc;
-  border-radius: 0.25rem;
-  list-style-type: none;
+    border: 0px solid #ccc;
+    border-radius: 0.25rem;
+    list-style-type: none;
 
-  max-height: var(--height-contribute-input);
-  max-height: 15vh;
+    max-height: var(--height-contribute-input);
+    max-height: 15vh;
 
-  overflow-y: scroll;
+    overflow-y: scroll;
 }
 
 #current-tags li {
-  margin: 0.375rem;
-  padding: 0.188rem 0.375rem;
-  color: var(--text-color-offwhite);
-  background-color: var(--primary-color);
-  box-shadow: 0 0 0.125rem var(--shadow-color);
-  border-radius: 0.25rem;
+    margin: 0.375rem;
+    padding: 0.188rem 0.375rem;
+    color: var(--text-color-offwhite);
+    background-color: var(--primary-color);
+    box-shadow: 0 0 0.125rem var(--shadow-color);
+    border-radius: 0.25rem;
 
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
 
 #current-tags li > * {
-  margin: 0 0.188rem;
-  padding: 0;
+    margin: 0 0.188rem;
+    padding: 0;
 }
 
-#current-tags [data-role="remove"] {
-  background-color: var(--primary-color-hover);
-  cursor: pointer;
+#current-tags [data-role='remove'] {
+    background-color: var(--primary-color-hover);
+    cursor: pointer;
 }
 
-#current-tags [data-role="remove"]:hover:after {
-  background-color: rgba(0, 0, 0, 0.62);
+#current-tags [data-role='remove']:hover:after {
+    background-color: rgba(0, 0, 0, 0.62);
 }
 
-#current-tags [data-role="remove"]:hover:active {
-  box-shadow: inset 0 0.1875rem 0.3125rem rgba(0, 0, 0, 0.125);
+#current-tags [data-role='remove']:hover:active {
+    box-shadow: inset 0 0.1875rem 0.3125rem rgba(0, 0, 0, 0.125);
 }
 
 /*
@@ -974,14 +976,14 @@ body.view-transcriptions--asset-detail main,
 */
 
 div.related-links {
-  background-color: #ddd;
-  border: #000 1px solid;
+    background-color: #ddd;
+    border: #000 1px solid;
 }
 
 .related-links .list-group-item {
-  background-color: #ddd;
-  border: 0;
-  padding-left: unset;
+    background-color: #ddd;
+    border: 0;
+    padding-left: unset;
 }
 
 /*
@@ -989,43 +991,43 @@ div.related-links {
 */
 
 .alert.alert-primary {
-  background-color: var(--primary-color);
-  border-color: none;
-  color: var(--text-color-offwhite);
+    background-color: var(--primary-color);
+    border-color: none;
+    color: var(--text-color-offwhite);
 }
 
 .alert.alert-secondary {
-  background-color: var(--secondary-color);
-  border-color: none;
-  color: var(--text-color-primary);
+    background-color: var(--secondary-color);
+    border-color: none;
+    color: var(--text-color-primary);
 }
 
 .alert.alert-success {
-  background-color: var(--color-success);
-  border-color: none;
-  color: var(--text-color-offwhite);
+    background-color: var(--color-success);
+    border-color: none;
+    color: var(--text-color-offwhite);
 }
 
 .alert.alert-danger {
-  background-color: var(--color-danger);
-  border-color: none;
-  color: var(--text-color-offwhite);
+    background-color: var(--color-danger);
+    border-color: none;
+    color: var(--text-color-offwhite);
 }
 
 .alert.alert-warning {
-  background-color: var(--color-warning);
-  border-color: none;
-  color: var(--text-color-primary);
+    background-color: var(--color-warning);
+    border-color: none;
+    color: var(--text-color-primary);
 }
 
 .alert.alert-info {
-  background-color: var(--color-info);
-  border-color: none;
-  color: var(--text-color-primary);
+    background-color: var(--color-info);
+    border-color: none;
+    color: var(--text-color-primary);
 }
 
 .alert .close {
-  opacity: 0.8;
+    opacity: 0.8;
 }
 
 /*
@@ -1033,180 +1035,180 @@ div.related-links {
 */
 
 .footer-crowd {
-  background-color: var(--bg-lightest-gray);
-  border-top: 1px solid var(--bg-medium-gray);
-  padding: 22px 0;
+    background-color: var(--bg-lightest-gray);
+    border-top: 1px solid var(--bg-medium-gray);
+    padding: 22px 0;
 }
 
 .footer-crowd-row {
-  max-width: 1200px;
-  padding: 0 1rem;
-  margin: 0 auto;
-  box-sizing: border-box;
+    max-width: 1200px;
+    padding: 0 1rem;
+    margin: 0 auto;
+    box-sizing: border-box;
 }
 @media (min-width: 769px) {
-  .footer-crowd-row {
-    display: flex;
-    padding: 0 2rem;
-  }
+    .footer-crowd-row {
+        display: flex;
+        padding: 0 2rem;
+    }
 }
 .footer-crowd-social {
-  text-align: center;
+    text-align: center;
 }
 @media (min-width: 769px) {
-  .footer-crowd-social {
-    text-align: left;
-    padding-right: 20px;
-  }
+    .footer-crowd-social {
+        text-align: left;
+        padding-right: 20px;
+    }
 }
 @media (min-width: 993px) {
-  .footer-crowd-social {
-    padding-right: 40px;
-  }
+    .footer-crowd-social {
+        padding-right: 40px;
+    }
 }
 .footer-crowd-social > h2 {
-  font-family: inherit;
-  font-weight: normal;
-  line-height: 1.2;
-  color: var(--bg-darkest-gray);
-  font-size: 1.25rem;
-  margin: 0 0 0.75rem;
+    font-family: inherit;
+    font-weight: normal;
+    line-height: 1.2;
+    color: var(--bg-darkest-gray);
+    font-size: 1.25rem;
+    margin: 0 0 0.75rem;
 }
 
 .footer-crowd-social .links-social {
-  margin: 0 -6.5px;
-  display: inline-block;
-  margin-bottom: 0;
+    margin: 0 -6.5px;
+    display: inline-block;
+    margin-bottom: 0;
 }
 
 .footer-crowd-social .links-social > li {
-  display: inline-block;
-  margin: 0 6.5px;
+    display: inline-block;
+    margin: 0 6.5px;
 }
 
 .footer-crowd-links {
-  border-top: 1px solid var(--bg-medium-gray);
-  border-bottom: 1px solid var(--bg-medium-gray);
-  padding: 16px 0;
-  margin: 16px 0;
+    border-top: 1px solid var(--bg-medium-gray);
+    border-bottom: 1px solid var(--bg-medium-gray);
+    padding: 16px 0;
+    margin: 16px 0;
 }
 @media (min-width: 769px) {
-  .footer-crowd-links {
-    flex: 1;
-    border: none;
-    border-left: 1px solid var(--bg-medium-gray);
-    padding: 0;
-    padding-left: 20px;
-    margin: 0;
-  }
+    .footer-crowd-links {
+        flex: 1;
+        border: none;
+        border-left: 1px solid var(--bg-medium-gray);
+        padding: 0;
+        padding-left: 20px;
+        margin: 0;
+    }
 }
 @media (min-width: 993px) {
-  .footer-crowd-links {
-    padding-left: 40px;
-  }
+    .footer-crowd-links {
+        padding-left: 40px;
+    }
 }
 .footer-crowd-links > ul {
-  font-size: 14px;
-  font-weight: bold;
-  margin: 0;
+    font-size: 14px;
+    font-weight: bold;
+    margin: 0;
 }
 .footer-crowd-links > ul > li {
-  margin-bottom: 5px;
-  text-align: center;
+    margin-bottom: 5px;
+    text-align: center;
 }
 @media (min-width: 769px) {
-  .footer-crowd-links > ul > li {
-    text-align: left;
-  }
+    .footer-crowd-links > ul > li {
+        text-align: left;
+    }
 }
 @media (min-width: 769px) {
-  .footer-crowd-links-aside {
-    border-left: 1px solid var(--bg-medium-gray);
-    padding-left: 20px;
-    padding-top: 20px;
-  }
+    .footer-crowd-links-aside {
+        border-left: 1px solid var(--bg-medium-gray);
+        padding-left: 20px;
+        padding-top: 20px;
+    }
 }
 @media (min-width: 993px) {
-  .footer-crowd-links-aside {
-    padding-left: 40px;
-  }
+    .footer-crowd-links-aside {
+        padding-left: 40px;
+    }
 }
 .footer-crowd-links-aside .links-aside {
-  padding-left: 0;
-  list-style: none;
-  text-align: center;
-  margin-bottom: 15px;
+    padding-left: 0;
+    list-style: none;
+    text-align: center;
+    margin-bottom: 15px;
 }
 @media (min-width: 769px) {
-  .footer-crowd-links-aside .links-aside {
-    text-align: left;
-  }
+    .footer-crowd-links-aside .links-aside {
+        text-align: left;
+    }
 }
 .footer-crowd-links-aside .links-aside > li {
-  display: inline-block;
-  font-size: 13px;
-  line-height: 1.1;
+    display: inline-block;
+    font-size: 13px;
+    line-height: 1.1;
 }
 .footer-crowd-links-aside .links-aside > li:not(:last-child) {
-  border-right: 1px solid var(--bg-medium-gray);
-  padding-right: 8px;
-  margin-right: 5px;
+    border-right: 1px solid var(--bg-medium-gray);
+    padding-right: 8px;
+    margin-right: 5px;
 }
 .footer-crowd-links-aside .links-intersites {
-  padding-left: 0;
-  list-style: none;
-  margin: 0 -1rem;
+    padding-left: 0;
+    list-style: none;
+    margin: 0 -1rem;
 }
 .footer-crowd-links-aside .links-intersites > li {
-  display: inline-block;
-  margin: 0 1rem;
+    display: inline-block;
+    margin: 0 1rem;
 }
 .footer-crowd-links-aside .links-intersites > li > a {
-  display: block;
+    display: block;
 }
 
 @media (max-width: 992px) {
-  .footer-crowd-links-aside .links-intersites > li > a {
-    margin: 5px 0;
-  }
+    .footer-crowd-links-aside .links-intersites > li > a {
+        margin: 5px 0;
+    }
 }
 .footer-crowd-links-aside .links-intersites > li.intersites-link-congress > a {
-  width: 125px;
-  height: 30px;
-  background-size: 125px 30px;
-  background: url(../img/congress-gov.svg) no-repeat;
+    width: 125px;
+    height: 30px;
+    background-size: 125px 30px;
+    background: url(../img/congress-gov.svg) no-repeat;
 }
 .footer-crowd-links-aside .links-intersites > li.intersites-link-copyright > a {
-  width: 175px;
-  height: 30px;
-  background-size: 175px 30px;
-  background: url(../img/copyright-gov.svg) no-repeat;
+    width: 175px;
+    height: 30px;
+    background-size: 175px 30px;
+    background: url(../img/copyright-gov.svg) no-repeat;
 }
 @media (max-width: 768px) {
-  .footer-crowd-links-aside .links-intersites {
-    text-align: center;
-  }
+    .footer-crowd-links-aside .links-intersites {
+        text-align: center;
+    }
 }
 .bitmap-icon {
-  display: inline-block;
-  width: 24px;
-  height: 24px;
-  vertical-align: text-top;
-  background-image: url(../img/social-icons-sprite.png);
-  background-position: -200px 0;
-  background-repeat: no-repeat;
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    vertical-align: text-top;
+    background-image: url(../img/social-icons-sprite.png);
+    background-position: -200px 0;
+    background-repeat: no-repeat;
 }
 .bitmap-icon.github-icon {
-  background-position: 0 0;
+    background-position: 0 0;
 }
 .bitmap-icon.twitter-icon {
-  background-position: -40px 0;
+    background-position: -40px 0;
 }
 .bitmap-icon.email-icon {
-  background-position: -80px 0;
+    background-position: -80px 0;
 }
 
 /* Registration page */
 #registration-form-container > .col-md-6 {
-  max-width: 30rem;
+    max-width: 30rem;
 }

--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -1,318 +1,317 @@
 :root {
-    --primary-color: #f05129;
-    --primary-color-hover: rgba(188, 57, 1, 1); /* #BC3901 */
-    --secondary-color: rgba(0, 167, 228, 1); /* #00A7E4 */
-    --secondary-color-hover: rgba(0, 35, 71, 1); /* #002347 */
-    --color-success: rgba(22, 201, 74, 1); /* #16C94A */
-    --color-danger: rgba(254, 12, 11, 1); /* #FE0C0B */
-    --color-warning: rgba(254, 153, 11, 1); /* #FE990B */
-    --color-info: rgba(2, 252, 216, 1); /* #02FCD8 */
-    --text-color-primary: rgba(38, 50, 56, 1); /* #263238 */
-    --text-color-offwhite: rgba(250, 250, 250, 1); /* #FAFAFA */
-    --text-nav-current: #f05129;
+  --primary-color: #f05129;
+  --primary-color-hover: rgba(188, 57, 1, 1); /* #BC3901 */
+  --secondary-color: rgba(0, 167, 228, 1); /* #00A7E4 */
+  --secondary-color-hover: rgba(0, 35, 71, 1); /* #002347 */
+  --color-success: rgba(22, 201, 74, 1); /* #16C94A */
+  --color-danger: rgba(254, 12, 11, 1); /* #FE0C0B */
+  --color-warning: rgba(254, 153, 11, 1); /* #FE990B */
+  --color-info: rgba(2, 252, 216, 1); /* #02FCD8 */
+  --text-color-primary: rgba(38, 50, 56, 1); /* #263238 */
+  --text-color-offwhite: rgba(250, 250, 250, 1); /* #FAFAFA */
+  --text-nav-current: #f05129;
 
-    --bg-offwhite: rgba(250, 250, 250, 1); /* #FAFAFA */
-    --bg-lightest-gray: rgba(245, 245, 245, 1); /* #F5F5F5 */
-    --bg-darkest-gray: rgba(51, 51, 51, 1); /* #333333 */
-    --bg-offblack: rgba(38, 50, 56, 1); /* #263238 */
-    --bg-dark-gray: rgba(102, 102, 102, 1); /* #666666 */
-    --bg-medium-gray: rgba(153, 153, 153, 1); /* #999999 */
-    --bg-footer: rgba(238, 238, 238, 1); /* #EEEEEE */
-    --bg-divider: rgba(189, 189, 189, 1); /* #BDBDBD */
-    --bg-card-title: rgba(51, 51, 51, 0.7); /* #333333 */
-    --bg-loading: rgba(51, 51, 51, 0.5); /* #333333 */
-    --bg-completed: #00618e;
-    --bg-submitted: #2e91bf;
-    --bg-in_progress: #80cef3;
-    --bg-not_started: #e9ecef;
+  --bg-offwhite: rgba(250, 250, 250, 1); /* #FAFAFA */
+  --bg-lightest-gray: rgba(245, 245, 245, 1); /* #F5F5F5 */
+  --bg-darkest-gray: rgba(51, 51, 51, 1); /* #333333 */
+  --bg-offblack: rgba(38, 50, 56, 1); /* #263238 */
+  --bg-dark-gray: rgba(102, 102, 102, 1); /* #666666 */
+  --bg-medium-gray: rgba(153, 153, 153, 1); /* #999999 */
+  --bg-footer: rgba(238, 238, 238, 1); /* #EEEEEE */
+  --bg-divider: rgba(189, 189, 189, 1); /* #BDBDBD */
+  --bg-card-title: rgba(51, 51, 51, 0.7); /* #333333 */
+  --bg-loading: rgba(51, 51, 51, 0.5); /* #333333 */
+  --bg-completed: #00618e;
+  --bg-submitted: #2e91bf;
+  --bg-in_progress: #80cef3;
+  --bg-not_started: #e9ecef;
 
-    --shadow-color: rgba(51, 51, 51, 0.8); /* #333333 */
-    --light-shadow-color: rgba(51, 51, 51, 0.4); /* #333333 */
-    --footer-links-color: #00618e;
+  --shadow-color: rgba(51, 51, 51, 0.8); /* #333333 */
+  --light-shadow-color: rgba(51, 51, 51, 0.4); /* #333333 */
+  --footer-links-color: #00618e;
 
-    /* Colors used to build complex interface widgets */
-    --control-bg-light: #efefef;
-    --control-bg-default: #d8d8d8;
-    --control-label-color: #333333;
+  /* Colors used to build complex interface widgets */
+  --control-bg-light: #efefef;
+  --control-bg-default: #d8d8d8;
+  --control-label-color: #333333;
 
-    --height-top-nav: 113px; /* Height of logo image plus padding */
-    --height-footer: 149px;
-    --height-main: calc(100vh - (var(--height-top-nav) + var(--height-footer)));
+  --height-top-nav: 113px; /* Height of logo image plus padding */
+  --height-footer: 149px;
+  --height-main: calc(100vh - (var(--height-top-nav) + var(--height-footer)));
 
-    /* Making room for instructions button on bottom and breadcrumb and nav on top */
-    --height-contribute-image: calc(
-        100vh - (8.0625rem + 1.59375rem + 2.375rem)
-    );
+  /* Making room for instructions button on bottom and breadcrumb and nav on top */
+  --height-contribute-image: calc(100vh - (8.0625rem + 1.59375rem + 2.375rem));
 
-    /* Subtract height of navbar, breadcrumbs, and nav pills */
-    --height-contribute-input: calc(50vh - 5.96875rem);
-    --height-tags-input: calc(50vh - 2.625rem);
-    --top-tags-input: calc(50vh - 0.75rem);
+  /* Subtract height of navbar, breadcrumbs, and nav pills */
+  --height-contribute-input: calc(50vh - 5.96875rem);
+  --height-tags-input: calc(50vh - 2.625rem);
+  --top-tags-input: calc(50vh - 0.75rem);
 }
 
 body {
-    color: var(--text-color-primary);
-    border-top: 0.25rem solid var(--primary-color);
-    background-color: var(--bg-offwhite);
+  color: var(--text-color-primary);
+  border-top: 0.25rem solid var(--primary-color);
+  background-color: var(--bg-offwhite);
 }
 
 main {
-    min-height: var(--height-main);
+  min-height: var(--height-main);
 }
 
-h1, .h1 {
-    font-family: 'Roboto Slab', serif;
-    font-weight: bold;
-    color: var(--text-color-primary);
+h1,
+.h1 {
+  font-family: "Roboto Slab", serif;
+  font-weight: bold;
+  color: var(--text-color-primary);
 }
 
 h1.header-text {
-    font-family: 'Open Sans', sans-serif;
-    font-size: 2.5rem;
-    font-weight: normal;
-    color: black;
-    text-transform: uppercase;
+  font-family: "Open Sans", sans-serif;
+  font-size: 2.5rem;
+  font-weight: normal;
+  color: black;
+  text-transform: uppercase;
 }
 
 .header-text .beta-label {
-    font-size: x-small;
-    color: var(--primary-color);
+  font-size: x-small;
+  color: var(--primary-color);
 }
 
 h2 {
-    font-size: 1.5rem;
-    line-height: 125%;
-    font-weight: bold;
-    color: var(--text-color-primary);
+  font-size: 1.5rem;
+  line-height: 125%;
+  font-weight: bold;
+  color: var(--text-color-primary);
 }
 
 h2.offwhite {
-    color: var(--text-color-offwhite);
+  color: var(--text-color-offwhite);
 }
 
 h2 small {
-    color: var(--text-color-primary);
+  color: var(--text-color-primary);
 }
 
 h3 {
-    font-size: 1.25rem;
-    line-height: 125%;
-    font-weight: bold;
-    color: var(--text-color-primary);
+  font-size: 1.25rem;
+  line-height: 125%;
+  font-weight: bold;
+  color: var(--text-color-primary);
 }
 
 h4 {
-    font-family: 'Open Sans', sans-serif;
-    font-size: 1.125rem;
-    line-height: 125%;
-    font-weight: bold;
-    color: var(--text-color-primary);
+  font-family: "Open Sans", sans-serif;
+  font-size: 1.125rem;
+  line-height: 125%;
+  font-weight: bold;
+  color: var(--text-color-primary);
 }
 
 h5 {
-    font-family: 'Open Sans', sans-serif;
-    font-size: 1rem;
-    line-height: 125%;
-    font-weight: bold;
-    font-weight: normal;
+  font-family: "Open Sans", sans-serif;
+  font-size: 1rem;
+  line-height: 125%;
+  font-weight: bold;
+  font-weight: normal;
 }
 
 h6 {
-    font-family: 'Open Sans', sans-serif;
-    font-size: 0.875rem;
-    line-height: 125%;
-    font-weight: bold;
-    color: var(--text-color-primary);
+  font-family: "Open Sans", sans-serif;
+  font-size: 0.875rem;
+  line-height: 125%;
+  font-weight: bold;
+  color: var(--text-color-primary);
 }
 
 .offwhite-text {
-    color: var(--text-color-offwhite);
+  color: var(--text-color-offwhite);
 }
 
 .primary-text {
-    color: var(--primary-color);
+  color: var(--primary-color);
 }
 
 .secondary-text {
-    color: var(--secondary-color);
+  color: var(--secondary-color);
 }
 
 .gray-text {
-    color: var(--text-color-primary);
+  color: var(--text-color-primary);
 }
 
 a:hover {
-    color: var(--text-color-primary);
+  color: var(--text-color-primary);
 }
 
 a.primary-text {
-    color: var(--primary-color);
-    text-decoration: none;
+  color: var(--primary-color);
+  text-decoration: none;
 }
 
 a.primary-text:hover {
-    color: var(--primary-color-hover);
-    text-decoration: underline;
+  color: var(--primary-color-hover);
+  text-decoration: underline;
 }
 
 a.secondary-text {
-    color: var(--secondary-color);
-    text-decoration: none;
+  color: var(--secondary-color);
+  text-decoration: none;
 }
 
 a.secondary-text:hover {
-    color: var(--secondary-color-hover);
-    text-decoration: underline;
+  color: var(--secondary-color-hover);
+  text-decoration: underline;
 }
 
 a.offwhite-text {
-    color: var(--text-color-offwhite);
-    text-decoration: none;
+  color: var(--text-color-offwhite);
+  text-decoration: none;
 }
 
 a.offwhite-text:hover {
-    color: var(--primary-color);
-    text-decoration: underline;
+  color: var(--primary-color);
+  text-decoration: underline;
 }
 
 a.gray-text {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 a.gray-text:hover {
-    color: var(--primary-color);
-    text-decoration: none;
+  color: var(--primary-color);
+  text-decoration: none;
 }
 
 a.nav-secondary {
-    font-family: 'Open Sans', sans-serif;
-    font-weight: normal;
-    font-size: 0.875rem;
-    color: var(--text-color-primary);
+  font-family: "Open Sans", sans-serif;
+  font-weight: normal;
+  font-size: 0.875rem;
+  color: var(--text-color-primary);
 }
 
 a.nav-secondary:hover {
-    opacity: 70%;
-    text-decoration: none;
+  opacity: 70%;
+  text-decoration: none;
 }
 
 a .campaign-title:hover,
 .hero-text a:hover {
-    color: var(--text-color-primary);
-    text-decoration: underline;
+  color: var(--text-color-primary);
+  text-decoration: underline;
 }
 
 ul.nav-secondary li:first-of-type {
-    border-right: solid 0.0675rem var(--bg-darkest-gray);
+  border-right: solid 0.0675rem var(--bg-darkest-gray);
 }
 
 p.hero-secondary {
-    font-family: 'Open Sans', sans-serif;
-    font-size: 1.125rem;
-    color: var(--text-color-primary);
+  font-family: "Open Sans", sans-serif;
+  font-size: 1.125rem;
+  color: var(--text-color-primary);
 }
 
 p.hero-secondary.offwhite-text {
-    font-family: 'Open Sans', sans-serif;
-    font-size: 1.125rem;
-    color: var(--text-color-offwhite);
+  font-family: "Open Sans", sans-serif;
+  font-size: 1.125rem;
+  color: var(--text-color-offwhite);
 }
 
 .bg-offwhite {
-    background-color: var(--bg-offwhite);
+  background-color: var(--bg-offwhite);
 }
 
 .bg-lightest-gray {
-    background-color: var(--bg-lightest-gray);
+  background-color: var(--bg-lightest-gray);
 }
 
 .bg-medium-gray {
-    background-color: var(--bg-medium-gray);
+  background-color: var(--bg-medium-gray);
 }
 
 .bg-darkest-gray {
-    background-color: var(--bg-darkest-gray);
+  background-color: var(--bg-darkest-gray);
 }
 
 .bg-dark-gray {
-    background-color: var(--bg-darkest-gray);
+  background-color: var(--bg-darkest-gray);
 }
 
 .bg-footer {
-    background-color: var(--bg-footer);
+  background-color: var(--bg-footer);
 }
 
 .bg-card-title {
-    background-color: var(--bg-card-title);
+  background-color: var(--bg-card-title);
 }
 
 .bg-home-contribute {
-    /* For browsers that do not support gradients */
-    background-color: var(--bg-darkest-gray);
+  /* For browsers that do not support gradients */
+  background-color: var(--bg-darkest-gray);
 
-    background-image: linear-gradient(
-            rgba(250, 250, 250, 0.25),
-            rgba(38, 50, 56, 0.25)
-        ),
-        linear-gradient(rgba(51, 51, 51, 1), rgba(51, 51, 51, 1));
+  background-image: linear-gradient(
+      rgba(250, 250, 250, 0.25),
+      rgba(38, 50, 56, 0.25)
+    ),
+    linear-gradient(rgba(51, 51, 51, 1), rgba(51, 51, 51, 1));
 }
 
 .bg-img-placeholder {
-    background-color: var(--bg-divider);
+  background-color: var(--bg-divider);
 }
 
 .bg-img-placeholder:hover {
-    background-image: linear-gradient(
-            rgba(252, 76, 2, 0.5),
-            rgba(252, 76, 2, 0.1)
-        ),
-        linear-gradient(rgba(189, 189, 189, 1), rgba(189, 189, 189, 1));
+  background-image: linear-gradient(
+      rgba(252, 76, 2, 0.5),
+      rgba(252, 76, 2, 0.1)
+    ),
+    linear-gradient(rgba(189, 189, 189, 1), rgba(189, 189, 189, 1));
 }
 
 .bg-primary-color {
-    background-color: var(--primary-color);
+  background-color: var(--primary-color);
 }
 
 .bg-completed {
-    background-color: var(--bg-completed);
+  background-color: var(--bg-completed);
 }
 
 .bg-submitted {
-    background-color: var(--bg-submitted);
+  background-color: var(--bg-submitted);
 }
 
 .bg-in_progress {
-    background-color: var(--bg-in_progress);
+  background-color: var(--bg-in_progress);
 }
 
 .bg-not_started {
-    background-color: var(--bg-not_started);
+  background-color: var(--bg-not_started);
 }
 
 input {
-    color: var(--text-color-primary);
-    background-color: var(--bg-offwhite);
+  color: var(--text-color-primary);
+  background-color: var(--bg-offwhite);
 }
 
 hr {
-    color: var(--bg-dark-gray);
+  color: var(--bg-dark-gray);
 }
 
 .navbar-brand {
-    padding-top: 0;
-    padding-bottom: 0;
-    margin-right: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  margin-right: 0;
 }
 
 .navbar-brand img {
-    width: 10.625rem;
-    height: auto;
+  width: 10.625rem;
+  height: auto;
 }
 
 ul.nav-secondary {
-    position: absolute;
-    right: 1.5rem;
-    top: 1.5rem;
+  position: absolute;
+  right: 1.5rem;
+  top: 1.5rem;
 }
 
 /*
@@ -320,181 +319,181 @@ ul.nav-secondary {
 */
 
 .navbar-brand .vl {
-    height: 6rem;
-    background-color: var(--bg-dark-gray);
-    width: 0.0675rem;
+  height: 6rem;
+  background-color: var(--bg-dark-gray);
+  width: 0.0675rem;
 }
 
 .border-login-register {
-    border-left: solid 0.0675 var(--bg-darkest-gray);
+  border-left: solid 0.0675 var(--bg-darkest-gray);
 }
 
 .border-left-home-contribute {
-    border-left: solid 0.0675rem var(--bg-offwhite);
+  border-left: solid 0.0675rem var(--bg-offwhite);
 }
 
 .navbar-offwhite .navbar-nav .active > .nav-link,
 .navbar-offwhite .navbar-nav .nav-link.active,
 .navbar-offwhite .navbar-nav .nav-link.show,
 .navbar-offwhite .navbar-nav .show > .nav-link {
-    color: var(--text-nav-current);
+  color: var(--text-nav-current);
 }
 
 .navbar-offwhite .navbar-nav .nav-link {
-    font-family: 'Open Sans', sans-serif;
-    font-weight: bold;
-    color: var(--text-color-primary);
+  font-family: "Open Sans", sans-serif;
+  font-weight: bold;
+  color: var(--text-color-primary);
 }
 
 #topnav-account-dropdown .dropdown-menu {
-    /* Our custom styling conflicts with the Bootstrap defaults */
-    top: 2.8rem;
-    left: -5rem;
+  /* Our custom styling conflicts with the Bootstrap defaults */
+  top: 2.8rem;
+  left: -5rem;
 }
 
 .btn.disabled,
 .btn:disabled {
-    opacity: 0.3 !important;
+  opacity: 0.3 !important;
 }
 
 .btn-secondary {
-    background-color: var(--secondary-color);
-    border-color: var(--secondary-color);
-    color: var(--text-color-offwhite);
+  background-color: var(--secondary-color);
+  border-color: var(--secondary-color);
+  color: var(--text-color-offwhite);
 }
 
 .btn-secondary:hover {
-    background-color: var(--secondary-color-hover);
-    border-color: var(--secondary-color-hover);
-    color: var(--text-color-offwhite);
+  background-color: var(--secondary-color-hover);
+  border-color: var(--secondary-color-hover);
+  color: var(--text-color-offwhite);
 }
 
 .btn-outline-secondary {
-    border-color: var(--secondary-color);
-    color: var(--secondary-color);
+  border-color: var(--secondary-color);
+  color: var(--secondary-color);
 }
 
 .btn-outline-secondary:hover {
-    border-color: var(--secondary-color-hover);
-    background-color: transparent;
-    color: var(--secondary-color-hover);
+  border-color: var(--secondary-color-hover);
+  background-color: transparent;
+  color: var(--secondary-color-hover);
 }
 
 .btn-minimal-secondary {
-    background-color: transparent;
-    border-color: transparent;
-    color: var(--secondary-color);
+  background-color: transparent;
+  border-color: transparent;
+  color: var(--secondary-color);
 }
 
 .btn-minimal-secondary:hover {
-    background-color: var(--secondary-color);
-    border-color: transparent;
-    color: var(--text-color-offwhite);
+  background-color: var(--secondary-color);
+  border-color: transparent;
+  color: var(--text-color-offwhite);
 }
 
 .btn-secondary.disabled,
 .btn-secondary:disabled {
-    background-color: var(--secondary-color) !important;
-    border-color: var(--secondary-color) !important;
-    color: var(--text-color-offwhite) !important;
+  background-color: var(--secondary-color) !important;
+  border-color: var(--secondary-color) !important;
+  color: var(--text-color-offwhite) !important;
 }
 
 .btn-default {
-    background-color: rgba(158, 158, 158, 1);
-    border-color: rgba(158, 158, 158, 1);
-    color: var(--text-color-primary);
+  background-color: rgba(158, 158, 158, 1);
+  border-color: rgba(158, 158, 158, 1);
+  color: var(--text-color-primary);
 }
 
 .btn-default.disabled,
 .btn-default:disabled {
-    background-color: rgba(158, 158, 158, 1) !important;
-    border-color: rgba(158, 158, 158, 1) !important;
-    color: var(--text-color-primary) !important;
+  background-color: rgba(158, 158, 158, 1) !important;
+  border-color: rgba(158, 158, 158, 1) !important;
+  color: var(--text-color-primary) !important;
 }
 
 .btn-default:hover {
-    background-color: var(--bg-darkest-gray);
-    border-color: var(--bg-darkest-gray);
-    color: var(--text-color-offwhite);
+  background-color: var(--bg-darkest-gray);
+  border-color: var(--bg-darkest-gray);
+  color: var(--text-color-offwhite);
 }
 
 .btn-outline-default {
-    border-color: var(--bg-medium-gray);
-    color: var(--bg-medium-gray);
+  border-color: var(--bg-medium-gray);
+  color: var(--bg-medium-gray);
 }
 
 .btn-outline-default:hover {
-    border-color: var(--bg-darkest-gray);
-    background-color: transparent;
-    color: var(--bg-darkest-gray);
+  border-color: var(--bg-darkest-gray);
+  background-color: transparent;
+  color: var(--bg-darkest-gray);
 }
 
 .btn-row .btn {
-    width: 9.875rem !important;
+  width: 9.875rem !important;
 }
 
 .btn-dark {
-    background-color: var(--bg-offblack);
-    border-color: var(--bg-offblack);
-    color: var(--text-color-offwhite);
+  background-color: var(--bg-offblack);
+  border-color: var(--bg-offblack);
+  color: var(--text-color-offwhite);
 }
 
 .btn-dark.disabled,
 .btn-dark:disabled {
-    background-color: var(--bg-darkest-gray) !important;
-    border-color: var(--bg-darkest-gray) !important;
-    color: var(--text-color-offwhite) !important;
+  background-color: var(--bg-darkest-gray) !important;
+  border-color: var(--bg-darkest-gray) !important;
+  color: var(--text-color-offwhite) !important;
 }
 
 /* Forms */
 
 .form-group-required label {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 /* Cards */
 
 .card-body {
-    padding: 1rem 0.5rem;
+  padding: 1rem 0.5rem;
 }
 
 .card-img-campaign {
-    object-position: center top;
-    object-fit: cover;
-    height: 13.25rem;
+  object-position: center top;
+  object-fit: cover;
+  height: 13.25rem;
 }
 
 .card-img-overlay {
-    left: 0;
-    right: 0;
-    bottom: 0;
-    margin-bottom: 3.0675rem;
-    padding: 0.5rem 1.25rem;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin-bottom: 3.0675rem;
+  padding: 0.5rem 1.25rem;
 }
 
 .card-img-overlay.img-campaign {
-    padding: 0;
+  padding: 0;
 }
 
 .card-title {
-    margin-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .img-project {
-    min-height: 13.125rem;
+  min-height: 13.125rem;
 }
 
 .round-corners-bottom {
-    border-radius: 0 0 0.5rem 0.5rem;
+  border-radius: 0 0 0.5rem 0.5rem;
 }
 
 .img-fluid.rounded-circle {
-    max-height: 15rem;
-    width: auto;
+  max-height: 15rem;
+  width: auto;
 }
 
 .shadow-regular {
-    box-shadow: 0 0 0.25rem var(--shadow-color);
+  box-shadow: 0 0 0.25rem var(--shadow-color);
 }
 
 /*
@@ -502,18 +501,18 @@ ul.nav-secondary {
  */
 
 .breadcrumb {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    justify-content: start;
-    align-items: start;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: start;
+  align-items: start;
 }
 
 .breadcrumb-item {
-    max-width: 20em;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
+  max-width: 20em;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 /*
@@ -521,75 +520,75 @@ ul.nav-secondary {
  */
 
 .card-deck .card.concordia-object-card {
-    position: relative;
-    flex-grow: 0;
-    flex-basis: 200px;
+  position: relative;
+  flex-grow: 0;
+  flex-basis: 200px;
 
-    width: 200px;
-    min-height: 300px;
+  width: 200px;
+  min-height: 300px;
 
-    margin: 0.25rem;
+  margin: 0.25rem;
 
-    justify-content: start;
-    align-items: center;
+  justify-content: start;
+  align-items: center;
 
-    background-color: var(--bg-lightest-gray);
+  background-color: var(--bg-lightest-gray);
 }
 
 .card-deck .card.concordia-object-card > * {
-    /* This is only necessary for IE11 */
-    max-width: 100%;
+  /* This is only necessary for IE11 */
+  max-width: 100%;
 }
 
 @media screen and (max-width: 576px) {
-    .card-deck .card.concordia-object-card {
-        flex-basis: auto;
-    }
+  .card-deck .card.concordia-object-card {
+    flex-basis: auto;
+  }
 }
 
-.concordia-object-card[data-transcription-status='completed']:not(:hover) {
-    opacity: 0.5;
+.concordia-object-card[data-transcription-status="completed"]:not(:hover) {
+  opacity: 0.5;
 }
 
 .concordia-object-card .card-title,
 .concordia-object-card .card-actions {
-    position: absolute;
-    left: 0;
-    right: 0;
+  position: absolute;
+  left: 0;
+  right: 0;
 
-    color: var(--text-color-offwhite);
+  color: var(--text-color-offwhite);
 }
 
 .concordia-object-card .card-title {
-    top: 0;
-    padding: 2px;
+  top: 0;
+  padding: 2px;
 
-    font-weight: bold;
-    color: var(--text-color-offwhite);
-    background-color: var(--light-shadow-color);
+  font-weight: bold;
+  color: var(--text-color-offwhite);
+  background-color: var(--light-shadow-color);
 }
 
 .concordia-object-card .card-title:hover {
-    background-color: var(--shadow-color);
+  background-color: var(--shadow-color);
 }
 
 .concordia-object-card .card-actions {
-    bottom: 0;
+  bottom: 0;
 }
 
 .concordia-object-card .card-actions .btn-default:not(:hover) {
-    background-color: var(--light-shadow-color);
+  background-color: var(--light-shadow-color);
 }
 
 .concordia-object-card .card-img-container {
-    display: block;
-    height: 100%;
-    width: 100%;
+  display: block;
+  height: 100%;
+  width: 100%;
 }
 
 .card.concordia-object-card .progress {
-    height: 1em;
-    border-radius: 0;
+  height: 1em;
+  border-radius: 0;
 }
 
 /*
@@ -597,23 +596,23 @@ ul.nav-secondary {
  */
 
 #progress-bar {
-    height: 2rem;
+  height: 2rem;
 }
 
 #progress-stats {
-    font-size: smaller;
+  font-size: smaller;
 }
 
 #progress-stats th {
-    font-size: inherit;
-    font-weight: inherit;
+  font-size: inherit;
+  font-weight: inherit;
 }
 
 .transcription-status-key {
-    display: inline-block;
-    height: 0.6em;
-    width: 0.6em;
-    vertical-align: baseline;
+  display: inline-block;
+  height: 0.6em;
+  width: 0.6em;
+  vertical-align: baseline;
 }
 
 /*
@@ -621,158 +620,158 @@ ul.nav-secondary {
  */
 
 .view-homepage h1 {
-    font-size: 2rem;
-    line-height: 125%;
+  font-size: 2rem;
+  line-height: 125%;
 }
 
 .view-homepage .carousel-indicators li {
-    width: 12px;
-    height: 12px;
+  width: 12px;
+  height: 12px;
 
-    background: url('data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2212%22%20viewBox%3D%220%200%2012%2012%22%20width%3D%2212%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Ccircle%20cx%3D%226%22%20cy%3D%226%22%20fill%3D%22%23fff%22%20fill-rule%3D%22evenodd%22%20r%3D%225.5%22%20stroke%3D%22%23333%22/%3E%3C/svg%3E');
-    background-repeat: no-repeat;
+  background: url("data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2212%22%20viewBox%3D%220%200%2012%2012%22%20width%3D%2212%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Ccircle%20cx%3D%226%22%20cy%3D%226%22%20fill%3D%22%23fff%22%20fill-rule%3D%22evenodd%22%20r%3D%225.5%22%20stroke%3D%22%23333%22/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
 }
 
 .view-homepage .carousel-indicators .active {
-    background: url('data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2212%22%20viewBox%3D%220%200%2012%2012%22%20width%3D%2212%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Ccircle%20cx%3D%226%22%20cy%3D%226%22%20fill%3D%22%23F05129%22%20fill-rule%3D%22evenodd%22%20r%3D%225.5%22%20stroke%3D%22%23fff%22/%3E%3C/svg%3E');
+  background: url("data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2212%22%20viewBox%3D%220%200%2012%2012%22%20width%3D%2212%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Ccircle%20cx%3D%226%22%20cy%3D%226%22%20fill%3D%22%23F05129%22%20fill-rule%3D%22evenodd%22%20r%3D%225.5%22%20stroke%3D%22%23fff%22/%3E%3C/svg%3E");
 }
 
 .view-homepage .carousel-control-next,
 .view-homepage .carousel-control-prev {
-    opacity: 1;
+  opacity: 1;
 }
 
 .view-homepage .carousel-control-next-icon,
 .view-homepage .carousel-control-prev-icon {
-    height: 55px;
-    width: 33px;
+  height: 55px;
+  width: 33px;
 }
 
 .view-homepage .carousel-control-next-icon {
-    background-image: url('data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2255%22%20viewBox%3D%220%200%2033%2055%22%20width%3D%2233%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22m1221.23218%20395.14282c0%20.428572-.21429.910716-.53571%201.232145l-24.96432%2024.964315c-.32143.321429-.80357.535715-1.23214.535715-.42858%200-.91072-.214286-1.23215-.535715l-2.67857-2.678574c-.32143-.321429-.53572-.750001-.53572-1.232145%200-.428572.21429-.910715.53572-1.232144l21.05359-21.053597-21.05359-21.053596c-.32143-.321429-.53572-.803573-.53572-1.232144%200-.428572.21429-.910716.53572-1.232145l2.67857-2.678574c.32143-.321429.80357-.535715%201.23215-.535715.42857%200%20.91071.214286%201.23214.535715l24.96432%2024.964315c.32142.321429.53571.803572.53571%201.232144z%22%20fill%3D%22%23fff%22%20fill-rule%3D%22evenodd%22%20stroke%3D%22%23333%22%20stroke-width%3D%22.5%22%20transform%3D%22translate%28-1189%20-368%29%22/%3E%3C/svg%3E');
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2255%22%20viewBox%3D%220%200%2033%2055%22%20width%3D%2233%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22m1221.23218%20395.14282c0%20.428572-.21429.910716-.53571%201.232145l-24.96432%2024.964315c-.32143.321429-.80357.535715-1.23214.535715-.42858%200-.91072-.214286-1.23215-.535715l-2.67857-2.678574c-.32143-.321429-.53572-.750001-.53572-1.232145%200-.428572.21429-.910715.53572-1.232144l21.05359-21.053597-21.05359-21.053596c-.32143-.321429-.53572-.803573-.53572-1.232144%200-.428572.21429-.910716.53572-1.232145l2.67857-2.678574c.32143-.321429.80357-.535715%201.23215-.535715.42857%200%20.91071.214286%201.23214.535715l24.96432%2024.964315c.32142.321429.53571.803572.53571%201.232144z%22%20fill%3D%22%23fff%22%20fill-rule%3D%22evenodd%22%20stroke%3D%22%23333%22%20stroke-width%3D%22.5%22%20transform%3D%22translate%28-1189%20-368%29%22/%3E%3C/svg%3E");
 }
 
 .view-homepage .carousel-control-next:hover .carousel-control-next-icon {
-    background-image: url('data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2255%22%20viewBox%3D%220%200%2033%2055%22%20width%3D%2233%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22m1221.23218%20395.14282c0%20.428572-.21429.910716-.53571%201.232145l-24.96432%2024.964315c-.32143.321429-.80357.535715-1.23214.535715-.42858%200-.91072-.214286-1.23215-.535715l-2.67857-2.678574c-.32143-.321429-.53572-.750001-.53572-1.232145%200-.428572.21429-.910715.53572-1.232144l21.05359-21.053597-21.05359-21.053596c-.32143-.321429-.53572-.803573-.53572-1.232144%200-.428572.21429-.910716.53572-1.232145l2.67857-2.678574c.32143-.321429.80357-.535715%201.23215-.535715.42857%200%20.91071.214286%201.23214.535715l24.96432%2024.964315c.32142.321429.53571.803572.53571%201.232144z%22%20fill%3D%22%23F05129%22%20fill-rule%3D%22evenodd%22%20stroke%3D%22%23fff%22%20stroke-width%3D%22.5%22%20transform%3D%22translate%28-1189%20-368%29%22/%3E%3C/svg%3E');
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2255%22%20viewBox%3D%220%200%2033%2055%22%20width%3D%2233%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22m1221.23218%20395.14282c0%20.428572-.21429.910716-.53571%201.232145l-24.96432%2024.964315c-.32143.321429-.80357.535715-1.23214.535715-.42858%200-.91072-.214286-1.23215-.535715l-2.67857-2.678574c-.32143-.321429-.53572-.750001-.53572-1.232145%200-.428572.21429-.910715.53572-1.232144l21.05359-21.053597-21.05359-21.053596c-.32143-.321429-.53572-.803573-.53572-1.232144%200-.428572.21429-.910716.53572-1.232145l2.67857-2.678574c.32143-.321429.80357-.535715%201.23215-.535715.42857%200%20.91071.214286%201.23214.535715l24.96432%2024.964315c.32142.321429.53571.803572.53571%201.232144z%22%20fill%3D%22%23F05129%22%20fill-rule%3D%22evenodd%22%20stroke%3D%22%23fff%22%20stroke-width%3D%22.5%22%20transform%3D%22translate%28-1189%20-368%29%22/%3E%3C/svg%3E");
 }
 
 .carousel-control-prev-icon {
-    background-image: url('data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2255%22%20viewBox%3D%220%200%2033%2055%22%20width%3D%2233%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22m100.946469%20372.85708c0%20.428571-.214286.910715-.535715%201.232144l-21.0535968%2021.053596%2021.0535968%2021.053597c.321429.321429.535715.803572.535715%201.232144s-.214286.910716-.535715%201.232145l-2.6785749%202.678574c-.321429.321429-.8035724.535715-1.2321444.535715-.4285719%200-.9107153-.214286-1.2321443-.535715l-24.9643155-24.964315c-.3214289-.321429-.5357149-.803573-.5357149-1.232145s.214286-.910715.5357149-1.232144l24.9643155-24.964315c.321429-.321429.8035724-.535715%201.2321443-.535715.428572%200%20.9107154.214286%201.2321444.535715l2.6785749%202.678574c.321429.321429.535715.750001.535715%201.232145z%22%20fill%3D%22%23fff%22%20fill-rule%3D%22evenodd%22%20stroke%3D%22%23333%22%20stroke-width%3D%22.5%22%20transform%3D%22translate%28-69%20-368%29%22/%3E%3C/svg%3E');
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2255%22%20viewBox%3D%220%200%2033%2055%22%20width%3D%2233%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22m100.946469%20372.85708c0%20.428571-.214286.910715-.535715%201.232144l-21.0535968%2021.053596%2021.0535968%2021.053597c.321429.321429.535715.803572.535715%201.232144s-.214286.910716-.535715%201.232145l-2.6785749%202.678574c-.321429.321429-.8035724.535715-1.2321444.535715-.4285719%200-.9107153-.214286-1.2321443-.535715l-24.9643155-24.964315c-.3214289-.321429-.5357149-.803573-.5357149-1.232145s.214286-.910715.5357149-1.232144l24.9643155-24.964315c.321429-.321429.8035724-.535715%201.2321443-.535715.428572%200%20.9107154.214286%201.2321444.535715l2.6785749%202.678574c.321429.321429.535715.750001.535715%201.232145z%22%20fill%3D%22%23fff%22%20fill-rule%3D%22evenodd%22%20stroke%3D%22%23333%22%20stroke-width%3D%22.5%22%20transform%3D%22translate%28-69%20-368%29%22/%3E%3C/svg%3E");
 }
 
 .view-homepage .carousel-control-prev:hover .carousel-control-prev-icon {
-    background-image: url('data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2255%22%20viewBox%3D%220%200%2033%2055%22%20width%3D%2233%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22m100.946469%20372.85708c0%20.428571-.214286.910715-.535715%201.232144l-21.0535968%2021.053596%2021.0535968%2021.053597c.321429.321429.535715.803572.535715%201.232144s-.214286.910716-.535715%201.232145l-2.6785749%202.678574c-.321429.321429-.8035724.535715-1.2321444.535715-.4285719%200-.9107153-.214286-1.2321443-.535715l-24.9643155-24.964315c-.3214289-.321429-.5357149-.803573-.5357149-1.232145s.214286-.910715.5357149-1.232144l24.9643155-24.964315c.321429-.321429.8035724-.535715%201.2321443-.535715.428572%200%20.9107154.214286%201.2321444.535715l2.6785749%202.678574c.321429.321429.535715.750001.535715%201.232145z%22%20fill%3D%22%23F05129%22%20fill-rule%3D%22evenodd%22%20stroke%3D%22%23fff%22%20stroke-width%3D%22.5%22%20transform%3D%22translate%28-69%20-368%29%22/%3E%3C/svg%3E');
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20height%3D%2255%22%20viewBox%3D%220%200%2033%2055%22%20width%3D%2233%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22m100.946469%20372.85708c0%20.428571-.214286.910715-.535715%201.232144l-21.0535968%2021.053596%2021.0535968%2021.053597c.321429.321429.535715.803572.535715%201.232144s-.214286.910716-.535715%201.232145l-2.6785749%202.678574c-.321429.321429-.8035724.535715-1.2321444.535715-.4285719%200-.9107153-.214286-1.2321443-.535715l-24.9643155-24.964315c-.3214289-.321429-.5357149-.803573-.5357149-1.232145s.214286-.910715.5357149-1.232144l24.9643155-24.964315c.321429-.321429.8035724-.535715%201.2321443-.535715.428572%200%20.9107154.214286%201.2321444.535715l2.6785749%202.678574c.321429.321429.535715.750001.535715%201.232145z%22%20fill%3D%22%23F05129%22%20fill-rule%3D%22evenodd%22%20stroke%3D%22%23fff%22%20stroke-width%3D%22.5%22%20transform%3D%22translate%28-69%20-368%29%22/%3E%3C/svg%3E");
 }
 
 .view-homepage .hero-text {
-    font-family: 'Open Sans', sans-serif;
-    max-width: 30em;
+  font-family: "Open Sans", sans-serif;
+  max-width: 30em;
 }
 
 #homepage-contribute-activities {
-    max-width: 100%;
-    margin: auto;
+  max-width: 100%;
+  margin: auto;
 }
 
 .homepage-activity {
-    width: calc(33% - 8px);
-    flex-shrink: 0;
-    flex-grow: 0;
+  width: calc(33% - 8px);
+  flex-shrink: 0;
+  flex-grow: 0;
 }
 
 .homepage-activity a {
-    display: block;
+  display: block;
 }
 
 #homepage-campaign-list .campaign {
-    width: 380px;
+  width: 380px;
 }
 
 #homepage-campaign-list img {
-    width: 368px;
-    height: 262px;
-    display: block;
-    object-fit: cover;
+  width: 368px;
+  height: 262px;
+  display: block;
+  object-fit: cover;
 }
 
 #homepage-campaign-list h3 {
-    /* avoid the text below the images overhanging the image */
-    max-width: 360px;
+  /* avoid the text below the images overhanging the image */
+  max-width: 360px;
 }
 
 @media screen and (max-width: 575px) {
-    .view-homepage h1 {
-        font-size: 2rem;
-    }
+  .view-homepage h1 {
+    font-size: 2rem;
+  }
 
-    .view-homepage p.hero-text {
-        font-size: 95%;
-    }
+  .view-homepage p.hero-text {
+    font-size: 95%;
+  }
 
-    .homepage-activity h4 {
-        font-size: 95%;
-    }
-    .homepage-activity p {
-        font-size: 85%;
-    }
+  .homepage-activity h4 {
+    font-size: 95%;
+  }
+  .homepage-activity p {
+    font-size: 85%;
+  }
 
-    .view-homepage .carousel-control-next,
-    .view-homepage .carousel-control-prev {
-        /*
+  .view-homepage .carousel-control-next,
+  .view-homepage .carousel-control-prev {
+    /*
             the background images are all 1200x480 sized with width:100% so
             we'll set our height to match that aspect ratio plus the control icon height and a bit of padding
         */
-        height: calc((100vw / (1200 / 480)) + 36px + 8px);
-        align-items: flex-end;
-    }
+    height: calc((100vw / (1200 / 480)) + 36px + 8px);
+    align-items: flex-end;
+  }
 
-    .view-homepage .carousel-control-next-icon,
-    .view-homepage .carousel-control-prev-icon {
-        height: 36.5px;
-        width: 22px;
-        filter: invert(1);
-    }
+  .view-homepage .carousel-control-next-icon,
+  .view-homepage .carousel-control-prev-icon {
+    height: 36.5px;
+    width: 22px;
+    filter: invert(1);
+  }
 
-    .view-homepage .carousel-overlay .title {
-        max-width: 70%;
-    }
+  .view-homepage .carousel-overlay .title {
+    max-width: 70%;
+  }
 }
 
 @media screen and (min-width: 720px) {
-    #homepage-carousel {
-        position: relative;
-    }
+  #homepage-carousel {
+    position: relative;
+  }
 
-    #homepage-carousel img {
-        cursor: pointer;
-    }
+  #homepage-carousel img {
+    cursor: pointer;
+  }
 
-    .carousel-overlay {
-        position: absolute;
-        top: 50px;
-        left: 120px;
-        width: 420px;
-        height: 232px;
-        background-color: var(--bg-offwhite);
-        padding: 1rem 1rem 1.3rem 1rem;
-    }
+  .carousel-overlay {
+    position: absolute;
+    top: 50px;
+    left: 120px;
+    width: 420px;
+    height: 232px;
+    background-color: var(--bg-offwhite);
+    padding: 1rem 1rem 1.3rem 1rem;
+  }
 
-    #homepage-carousel[data-overlay-position='top-right'] .carousel-overlay {
-        left: unset;
-        right: 120px;
-    }
+  #homepage-carousel[data-overlay-position="top-right"] .carousel-overlay {
+    left: unset;
+    right: 120px;
+  }
 
-    #homepage-campaign-list .campaign {
-        max-width: 30%;
-    }
+  #homepage-campaign-list .campaign {
+    max-width: 30%;
+  }
 
-    .view-homepage .carousel-control-next {
-        padding-left: 50px;
-    }
+  .view-homepage .carousel-control-next {
+    padding-left: 50px;
+  }
 
-    .view-homepage .carousel-control-prev {
-        padding-right: 50px;
-    }
+  .view-homepage .carousel-control-prev {
+    padding-right: 50px;
+  }
 }
 
 /*
@@ -782,146 +781,146 @@ ul.nav-secondary {
  */
 
 body.view-transcriptions--asset-detail main {
-    min-height: 740px;
-    height: var(--height-main);
-    background-color: inherit;
+  min-height: 740px;
+  height: var(--height-main);
+  background-color: inherit;
 }
 
 #contribute-main-content {
-    position: relative;
+  position: relative;
 }
 
 body.view-transcriptions--asset-detail main,
 #contribute-main-content {
-    /* This avoids browser inconsistencies when using the fullscreen API */
-    background-color: inherit;
+  /* This avoids browser inconsistencies when using the fullscreen API */
+  background-color: inherit;
 }
 
 #contribute-main-content h2 {
-    font-size: inherit;
+  font-size: inherit;
 }
 
 #navigation-container {
-    background-color: var(--control-bg-light);
-    border: solid var(--control-bg-default) 1px;
-    border-bottom: unset;
+  background-color: var(--control-bg-light);
+  border: solid var(--control-bg-default) 1px;
+  border-bottom: unset;
 }
 
 #contribute-container {
-    border: solid var(--control-bg-default) 1px;
+  border: solid var(--control-bg-default) 1px;
 }
 
 .gutter.gutter-horizontal {
-    display: block;
+  display: block;
 
-    position: relative;
+  position: relative;
 
-    cursor: ew-resize;
-    background-color: var(--control-bg-default);
+  cursor: ew-resize;
+  background-color: var(--control-bg-default);
 }
 
 .gutter.gutter-horizontal::after {
-    display: block;
+  display: block;
 
-    position: absolute;
-    top: calc(50% - 40px);
-    left: -4px;
+  position: absolute;
+  top: calc(50% - 40px);
+  left: -4px;
 
-    content: '';
+  content: "";
 
-    height: 40px;
-    width: 16px;
+  height: 40px;
+  width: 16px;
 
-    background: url(../img/handle.svg) no-repeat;
+  background: url(../img/handle.svg) no-repeat;
 }
 
 #transcription-editor textarea {
-    resize: none;
+  resize: none;
 }
 
 #help-container {
-    display: flex;
-    justify-content: end;
-    align-items: center;
+  display: flex;
+  justify-content: end;
+  align-items: center;
 }
 
 #help-container > * {
-    margin: 0.6rem;
+  margin: 0.6rem;
 }
 
 /* Help Center */
 
 .help-center-card {
-    color: #fff;
-    width: 300px;
-    height: 225px;
-    background-color: var(--primary-color);
+  color: #fff;
+  width: 300px;
+  height: 225px;
+  background-color: var(--primary-color);
 }
 
 .help-center-card a {
-    color: #fff;
+  color: #fff;
 }
 
 #faqAccordion {
-    padding-bottom: 20px;
+  padding-bottom: 20px;
 }
 
 #faqAccordion button {
-    color: #333;
+  color: #333;
 }
 
 #faqAccordion .card {
-    border-left: 0;
-    border-right: 0;
+  border-left: 0;
+  border-right: 0;
 }
 
 #faqAccordion .card-header {
-    padding-left: 0;
+  padding-left: 0;
 }
 
 #faqAccordion .card-header button {
-    padding-left: 0;
+  padding-left: 0;
 }
 
 .help-center .nav-link {
-    padding: 0.5rem 0.5rem;
+  padding: 0.5rem 0.5rem;
 }
 
 .help-center a.nav-link {
-    color: #333;
-    font-weight: bold;
+  color: #333;
+  font-weight: bold;
 }
 
 .help-center a.nav-link.active {
-    color: var(--primary-color);
+  color: var(--primary-color);
 }
 
 /* End of help center stuff */
 
 #instruction-window {
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    left: 0;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  left: 0;
 
-    z-index: 10;
+  z-index: 10;
 
-    background-color: rgba(250, 250, 250, 0.8);
-    border-top: 1pt solid var(--bg-darkest-gray);
-    transition: height 1s linear 0;
+  background-color: rgba(250, 250, 250, 0.8);
+  border-top: 1pt solid var(--bg-darkest-gray);
+  transition: height 1s linear 0;
 }
 
 #instruction-window.collapse {
-    display: none;
+  display: none;
 }
 
 #instruction-window.collapse.show {
-    display: block;
+  display: block;
 }
 
 #instruction-window p {
-    max-width: 40em;
-    margin: auto;
+  max-width: 40em;
+  margin: auto;
 }
 
 /*
@@ -929,45 +928,45 @@ body.view-transcriptions--asset-detail main,
  */
 
 #current-tags {
-    border: 0px solid #ccc;
-    border-radius: 0.25rem;
-    list-style-type: none;
+  border: 0px solid #ccc;
+  border-radius: 0.25rem;
+  list-style-type: none;
 
-    max-height: var(--height-contribute-input);
-    max-height: 15vh;
+  max-height: var(--height-contribute-input);
+  max-height: 15vh;
 
-    overflow-y: scroll;
+  overflow-y: scroll;
 }
 
 #current-tags li {
-    margin: 0.375rem;
-    padding: 0.188rem 0.375rem;
-    color: var(--text-color-offwhite);
-    background-color: var(--primary-color);
-    box-shadow: 0 0 0.125rem var(--shadow-color);
-    border-radius: 0.25rem;
+  margin: 0.375rem;
+  padding: 0.188rem 0.375rem;
+  color: var(--text-color-offwhite);
+  background-color: var(--primary-color);
+  box-shadow: 0 0 0.125rem var(--shadow-color);
+  border-radius: 0.25rem;
 
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 #current-tags li > * {
-    margin: 0 0.188rem;
-    padding: 0;
+  margin: 0 0.188rem;
+  padding: 0;
 }
 
-#current-tags [data-role='remove'] {
-    background-color: var(--primary-color-hover);
-    cursor: pointer;
+#current-tags [data-role="remove"] {
+  background-color: var(--primary-color-hover);
+  cursor: pointer;
 }
 
-#current-tags [data-role='remove']:hover:after {
-    background-color: rgba(0, 0, 0, 0.62);
+#current-tags [data-role="remove"]:hover:after {
+  background-color: rgba(0, 0, 0, 0.62);
 }
 
-#current-tags [data-role='remove']:hover:active {
-    box-shadow: inset 0 0.1875rem 0.3125rem rgba(0, 0, 0, 0.125);
+#current-tags [data-role="remove"]:hover:active {
+  box-shadow: inset 0 0.1875rem 0.3125rem rgba(0, 0, 0, 0.125);
 }
 
 /*
@@ -975,14 +974,14 @@ body.view-transcriptions--asset-detail main,
 */
 
 div.related-links {
-    background-color: #ddd;
-    border: #000 1px solid;
+  background-color: #ddd;
+  border: #000 1px solid;
 }
 
 .related-links .list-group-item {
-    background-color: #ddd;
-    border: 0;
-    padding-left: unset;
+  background-color: #ddd;
+  border: 0;
+  padding-left: unset;
 }
 
 /*
@@ -990,43 +989,43 @@ div.related-links {
 */
 
 .alert.alert-primary {
-    background-color: var(--primary-color);
-    border-color: none;
-    color: var(--text-color-offwhite);
+  background-color: var(--primary-color);
+  border-color: none;
+  color: var(--text-color-offwhite);
 }
 
 .alert.alert-secondary {
-    background-color: var(--secondary-color);
-    border-color: none;
-    color: var(--text-color-primary);
+  background-color: var(--secondary-color);
+  border-color: none;
+  color: var(--text-color-primary);
 }
 
 .alert.alert-success {
-    background-color: var(--color-success);
-    border-color: none;
-    color: var(--text-color-offwhite);
+  background-color: var(--color-success);
+  border-color: none;
+  color: var(--text-color-offwhite);
 }
 
 .alert.alert-danger {
-    background-color: var(--color-danger);
-    border-color: none;
-    color: var(--text-color-offwhite);
+  background-color: var(--color-danger);
+  border-color: none;
+  color: var(--text-color-offwhite);
 }
 
 .alert.alert-warning {
-    background-color: var(--color-warning);
-    border-color: none;
-    color: var(--text-color-primary);
+  background-color: var(--color-warning);
+  border-color: none;
+  color: var(--text-color-primary);
 }
 
 .alert.alert-info {
-    background-color: var(--color-info);
-    border-color: none;
-    color: var(--text-color-primary);
+  background-color: var(--color-info);
+  border-color: none;
+  color: var(--text-color-primary);
 }
 
 .alert .close {
-    opacity: 0.8;
+  opacity: 0.8;
 }
 
 /*
@@ -1034,180 +1033,180 @@ div.related-links {
 */
 
 .footer-crowd {
-    background-color: var(--bg-lightest-gray);
-    border-top: 1px solid var(--bg-medium-gray);
-    padding: 22px 0;
+  background-color: var(--bg-lightest-gray);
+  border-top: 1px solid var(--bg-medium-gray);
+  padding: 22px 0;
 }
 
 .footer-crowd-row {
-    max-width: 1200px;
-    padding: 0 1rem;
-    margin: 0 auto;
-    box-sizing: border-box;
+  max-width: 1200px;
+  padding: 0 1rem;
+  margin: 0 auto;
+  box-sizing: border-box;
 }
 @media (min-width: 769px) {
-    .footer-crowd-row {
-        display: flex;
-        padding: 0 2rem;
-    }
+  .footer-crowd-row {
+    display: flex;
+    padding: 0 2rem;
+  }
 }
 .footer-crowd-social {
-    text-align: center;
+  text-align: center;
 }
 @media (min-width: 769px) {
-    .footer-crowd-social {
-        text-align: left;
-        padding-right: 20px;
-    }
+  .footer-crowd-social {
+    text-align: left;
+    padding-right: 20px;
+  }
 }
 @media (min-width: 993px) {
-    .footer-crowd-social {
-        padding-right: 40px;
-    }
+  .footer-crowd-social {
+    padding-right: 40px;
+  }
 }
 .footer-crowd-social > h2 {
-    font-family: inherit;
-    font-weight: normal;
-    line-height: 1.2;
-    color: var(--bg-darkest-gray);
-    font-size: 1.25rem;
-    margin: 0 0 0.75rem;
+  font-family: inherit;
+  font-weight: normal;
+  line-height: 1.2;
+  color: var(--bg-darkest-gray);
+  font-size: 1.25rem;
+  margin: 0 0 0.75rem;
 }
 
 .footer-crowd-social .links-social {
-    margin: 0 -6.5px;
-    display: inline-block;
-    margin-bottom: 0;
+  margin: 0 -6.5px;
+  display: inline-block;
+  margin-bottom: 0;
 }
 
 .footer-crowd-social .links-social > li {
-    display: inline-block;
-    margin: 0 6.5px;
+  display: inline-block;
+  margin: 0 6.5px;
 }
 
 .footer-crowd-links {
-    border-top: 1px solid var(--bg-medium-gray);
-    border-bottom: 1px solid var(--bg-medium-gray);
-    padding: 16px 0;
-    margin: 16px 0;
+  border-top: 1px solid var(--bg-medium-gray);
+  border-bottom: 1px solid var(--bg-medium-gray);
+  padding: 16px 0;
+  margin: 16px 0;
 }
 @media (min-width: 769px) {
-    .footer-crowd-links {
-        flex: 1;
-        border: none;
-        border-left: 1px solid var(--bg-medium-gray);
-        padding: 0;
-        padding-left: 20px;
-        margin: 0;
-    }
+  .footer-crowd-links {
+    flex: 1;
+    border: none;
+    border-left: 1px solid var(--bg-medium-gray);
+    padding: 0;
+    padding-left: 20px;
+    margin: 0;
+  }
 }
 @media (min-width: 993px) {
-    .footer-crowd-links {
-        padding-left: 40px;
-    }
+  .footer-crowd-links {
+    padding-left: 40px;
+  }
 }
 .footer-crowd-links > ul {
-    font-size: 14px;
-    font-weight: bold;
-    margin: 0;
+  font-size: 14px;
+  font-weight: bold;
+  margin: 0;
 }
 .footer-crowd-links > ul > li {
-    margin-bottom: 5px;
-    text-align: center;
+  margin-bottom: 5px;
+  text-align: center;
 }
 @media (min-width: 769px) {
-    .footer-crowd-links > ul > li {
-        text-align: left;
-    }
+  .footer-crowd-links > ul > li {
+    text-align: left;
+  }
 }
 @media (min-width: 769px) {
-    .footer-crowd-links-aside {
-        border-left: 1px solid var(--bg-medium-gray);
-        padding-left: 20px;
-        padding-top: 20px;
-    }
+  .footer-crowd-links-aside {
+    border-left: 1px solid var(--bg-medium-gray);
+    padding-left: 20px;
+    padding-top: 20px;
+  }
 }
 @media (min-width: 993px) {
-    .footer-crowd-links-aside {
-        padding-left: 40px;
-    }
+  .footer-crowd-links-aside {
+    padding-left: 40px;
+  }
 }
 .footer-crowd-links-aside .links-aside {
-    padding-left: 0;
-    list-style: none;
-    text-align: center;
-    margin-bottom: 15px;
+  padding-left: 0;
+  list-style: none;
+  text-align: center;
+  margin-bottom: 15px;
 }
 @media (min-width: 769px) {
-    .footer-crowd-links-aside .links-aside {
-        text-align: left;
-    }
+  .footer-crowd-links-aside .links-aside {
+    text-align: left;
+  }
 }
 .footer-crowd-links-aside .links-aside > li {
-    display: inline-block;
-    font-size: 13px;
-    line-height: 1.1;
+  display: inline-block;
+  font-size: 13px;
+  line-height: 1.1;
 }
 .footer-crowd-links-aside .links-aside > li:not(:last-child) {
-    border-right: 1px solid var(--bg-medium-gray);
-    padding-right: 8px;
-    margin-right: 5px;
+  border-right: 1px solid var(--bg-medium-gray);
+  padding-right: 8px;
+  margin-right: 5px;
 }
 .footer-crowd-links-aside .links-intersites {
-    padding-left: 0;
-    list-style: none;
-    margin: 0 -1rem;
+  padding-left: 0;
+  list-style: none;
+  margin: 0 -1rem;
 }
 .footer-crowd-links-aside .links-intersites > li {
-    display: inline-block;
-    margin: 0 1rem;
+  display: inline-block;
+  margin: 0 1rem;
 }
 .footer-crowd-links-aside .links-intersites > li > a {
-    display: block;
+  display: block;
 }
 
 @media (max-width: 992px) {
-    .footer-crowd-links-aside .links-intersites > li > a {
-        margin: 5px 0;
-    }
+  .footer-crowd-links-aside .links-intersites > li > a {
+    margin: 5px 0;
+  }
 }
 .footer-crowd-links-aside .links-intersites > li.intersites-link-congress > a {
-    width: 125px;
-    height: 30px;
-    background-size: 125px 30px;
-    background: url(../img/congress-gov.svg) no-repeat;
+  width: 125px;
+  height: 30px;
+  background-size: 125px 30px;
+  background: url(../img/congress-gov.svg) no-repeat;
 }
 .footer-crowd-links-aside .links-intersites > li.intersites-link-copyright > a {
-    width: 175px;
-    height: 30px;
-    background-size: 175px 30px;
-    background: url(../img/copyright-gov.svg) no-repeat;
+  width: 175px;
+  height: 30px;
+  background-size: 175px 30px;
+  background: url(../img/copyright-gov.svg) no-repeat;
 }
 @media (max-width: 768px) {
-    .footer-crowd-links-aside .links-intersites {
-        text-align: center;
-    }
+  .footer-crowd-links-aside .links-intersites {
+    text-align: center;
+  }
 }
 .bitmap-icon {
-    display: inline-block;
-    width: 24px;
-    height: 24px;
-    vertical-align: text-top;
-    background-image: url(../img/social-icons-sprite.png);
-    background-position: -200px 0;
-    background-repeat: no-repeat;
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  vertical-align: text-top;
+  background-image: url(../img/social-icons-sprite.png);
+  background-position: -200px 0;
+  background-repeat: no-repeat;
 }
 .bitmap-icon.github-icon {
-    background-position: 0 0;
+  background-position: 0 0;
 }
 .bitmap-icon.twitter-icon {
-    background-position: -40px 0;
+  background-position: -40px 0;
 }
 .bitmap-icon.email-icon {
-    background-position: -80px 0;
+  background-position: -80px 0;
 }
 
 /* Registration page */
 #registration-form-container > .col-md-6 {
-    max-width: 30rem;
+  max-width: 30rem;
 }

--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -60,7 +60,7 @@ main {
     min-height: var(--height-main);
 }
 
-h1 {
+h1, .h1 {
     font-family: 'Roboto Slab', serif;
     font-weight: bold;
     color: var(--text-color-primary);
@@ -355,6 +355,17 @@ ul.nav-secondary {
 .btn.disabled,
 .btn:disabled {
     opacity: 0.3 !important;
+}
+
+.btn-primary-alternative {
+    background-color: var(--primary-color);
+    border-color: var(--primary-color);
+    color: var(--text-color-offwhite);
+}
+.btn-primary-alternative:hover {
+    background-color: var(--primary-color-hover);
+    border-color: var(--primary-color-hover);
+    color: var(--text-color-offwhite);
 }
 
 .btn-secondary {

--- a/concordia/templates/base.html
+++ b/concordia/templates/base.html
@@ -9,7 +9,7 @@
     <title>Crowd: {% block title %}{% if title %}{{ title }}{% else %}Untitled{% endif %}{% endblock title %}</title>
     <link rel="shortcut icon" href="{% static 'favicon.ico' %}">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha256-eSi1q2PG6J7g7ib17yAaWMcrr5GrtohYChqibrV7PBE=" crossorigin="anonymous" />
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Roboto+Slab:400,700" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,700|Roboto+Slab:400,700" rel="stylesheet">
     <link rel="stylesheet" href="{% static 'css/base.css' %}">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css" integrity="sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ" crossorigin="anonymous">
     {% block prefetch %}

--- a/concordia/templates/base.html
+++ b/concordia/templates/base.html
@@ -9,7 +9,7 @@
     <title>Crowd: {% block title %}{% if title %}{{ title }}{% else %}Untitled{% endif %}{% endblock title %}</title>
     <link rel="shortcut icon" href="{% static 'favicon.ico' %}">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha256-eSi1q2PG6J7g7ib17yAaWMcrr5GrtohYChqibrV7PBE=" crossorigin="anonymous" />
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,700|Roboto+Slab" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Roboto+Slab:400,700" rel="stylesheet">
     <link rel="stylesheet" href="{% static 'css/base.css' %}">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css" integrity="sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ" crossorigin="anonymous">
     {% block prefetch %}

--- a/concordia/templates/transcriptions/campaign_list.html
+++ b/concordia/templates/transcriptions/campaign_list.html
@@ -25,7 +25,7 @@
                     </a>
                     <div class="col-md">
                         <p>{{ campaign.short_description|linebreaksbr }}</p>
-                        <a class="btn btn-primary-alternative" href="{% url 'transcriptions:campaign-detail' campaign.slug %}">View Projects</a>
+                        <a class="btn btn-primary" href="{% url 'transcriptions:campaign-detail' campaign.slug %}">View Projects</a>
                     </div>
                 </div>
             </li>

--- a/concordia/templates/transcriptions/campaign_list.html
+++ b/concordia/templates/transcriptions/campaign_list.html
@@ -13,28 +13,24 @@
 {% endblock breadcrumbs %}
 
 {% block main_content %}
-<div class="container-fluid py-3">
-    <div class="row">
-        <div class="d-flex flex-wrap col-12 mb-3 justify-content-around">
-            {% for campaign in campaigns %}
-                <div class="bg-lightest-gray w-100 mb-3">
-                    <div class="row">
-                        <div class="col-12 col-md-8 px-3">
-                            <a href="{% url 'transcriptions:campaign-detail' campaign.slug %}">
-                                <h1 class="campaign-title">{{ campaign.title }}</h1>
-                            </a>
-                            {{ campaign.short_description|linebreaksbr }}
-                        </div>
-                        <div class="col-12 col-md-4">
-                            <a href="{% url 'transcriptions:campaign-detail' campaign.slug %}">
-                            <img src="{{ MEDIA_URL }}{{ campaign.thumbnail_image }}" class="img-fluid" alt="{{ campaign.title }} image">
-                            </a>
-                        </div>
-                    </div>
+<div class="container py-3">
+    <h1 class="mb-5 sr-only">Campaigns</h1>
+    <ul class="list-unstyled">
+        {% for campaign in campaigns %}
+        <li class="p-4 mb-1 bg-footer">
+            <h2 class="h1 mb-3">{{ campaign.title }}</h2>
+            <div class="row">
+                <a class="col-md-5 order-md-2" href="{% url 'transcriptions:campaign-detail' campaign.slug %}">
+                    <p class="mb-2 text-center"><img src="{{ MEDIA_URL }}{{ campaign.thumbnail_image }}" class="img-fluid" alt="{{ campaign.title }} image"></p>
+                </a>
+                <div class="col-md">
+                    <p>{{ campaign.short_description|linebreaksbr }}</p>
+                    <a href="{% url 'transcriptions:campaign-detail' campaign.slug %}" class="btn btn-primary-alternative">View Projects</a>
                 </div>
-            {% endfor %}
-        </div>
-    </div>
+            </div>
+        </li>
+        {% endfor %}
+    </ul>
     <div class="row">
         {% include "fragments/standard-pagination.html" %}
     </div>

--- a/concordia/templates/transcriptions/campaign_list.html
+++ b/concordia/templates/transcriptions/campaign_list.html
@@ -14,7 +14,7 @@
 
 {% block main_content %}
 <div class="container py-3">
-    <h1 class="mb-5 sr-only">Campaigns</h1>
+    <h1 class="sr-only">Campaigns</h1>
     <ul class="list-unstyled">
         {% for campaign in campaigns %}
             <li class="p-4 mb-1 bg-footer">

--- a/concordia/templates/transcriptions/campaign_list.html
+++ b/concordia/templates/transcriptions/campaign_list.html
@@ -17,18 +17,18 @@
     <h1 class="mb-5 sr-only">Campaigns</h1>
     <ul class="list-unstyled">
         {% for campaign in campaigns %}
-        <li class="p-4 mb-1 bg-footer">
-            <h2 class="h1 mb-3">{{ campaign.title }}</h2>
-            <div class="row">
-                <a class="col-md-5 order-md-2" href="{% url 'transcriptions:campaign-detail' campaign.slug %}">
-                    <p class="mb-2 text-center"><img src="{{ MEDIA_URL }}{{ campaign.thumbnail_image }}" class="img-fluid" alt="{{ campaign.title }} image"></p>
-                </a>
-                <div class="col-md">
-                    <p>{{ campaign.short_description|linebreaksbr }}</p>
-                    <a href="{% url 'transcriptions:campaign-detail' campaign.slug %}" class="btn btn-primary-alternative">View Projects</a>
+            <li class="p-4 mb-1 bg-footer">
+                <h2 class="h1 mb-3">{{ campaign.title }}</h2>
+                <div class="row">
+                    <a class="col-md-5 order-md-2" href="{% url 'transcriptions:campaign-detail' campaign.slug %}">
+                        <p class="mb-2 text-center"><img src="{{ MEDIA_URL }}{{ campaign.thumbnail_image }}" class="img-fluid" alt="{{ campaign.title }} image"></p>
+                    </a>
+                    <div class="col-md">
+                        <p>{{ campaign.short_description|linebreaksbr }}</p>
+                        <a class="btn btn-primary-alternative" href="{% url 'transcriptions:campaign-detail' campaign.slug %}">View Projects</a>
+                    </div>
                 </div>
-            </div>
-        </li>
+            </li>
         {% endfor %}
     </ul>
     <div class="row">


### PR DESCRIPTION
concordia/static/css/base.css
* Added class .h1 to match the font styling of a h1. this was needed so that we can use correct heading level `<h2>` in the markup for campaigns list. 
* Since both .btn-primary and .btn-secondary are already reserved, I temporarily created .btn-primary-alternative for orange button. I will work with Jaime for customizing global styles once we start using sass version of bootstrap.

concordia/templates/base.html
* Updated google font customize option for Roboto Slab so it displays the correct font weight (700) when using bold.

concordia/templates/transcriptions/campaign_list.html
* Updated the markup so it’s more meaningful, mainly to convert campaigns list into unordered list. And replaced `<h1>` heading level with `<h2>` for title of campaign list, and added `<h1>Campaigns</h1>` for page heading. 
* Also fine-tuned responsive design by using appropriate bootstrap classes.