### PR TITLE
#734 Added print CSS and bootstrap print display utility classes to t…

### DIFF
--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -252,9 +252,9 @@ p.hero-secondary.offwhite-text {
     background-color: var(--bg-darkest-gray);
 
     background-image: linear-gradient(
-        rgba(250, 250, 250, 0.25),
-        rgba(38, 50, 56, 0.25)
-    ),
+            rgba(250, 250, 250, 0.25),
+            rgba(38, 50, 56, 0.25)
+        ),
         linear-gradient(rgba(51, 51, 51, 1), rgba(51, 51, 51, 1));
 }
 
@@ -264,9 +264,9 @@ p.hero-secondary.offwhite-text {
 
 .bg-img-placeholder:hover {
     background-image: linear-gradient(
-        rgba(252, 76, 2, 0.5),
-        rgba(252, 76, 2, 0.1)
-    ),
+            rgba(252, 76, 2, 0.5),
+            rgba(252, 76, 2, 0.1)
+        ),
         linear-gradient(rgba(189, 189, 189, 1), rgba(189, 189, 189, 1));
 }
 

--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -252,9 +252,9 @@ p.hero-secondary.offwhite-text {
     background-color: var(--bg-darkest-gray);
 
     background-image: linear-gradient(
-            rgba(250, 250, 250, 0.25),
-            rgba(38, 50, 56, 0.25)
-        ),
+        rgba(250, 250, 250, 0.25),
+        rgba(38, 50, 56, 0.25)
+    ),
         linear-gradient(rgba(51, 51, 51, 1), rgba(51, 51, 51, 1));
 }
 
@@ -264,9 +264,9 @@ p.hero-secondary.offwhite-text {
 
 .bg-img-placeholder:hover {
     background-image: linear-gradient(
-            rgba(252, 76, 2, 0.5),
-            rgba(252, 76, 2, 0.1)
-        ),
+        rgba(252, 76, 2, 0.5),
+        rgba(252, 76, 2, 0.1)
+    ),
         linear-gradient(rgba(189, 189, 189, 1), rgba(189, 189, 189, 1));
 }
 
@@ -1211,4 +1211,42 @@ div.related-links {
 /* Registration page */
 #registration-form-container > .col-md-6 {
     max-width: 30rem;
+}
+
+/* print */
+@media print {
+    @page {
+        margin: 0.75in;
+    }
+    body {
+        border-style: none;
+        background-color: transparent;
+        font-size: 14pt;
+    }
+    header .navbar {
+        padding: 0;
+        background-color: transparent;
+    }
+    #navigation-container {
+        border-style: none;
+        padding: 0;
+    }
+    #contribute-container {
+        border-style: none;
+    }
+    #contribute-container #viewer-column {
+        height: 300px;
+    }
+    #contribute-container .gutter-horizontal {
+        display: none;
+    }
+    #contribute-container #editor-column .tx-status-display {
+        font-size: 24px;
+        margin: 2rem 0;
+    }
+    #contribute-container #editor-column .print-transcription-text {
+        display: block !important;
+        white-space: pre-wrap;
+        color: #000;
+    }
 }

--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -1237,6 +1237,11 @@ div.related-links {
     #contribute-container #viewer-column {
         height: 300px;
     }
+
+    #asset-image .openseadragon-container {
+        display: none;
+    }
+
     #contribute-container .gutter-horizontal {
         display: none;
     }

--- a/concordia/static/css/base.css
+++ b/concordia/static/css/base.css
@@ -252,9 +252,9 @@ p.hero-secondary.offwhite-text {
     background-color: var(--bg-darkest-gray);
 
     background-image: linear-gradient(
-            rgba(250, 250, 250, 0.25),
-            rgba(38, 50, 56, 0.25)
-        ),
+        rgba(250, 250, 250, 0.25),
+        rgba(38, 50, 56, 0.25)
+    ),
         linear-gradient(rgba(51, 51, 51, 1), rgba(51, 51, 51, 1));
 }
 
@@ -264,9 +264,9 @@ p.hero-secondary.offwhite-text {
 
 .bg-img-placeholder:hover {
     background-image: linear-gradient(
-            rgba(252, 76, 2, 0.5),
-            rgba(252, 76, 2, 0.1)
-        ),
+        rgba(252, 76, 2, 0.5),
+        rgba(252, 76, 2, 0.1)
+    ),
         linear-gradient(rgba(189, 189, 189, 1), rgba(189, 189, 189, 1));
 }
 
@@ -1234,14 +1234,15 @@ div.related-links {
     #contribute-container {
         border-style: none;
     }
