### PR TITLE
Add template blocks for major page components

### DIFF
--- a/concordia/templates/base.html
+++ b/concordia/templates/base.html
@@ -32,132 +32,138 @@
 </head>
 
 <body class="view-{{ VIEW_NAME_FOR_CSS }} section-{{ PATH_LEVEL_1|default:'homepage' }} environment-{{ CONCORDIA_ENVIRONMENT }} {% block extra_body_classes %}{% endblock %} d-print-block">
-    <header role="banner" aria-label="site navigation">
-        <nav class="navbar navbar-expand-lg flex-row navbar-offwhite bg-offwhite justify-content-between align-items-end d-print-block">
-            <div class="navbar-brand d-flex align-items-stretch">
-                <a href="https://www.loc.gov">
-                    <img src="{% static 'img/LoC-logo.svg' %}" alt="Library of Congress logo">
-                </a>
-                <span class="d-none d-sm-block vl mx-2"></span>
-                <h1 class="header-text m-0 d-none d-sm-flex align-items-center">
-                    <div>
-                        <a class="gray-text" href="/">Crowd</a>
-                        <span class="beta-label">beta</span>
-                    </div>
-                </h1>
-            </div>
-            <button class="navbar-toggler navbar-light d-print-none" type="button" data-toggle="collapse" data-target="#nav-menu" aria-controls="nav-menu" aria-expanded="false" aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
-            </button>
-            <div class="collapse navbar-collapse text-center d-print-none" id="nav-menu">
-                <ul class="navbar-nav ml-auto d-print-none">
-                    <li class="nav-item">
-                        <a class="nav-link {% if PATH_LEVEL_1 == 'about'%}active{% endif %}" href="{% url 'about' %}">About</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link {% if PATH_LEVEL_1 == 'campaigns' %}active{% endif %}" href="{% url 'transcriptions:campaign-list' %}">Campaigns</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="https://historyhub.history.gov/community/crowd-loc">Discuss</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link {% if PATH_LEVEL_1 == 'help-center' %}active{% endif %}" href="{% url 'help-center' %}">Help</a>
-                    </li>
-                    <li id="topnav-account-dropdown" class="nav-item dropdown nav-dropdown authenticated-only" hidden>
-                        <a id="topnav-account-dropdown-toggle" class="nav-link dropdown-toggle {% if PATH_LEVEL_1 == 'account'%}active{% endif %}" href="{% url 'user-profile' %}" rel="nofollow" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Account</a>
-                        <div class="dropdown-menu" aria-labelledby="topnav-account-dropdown-toggle">
-                            <a class="dropdown-item" href="{% url 'logout' %}" rel="nofollow">Logout</a>
+    {% block site-header %}
+        <header role="banner" aria-label="site navigation">
+            <nav class="navbar navbar-expand-lg flex-row navbar-offwhite bg-offwhite justify-content-between align-items-end d-print-block">
+                <div class="navbar-brand d-flex align-items-stretch">
+                    <a href="https://www.loc.gov">
+                        <img src="{% static 'img/LoC-logo.svg' %}" alt="Library of Congress logo">
+                    </a>
+                    <span class="d-none d-sm-block vl mx-2"></span>
+                    <h1 class="header-text m-0 d-none d-sm-flex align-items-center">
+                        <div>
+                            <a class="gray-text" href="/">Crowd</a>
+                            <span class="beta-label">beta</span>
                         </div>
+                    </h1>
+                </div>
+                <button class="navbar-toggler navbar-light d-print-none" type="button" data-toggle="collapse" data-target="#nav-menu" aria-controls="nav-menu" aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+                <div class="collapse navbar-collapse text-center d-print-none" id="nav-menu">
+                    <ul class="navbar-nav ml-auto d-print-none">
+                        <li class="nav-item">
+                            <a class="nav-link {% if PATH_LEVEL_1 == 'about'%}active{% endif %}" href="{% url 'about' %}">About</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link {% if PATH_LEVEL_1 == 'campaigns' %}active{% endif %}" href="{% url 'transcriptions:campaign-list' %}">Campaigns</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="https://historyhub.history.gov/community/crowd-loc">Discuss</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link {% if PATH_LEVEL_1 == 'help-center' %}active{% endif %}" href="{% url 'help-center' %}">Help</a>
+                        </li>
+                        <li id="topnav-account-dropdown" class="nav-item dropdown nav-dropdown authenticated-only" hidden>
+                            <a id="topnav-account-dropdown-toggle" class="nav-link dropdown-toggle {% if PATH_LEVEL_1 == 'account'%}active{% endif %}" href="{% url 'user-profile' %}" rel="nofollow" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Account</a>
+                            <div class="dropdown-menu" aria-labelledby="topnav-account-dropdown-toggle">
+                                <a class="dropdown-item" href="{% url 'logout' %}" rel="nofollow">Logout</a>
+                            </div>
+                        </li>
+                        <li class="nav-item anonymous-only">
+                            <a class="nav-link d-lg-none" href="{% url 'login' %}?next={{ request.path|urlencode }}" rel="nofollow">Login</a>
+                        </li>
+                        <li class="nav-item anonymous-only">
+                            <a class="nav-link d-lg-none" href="{% url 'registration_register' %}" rel="nofollow">Register</a>
+                        </li>
+                    </ul>
+                </div>
+
+                <ul class="nav-secondary anonymous-only list-unstyled d-none d-lg-flex d-print-none">
+                    <li class="nav-item">
+                        <a class="nav-link nav-secondary nav-link-login" href="{% url 'login' %}?next={{ request.path|urlencode }}" rel="nofollow">Login</a>
                     </li>
