### PR TITLE
Remove latest page

### DIFF
--- a/concordia/management/commands/print_frontend_test_urls.py
+++ b/concordia/management/commands/print_frontend_test_urls.py
@@ -24,7 +24,6 @@ class Command(BaseCommand):
         paths = [
             reverse("homepage"),
             reverse("about"),
-            reverse("latest"),
             reverse("contact"),
             # Help pages
             reverse("help-center"),

--- a/concordia/templates/base.html
+++ b/concordia/templates/base.html
@@ -58,9 +58,6 @@
                         <a class="nav-link {% if PATH_LEVEL_1 == 'campaigns' %}active{% endif %}" href="{% url 'transcriptions:campaign-list' %}">Campaigns</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link {% if PATH_LEVEL_1 == 'latest' %}active{% endif %}" href="{% url 'latest' %}">Latest</a>
-                    </li>
-                    <li class="nav-item">
                         <a class="nav-link" href="https://historyhub.history.gov/community/crowd-loc">Discuss</a>
                     </li>
                     <li class="nav-item">

--- a/concordia/urls.py
+++ b/concordia/urls.py
@@ -4,6 +4,7 @@ from django.contrib import admin
 from django.http import Http404, HttpResponseForbidden
 from django.urls import include, path
 from django.views.defaults import page_not_found, permission_denied, server_error
+from django.views.generic import RedirectView
 
 from exporter import views as exporter_views
 
@@ -75,7 +76,10 @@ urlpatterns = [
     path("help-center/how-to-review/", views.simple_page, name="how-to-review"),
     path("help-center/how-to-tag/", views.simple_page, name="how-to-tag"),
     path("for-educators/", views.simple_page, name="for-educators"),
-    path("latest/", views.simple_page, name="latest"),
+    path(
+        "latest/",
+        RedirectView.as_view(pattern_name="about", permanent=True, query_string=True),
+    ),
     path("questions/", views.simple_page, name="questions"),
     path("contact/", views.ContactUsView.as_view(), name="contact"),
     path("campaigns/", include(tx_urlpatterns, namespace="transcriptions")),


### PR DESCRIPTION
This replaces the /latest/ view with a redirect to /about/ 

Closes #781  