-    #contribute-container #viewer-column {
-        height: 300px;
+    #contribute-container #viewer-column .print-transcription-image {
+        height: 700px;
+        border: thin solid #ccc;
     }
-
-    #asset-image .openseadragon-container {
-        display: none;
+    #contribute-container #viewer-column .print-transcription-image img {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
     }
-
     #contribute-container .gutter-horizontal {
         display: none;
     }
@@ -1252,6 +1253,13 @@ div.related-links {
     #contribute-container #editor-column .print-transcription-text {
         display: block !important;
         white-space: pre-wrap;
+        color: #000;
+    }
+    #current-tags {
+        max-height: none;
+    }
+    #current-tags li {
+        background-color: transparent;
         color: #000;
     }
 }

--- a/concordia/templates/base.html
+++ b/concordia/templates/base.html
@@ -31,9 +31,9 @@
     {% endif %}
 </head>
 
-<body class="view-{{ VIEW_NAME_FOR_CSS }} section-{{ PATH_LEVEL_1|default:'homepage' }} environment-{{ CONCORDIA_ENVIRONMENT }} {% block extra_body_classes %}{% endblock %}">
+<body class="view-{{ VIEW_NAME_FOR_CSS }} section-{{ PATH_LEVEL_1|default:'homepage' }} environment-{{ CONCORDIA_ENVIRONMENT }} {% block extra_body_classes %}{% endblock %} d-print-block">
     <header role="banner" aria-label="site navigation">
-        <nav class="navbar navbar-expand-lg flex-row navbar-offwhite bg-offwhite justify-content-between align-items-end">
+        <nav class="navbar navbar-expand-lg flex-row navbar-offwhite bg-offwhite justify-content-between align-items-end d-print-block">
             <div class="navbar-brand d-flex align-items-stretch">
                 <a href="https://www.loc.gov">
                     <img src="{% static 'img/LoC-logo.svg' %}" alt="Library of Congress logo">
@@ -46,11 +46,11 @@
                     </div>
                 </h1>
             </div>
-            <button class="navbar-toggler navbar-light" type="button" data-toggle="collapse" data-target="#nav-menu" aria-controls="nav-menu" aria-expanded="false" aria-label="Toggle navigation">
+            <button class="navbar-toggler navbar-light d-print-none" type="button" data-toggle="collapse" data-target="#nav-menu" aria-controls="nav-menu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
-            <div class="collapse navbar-collapse text-center" id="nav-menu">
-                <ul class="navbar-nav ml-auto">
+            <div class="collapse navbar-collapse text-center d-print-none" id="nav-menu">
+                <ul class="navbar-nav ml-auto d-print-none">
                     <li class="nav-item">
                         <a class="nav-link {% if PATH_LEVEL_1 == 'about'%}active{% endif %}" href="{% url 'about' %}">About</a>
                     </li>
@@ -78,7 +78,7 @@
                 </ul>
             </div>
 
-            <ul class="nav-secondary anonymous-only list-unstyled d-none d-lg-flex">
+            <ul class="nav-secondary anonymous-only list-unstyled d-none d-lg-flex d-print-none">
                 <li class="nav-item">
                     <a class="nav-link nav-secondary nav-link-login" href="{% url 'login' %}?next={{ request.path|urlencode }}" rel="nofollow">Login</a>
                 </li>
@@ -88,7 +88,7 @@
             </ul>
         </nav>
     </header>
-    <main class="{% block extra_main_classes %}{% endblock %}">
+    <main class="{% block extra_main_classes %}{% endblock %} d-print-block">
         {% block breadcrumbs-container %}
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb bg-offwhite my-0">

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -201,28 +201,30 @@
 
                     <h2>Tags</h2>
 
-                    {% if user.is_authenticated %}
-                        <div class="form-row">
-                            <div class="input-group">
-                                <input type="text" id="new-tag-input" class="form-control" placeholder="Add a new tag…" aria-label="Add a new tag" pattern="[- _'\w]{1,50}">
-                                <div class="input-group-append">
-                                    <button id="new-tag-button" class="btn btn-outline-primary" type="button" title="Add tags to the page">Add</button>
-                                </div>
-                                <div class="invalid-feedback">
-                                    Tags must be between 1-50 characters and may contain only letters, numbers, dashes, underscores, apostrophes, and spaces
+                    <div class="d-print-none">
+                        {% if user.is_authenticated %}
+                            <div class="form-row">
+                                <div class="input-group">
+                                    <input type="text" id="new-tag-input" class="form-control" placeholder="Add a new tag…" aria-label="Add a new tag" pattern="[- _'\w]{1,50}">
+                                    <div class="input-group-append">
+                                        <button id="new-tag-button" class="btn btn-outline-primary" type="button" title="Add tags to the page">Add</button>
+                                    </div>
+                                    <div class="invalid-feedback">
+                                        Tags must be between 1-50 characters and may contain only letters, numbers, dashes, underscores, apostrophes, and spaces
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                    {% else %}
-                        <p class="help-text anonymous-only text-center d-print-none">
-                            Want to tag this page?
+                        {% else %}
+                            <p class="help-text anonymous-only text-center d-print-none">
+                                Want to tag this page?
 