-                    <li class="nav-item anonymous-only">
-                        <a class="nav-link d-lg-none" href="{% url 'login' %}?next={{ request.path|urlencode }}" rel="nofollow">Login</a>
-                    </li>
-                    <li class="nav-item anonymous-only">
-                        <a class="nav-link d-lg-none" href="{% url 'registration_register' %}" rel="nofollow">Register</a>
+                    <li class="nav-item">
+                        <a class="nav-link nav-secondary nav-link-register" href="{% url 'registration_register' %}" rel="nofollow">Register</a>
                     </li>
                 </ul>
-            </div>
-
-            <ul class="nav-secondary anonymous-only list-unstyled d-none d-lg-flex d-print-none">
-                <li class="nav-item">
-                    <a class="nav-link nav-secondary nav-link-login" href="{% url 'login' %}?next={{ request.path|urlencode }}" rel="nofollow">Login</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link nav-secondary nav-link-register" href="{% url 'registration_register' %}" rel="nofollow">Register</a>
-                </li>
-            </ul>
-        </nav>
-    </header>
-    <main class="{% block extra_main_classes %}{% endblock %} d-print-block">
-        {% block breadcrumbs-container %}
-            <nav aria-label="breadcrumb">
-                <ol class="breadcrumb bg-offwhite my-0">
-                    <li class="breadcrumb-item"><a class="primary-text" href="/">Home</a></li>
-                    {% block breadcrumbs %}{% endblock breadcrumbs %}
-                </ol>
             </nav>
-        {% endblock breadcrumbs-container %}
+        </header>
+    {% endblock site-header %}
+    {% block site-main %}
+        <main class="{% block extra_main_classes %}{% endblock %} d-print-block">
+            {% block breadcrumbs-container %}
+                <nav aria-label="breadcrumb">
+                    <ol class="breadcrumb bg-offwhite my-0">
+                        <li class="breadcrumb-item"><a class="primary-text" href="/">Home</a></li>
+                        {% block breadcrumbs %}{% endblock breadcrumbs %}
+                    </ol>
+                </nav>
+            {% endblock breadcrumbs-container %}
 
-        {% block messages-container %}
-            <div id="messages" class="row" hidden>
-                <div hidden id="message-template">
-                    {% comment %} This is a hidden <div> rather than <template> because it's not worth dealing with IE11 compatibility {% endcomment %}
-                    <div class="alert alert-dismissible w-100" role="alert">
-                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+            {% block messages-container %}
+                <div id="messages" class="row" hidden>
+                    <div hidden id="message-template">
+                        {% comment %} This is a hidden <div> rather than <template> because it's not worth dealing with IE11 compatibility {% endcomment %}
+                        <div class="alert alert-dismissible w-100" role="alert">
+                            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                <span aria-hidden="true">&times;</span>
+                            </button>
+                        </div>
                     </div>
                 </div>
-            </div>
-        {% endblock messages-container %}
+            {% endblock messages-container %}
 
