### PR TITLE
Remove crowd-prod.loc.gov canonical host name from task definition

### DIFF
--- a/cloudformation/master.yaml
+++ b/cloudformation/master.yaml
@@ -92,7 +92,6 @@ Parameters:
             - "crowd-dev.loc.gov"
             - "crowd-test.loc.gov"
             - "crowd-stage.loc.gov"
-            - "crowd-prod.loc.gov"
             - "crowd.loc.gov"
 
 Resources:


### PR DESCRIPTION
Remove crowd-prod.loc.gov from list of allowed canonical host name values

The task definition in AWS has already been updated.