### PR TITLE
Add Python dependency version check to CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,6 @@ script:
     - ./manage.py test concordia importer exporter
     - coverage run ./manage.py test concordia importer exporter
     - git diff --name-only $TRAVIS_COMMIT_RANGE | xargs pre-commit run --files
+    - pipenv check
 after_success:
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
     # We install pre-commit outside of the virtualenv to avoid issues with pipenv / pip
     # in the Travis CI Python 3.6 environment. Once we upgrade to Python 3.7 this will
     # no longer be necessary:
-    - pip install coveralls "pipenv>=2018.11.26" pre-commit
+    - pip install coveralls "pipenv>=2018.11.26" pre-commit safety
     - pipenv install --dev --deploy
 script:
     - mkdir logs
@@ -30,6 +30,6 @@ script:
     - ./manage.py test concordia importer exporter
     - coverage run ./manage.py test concordia importer exporter
     - git diff --name-only $TRAVIS_COMMIT_RANGE | xargs pre-commit run --files
-    - pipenv check
+    - safety check
 after_success:
     - coveralls

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "eslint": "^5.8.0",
         "eslint-plugin-prettier": "^3.0.0",
         "imagemin": "^6.0.0",
-        "imagemin-advpng": "^4.0.0",
+        "imagemin-advpng": "^5.0.0",
         "imagemin-jpegoptim": "^6.0.0",
         "imagemin-jpegtran": "^6.0.0",
         "imagemin-mozjpeg": "^8.0.0",


### PR DESCRIPTION
This makes it harder to miss any Python packages which need updating. I'm tempted to toss in `npm audit` but that will currently fail due to imagemin-advpng pulling in a dependency which is not an issue since it's only used for local developer tools but will fail a simple version scan.