-        {% block main_content %}{% endblock main_content %}
-    </main>
-    <footer class="footer-crowd footer d-print-none" role="contentinfo">
-        <div class="footer-crowd-row">
-            <div class="footer-crowd-social">
-                <h2>Follow Us</h2>
-                <ul class="links-social list-unstyled">
-                    <li class="link-github">
-                        <a href="https://github.com/LibraryOfCongress/concordia" title="GitHub">
-                            <span class="bitmap-icon github-icon"></span>
-                        </a>
-                    </li>
-                    <li class="link-twitter">
-                        <a href="https://www.twitter.com/Crowd_LOC" title="Twitter">
-                            <span class="bitmap-icon twitter-icon"></span>
-                        </a>
-                    </li>
-                    <li class="link-email">
-                        <a href="https://updates.loc.gov/accounts/USLOC/subscriber/new?topic_id=USLOC_175" title="Newsletter">
-                            <span class="bitmap-icon email-icon"></span>
-                        </a>
-                    </li>
-                </ul>
-            </div>
-            <div class="footer-crowd-links">
-                <ul class="list-unstyled">
-                    <li><a href="/for-educators/">For Educators</a></li>
-                    <li><a href="https://historyhub.history.gov/community/crowd-loc">Discuss</a></li>
-                    <li><a href="/contact/">Contact Us</a></li>
-                    <li><a href="/help-center/">Help</a></li>
-                </ul>
-            </div>
-            <div class="footer-crowd-links-aside">
-                <ul class="links-aside list-unstyled">
-                    <li><a href="https://www.loc.gov/accessibility/">Accessibility</a></li>
-                    <li><a href="https://www.loc.gov/legal/">Legal</a></li>
-                    <li><a href="https://www.loc.gov/about/office-of-the-inspector-general/">Inspector General</a></li>
-                    <li><a href="https://www.loc.gov/legal/standard-disclaimer-for-external-links/">External Link Disclaimer</a></li>
-                </ul>
+            {% block main_content %}{% endblock main_content %}
+        </main>
+    {% endblock site-main %}
+    {% block site-footer %}
+        <footer class="footer-crowd footer d-print-none" role="contentinfo">
+            <div class="footer-crowd-row">
+                <div class="footer-crowd-social">
+                    <h2>Follow Us</h2>
+                    <ul class="links-social list-unstyled">
+                        <li class="link-github">
+                            <a href="https://github.com/LibraryOfCongress/concordia" title="GitHub">
+                                <span class="bitmap-icon github-icon"></span>
+                            </a>
+                        </li>
+                        <li class="link-twitter">
+                            <a href="https://www.twitter.com/Crowd_LOC" title="Twitter">
+                                <span class="bitmap-icon twitter-icon"></span>
+                            </a>
+                        </li>
+                        <li class="link-email">
+                            <a href="https://updates.loc.gov/accounts/USLOC/subscriber/new?topic_id=USLOC_175" title="Newsletter">
+                                <span class="bitmap-icon email-icon"></span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="footer-crowd-links">
+                    <ul class="list-unstyled">
+                        <li><a href="/for-educators/">For Educators</a></li>
+                        <li><a href="https://historyhub.history.gov/community/crowd-loc">Discuss</a></li>
+                        <li><a href="/contact/">Contact Us</a></li>
+                        <li><a href="/help-center/">Help</a></li>
+                    </ul>
+                </div>
+                <div class="footer-crowd-links-aside">
+                    <ul class="links-aside list-unstyled">
+                        <li><a href="https://www.loc.gov/accessibility/">Accessibility</a></li>
+                        <li><a href="https://www.loc.gov/legal/">Legal</a></li>
+                        <li><a href="https://www.loc.gov/about/office-of-the-inspector-general/">Inspector General</a></li>
+                        <li><a href="https://www.loc.gov/legal/standard-disclaimer-for-external-links/">External Link Disclaimer</a></li>
+                    </ul>
 
-                <ul class="links-intersites list-unstyled">
-                    <li class="intersites-link-congress"><a href="https://www.congress.gov/" aria-label="Congress.gov"></a></li>
-                    <li class="intersites-link-copyright"><a href="https://copyright.gov" aria-label="United States Copyright Office"></a></li>
-                </ul>
+                    <ul class="links-intersites list-unstyled">
+                        <li class="intersites-link-congress"><a href="https://www.congress.gov/" aria-label="Congress.gov"></a></li>
+                        <li class="intersites-link-copyright"><a href="https://copyright.gov" aria-label="United States Copyright Office"></a></li>
+                    </ul>
+                </div>
             </div>
-        </div>
-    </footer>
+        </footer>
+    {% endblock site-footer %}
 
     {% if SENTRY_FRONTEND_DSN %}
         <script src="https://cdnjs.cloudflare.com/ajax/libs/raven.js/3.26.1/raven.min.js" integrity="sha256-N3YzTdAC27tvNKpIM2rly/WvlJf8YAat0NjPXgh5Bw4=" crossorigin="anonymous"></script>


### PR DESCRIPTION
This allows pages to override the core page structure when needed. It's probably easiest to compare ignoring whitespace since it's only 3 `{% block %}` tags but indentation adds a lot of noise.