-                            <a href="{% url 'registration_register' %}">Register</a>
-                            or
-                            <a href="{% url 'login' %}?next={{ request.path|urlencode }}">login</a>
-                            to add tags.
-                        </p>
-                    {% endif %}
+                                <a href="{% url 'registration_register' %}">Register</a>
+                                or
+                                <a href="{% url 'login' %}?next={{ request.path|urlencode }}">login</a>
+                                to add tags.
+                            </p>
+                        {% endif %}
+                    </div>
 
                     <ul id="current-tags" class="d-flex flex-wrap list-unstyled mb-0">
                         <li id="tag-template" hidden>

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -118,7 +118,9 @@
                 </div>
             </div>
 
-            <div id="asset-image" class="h-100 bg-dark"></div>
+            <div id="asset-image" class="h-100 bg-dark">
+                <img class="d-none d-print-block img-fluid" alt="Scanned image of the current content page" src="{% asset_media_url asset %}">
+            </div>
         </div>
 
         <div id="editor-column" class="d-flex flex-column flex-nowrap justify-content-between d-print-block">

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -118,7 +118,7 @@
                 </div>
             </div>
             <div id="asset-image" class="h-100 bg-dark d-print-none"></div>
-            <div class="print-transcription-image d-none d-print-block "><img class="img-fluid" alt="Scanned image of the current content page" src="{% asset_media_url asset %}"></div>
+            <div class="print-transcription-image d-none d-print-block"><img class="img-fluid" alt="Scanned image of the current content page" src="{% asset_media_url asset %}"></div>
         </div>
 
         <div id="editor-column" class="d-flex flex-column flex-nowrap justify-content-between d-print-block">

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -24,7 +24,7 @@
 
 {% block main_content %}
 <div id="contribute-main-content" class="container-fluid flex-grow-1 d-flex flex-column d-print-block">
-    <div id="navigation-container" class="row p-2 d-print-block">
+    <div id="navigation-container" class="row p-2 d-print-none">
         <nav id="asset-navigation" class="d-flex flex-grow-1 justify-content-between align-items-center d-print-block" role="navigation">
             <div class="d-flex align-items-center">
                 <form onsubmit="document.location.href = document.getElementById('asset-selection').value; return false">
@@ -43,7 +43,7 @@
                     </div>
                 </form>
 
-                <div class="btn-group btn-group-sm ml-2 d-print-none">
+                <div class="btn-group btn-group-sm ml-2">
                     <a class="btn btn-default {% if not previous_asset_url %}disabled{% endif %}" {% if previous_asset_url %}href="{{ previous_asset_url }}"{% else %}aria-disabled="true"{% endif %}>
                         <span class="fas fa-chevron-left"></span>
                         <span class="sr-only">Previous Page</span>
@@ -56,19 +56,19 @@
             </div>
 
             {% if asset.resource_url %}
-                <div class="btn-group btn-group-sm ml-2 d-print-none">
+                <div class="btn-group btn-group-sm ml-2">
                     <a class="btn btn-default" target="_blank" href="{{ asset.resource_url }}?sp={{ asset.sequence }}">View on www.loc.gov</a>
                 </div>
             {% endif %}
 
-            <div class="btn-group btn-group-sm ml-2 d-print-none">
+            <div class="btn-group btn-group-sm ml-2">
                 <button hidden id="go-fullscreen" class="btn btn-default" data-target="contribute-main-content">
                     <span class="fas fa-arrows-alt"></span>
                     Fullscreen
                 </button>
             </div>
 
-            <div class="btn-group btn-group-sm align-self-end d-print-none" role="navigation" aria-label="Link to the next editable page">
+            <div class="btn-group btn-group-sm align-self-end" role="navigation" aria-label="Link to the next editable page">
                 <a class="btn btn-default" title="Move to the next page in this item that needs help" href="{{ next_open_asset_url }}">Find a new page &rarr;</a>
           </div>
         </nav>
@@ -117,10 +117,8 @@
                     </div>
                 </div>
             </div>
-
-            <div id="asset-image" class="h-100 bg-dark">
-                <img class="d-none d-print-block img-fluid" alt="Scanned image of the current content page" src="{% asset_media_url asset %}">
-            </div>
+            <div id="asset-image" class="h-100 bg-dark d-print-none"></div>
+            <div class="print-transcription-image d-none d-print-block "><img class="img-fluid" alt="Scanned image of the current content page" src="{% asset_media_url asset %}"></div>
         </div>
 
         <div id="editor-column" class="d-flex flex-column flex-nowrap justify-content-between d-print-block">
@@ -216,7 +214,7 @@
                             </div>
                         </div>
                     {% else %}
-                        <p class="help-text anonymous-only text-center">
+                        <p class="help-text anonymous-only text-center d-print-none">
                             Want to tag this page?
 
                             <a href="{% url 'registration_register' %}">Register</a>

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -23,9 +23,9 @@
 {% block extra_main_classes %}flex-grow-1 d-flex flex-column{% endblock %}
 
 {% block main_content %}
-<div id="contribute-main-content" class="container-fluid flex-grow-1 d-flex flex-column">
-    <div id="navigation-container" class="row p-2">
-        <nav id="asset-navigation" class="d-flex flex-grow-1 justify-content-between align-items-center" role="navigation">
+<div id="contribute-main-content" class="container-fluid flex-grow-1 d-flex flex-column d-print-block">
+    <div id="navigation-container" class="row p-2 d-print-block">
+        <nav id="asset-navigation" class="d-flex flex-grow-1 justify-content-between align-items-center d-print-block" role="navigation">
             <div class="d-flex align-items-center">
                 <form onsubmit="document.location.href = document.getElementById('asset-selection').value; return false">
                     <div class="input-group input-group-sm">
@@ -43,7 +43,7 @@
                     </div>
                 </form>
 
-                <div class="btn-group btn-group-sm ml-2">
+                <div class="btn-group btn-group-sm ml-2 d-print-none">
                     <a class="btn btn-default {% if not previous_asset_url %}disabled{% endif %}" {% if previous_asset_url %}href="{{ previous_asset_url }}"{% else %}aria-disabled="true"{% endif %}>
                         <span class="fas fa-chevron-left"></span>
                         <span class="sr-only">Previous Page</span>
@@ -56,26 +56,26 @@
             </div>
 
             {% if asset.resource_url %}
-                <div class="btn-group btn-group-sm ml-2">
+                <div class="btn-group btn-group-sm ml-2 d-print-none">
                     <a class="btn btn-default" target="_blank" href="{{ asset.resource_url }}?sp={{ asset.sequence }}">View on www.loc.gov</a>
                 </div>
             {% endif %}
 
-            <div class="btn-group btn-group-sm ml-2">
+            <div class="btn-group btn-group-sm ml-2 d-print-none">
                 <button hidden id="go-fullscreen" class="btn btn-default" data-target="contribute-main-content">
                     <span class="fas fa-arrows-alt"></span>
                     Fullscreen
                 </button>
             </div>
 
-            <div class="btn-group btn-group-sm align-self-end" role="navigation" aria-label="Link to the next editable page">
+            <div class="btn-group btn-group-sm align-self-end d-print-none" role="navigation" aria-label="Link to the next editable page">
                 <a class="btn btn-default" title="Move to the next page in this item that needs help" href="{{ next_open_asset_url }}">Find a new page &rarr;</a>
           </div>
         </nav>
     </div>
-    <div id="contribute-container" class="row flex-grow-1 pb-2">
-        <div id="viewer-column" class="pl-0 d-flex flex-column align-items-stretch bg-dark">
-            <div id="viewer-controls" class="m-1 text-center">
+    <div id="contribute-container" class="row flex-grow-1 pb-2 d-print-block">
+        <div id="viewer-column" class="pl-0 d-flex flex-column align-items-stretch bg-dark d-print-block">
+            <div id="viewer-controls" class="m-1 text-center d-print-none">
                 <div class="d-inline-flex justify-content-between">
                     <div class="d-flex btn-group btn-group-sm m-1">
                         <button id="viewer-home" class="btn btn-default">
@@ -121,8 +121,8 @@
             <div id="asset-image" class="h-100 bg-dark"></div>
         </div>
 
-        <div id="editor-column" class="d-flex flex-column flex-nowrap justify-content-between">
-            <div class="flex-grow-1 d-flex flex-column">
+        <div id="editor-column" class="d-flex flex-column flex-nowrap justify-content-between d-print-block">
+            <div class="flex-grow-1 d-flex flex-column d-print-block">
                 <div class="tx-status-display">
                     <span class="tx-submitted" {% if transcription_status != 'submitted' %}hidden{% endif %}>
                         <span class="fas fa-list"></span>
@@ -146,16 +146,18 @@
                     </span>
                 </div>
 
-                <form id="transcription-editor" class="ajax-submission flex-grow-1 d-flex flex-column" method="post" action="{% url 'save-transcription' asset_pk=asset.pk %}" data-transcription-status="{{ transcription_status }}" {% if transcription %}data-transcription-id="{{ transcription.pk|default:'' }}" {% if transcription.submitted %}data-unsaved-changes="true"{% endif %} data-submit-url="{% url 'submit-transcription' pk=transcription.pk %}" data-review-url="{% url 'review-transcription' pk=transcription.pk %}"{% endif %}>
+                <form id="transcription-editor" class="ajax-submission flex-grow-1 d-flex flex-column d-print-block" method="post" action="{% url 'save-transcription' asset_pk=asset.pk %}" data-transcription-status="{{ transcription_status }}" {% if transcription %}data-transcription-id="{{ transcription.pk|default:'' }}" {% if transcription.submitted %}data-unsaved-changes="true"{% endif %} data-submit-url="{% url 'submit-transcription' pk=transcription.pk %}" data-review-url="{% url 'review-transcription' pk=transcription.pk %}"{% endif %}>
                     {% csrf_token %}
                     <input type="hidden" name="supersedes" value="{{ transcription.pk|default:'' }}" />
 
                     <h2>Transcription</h2>
 
                     {% spaceless %}
-                        <textarea readonly class="form-control w-100 rounded flex-grow-1" name="text" id="transcription-input" placeholder="{% if transcription_status == 'not_started' or transcription_status == 'in_progress' %}Go ahead, start typing. You got this!{% else %}Nothing to transcribe{% endif %}" aria-label="Transcription input">
+                        <textarea readonly class="form-control w-100 rounded flex-grow-1 d-print-none" name="text" id="transcription-input" placeholder="{% if transcription_status == 'not_started' or transcription_status == 'in_progress' %}Go ahead, start typing. You got this!{% else %}Nothing to transcribe{% endif %}" aria-label="Transcription input">
                             {{ transcription.text }}
                         </textarea>
+
+                        <div class="print-transcription-text" aria-hidden="true" style="display: none;">{{ transcription.text }}</div>
 
                         <div class="my-3 d-flex flex-wrap justify-content-around align-items-center btn-row">
                             {% if transcription_status == 'not_started' or transcription_status == 'in_progress' %}
@@ -253,7 +255,7 @@
             </div>
         </div>
     </div>
-    <div id="help-container" class="row justify-content-center">
+    <div id="help-container" class="row justify-content-center d-print-none">
         <p>Need help?</p>
 
         <button id="instruction-button" class="btn btn-secondary" type="button" data-toggle="collapse" data-target="#instruction-window" aria-expanded="false" aria-controls="instruction-window">

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -159,7 +159,7 @@
 
                         <div class="print-transcription-text" aria-hidden="true" style="display: none;">{{ transcription.text }}</div>
 
-                        <div class="my-3 d-flex flex-wrap justify-content-around align-items-center btn-row">
+                        <div class="my-3 d-print-none d-flex flex-wrap justify-content-around align-items-center btn-row">
                             {% if transcription_status == 'not_started' or transcription_status == 'in_progress' %}
                                 <div class="form-check w-100 text-center mt-0 mb-3">
                                     <input id="nothing-to-transcribe" type="checkbox" class="form-check-input" />


### PR DESCRIPTION
1) Since `textarea` cannot be resized to fit its content, it'd get cut off when content is longer than the specified height. To resolve this, I've added a dedicated container for printing a transcription `<div class="print-transcription-text" aria-hidden="true" style="display: none;">{{ transcription.text }}</div>` which will only be available when the page is printed. 
2) Firefox has some issues printing flexbox elements. A workaround is to replace `display: flex` with `display: block`,  which can be accomplished by adding `.d-print-block` class.
~https://bugzilla.mozilla.org/show_bug.cgi?id=258397 (duplicate of 939897)~
~https://bugzilla.mozilla.org/show_bug.cgi?id=1414253 (duplicate of 939897)~
https://stackoverflow.com/questions/45414152/css-flex-box-not-printing-all-pages-on-firefox
https://bugzilla.mozilla.org/show_bug.cgi?id=939897
3) In most cases, `.d-print-none` (hide) and `.d-print-block` (block element) were enough to style the print screen, a small block of CSS has been added for the ones that needed additional styling.
4) I’m having difficulty scaling the image in OpenSeadragon and keep the aspect ratio. @acdha and @rstorey: Can you please take a look?