### PR TITLE
Enable SonarQube scans using sonarcloud.io OSS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ env:
     - DJANGO_SETTINGS_MODULE=concordia.settings_test
 dist: xenial
 sudo: required
+addons:
+    sonarcloud:
+        organization: 'libraryofcongress'
 python:
     - '3.6'
     - '3.7'
@@ -31,5 +34,6 @@ script:
     - coverage run ./manage.py test concordia importer exporter
     - git diff --name-only $TRAVIS_COMMIT_RANGE | xargs pre-commit run --files
     - safety check
+    - sonar-scanner -Dsonar.projectKey=libraryofcongress_concordia -Dsonar.organization=libraryofcongress -Dsonar.sources=. -Dsonar.host.url=https://sonarcloud.io
 after_success:
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 env:
-    - DJANGO_SETTINGS_MODULE=concordia.settings_test
-    - PIPENV_IGNORE_VIRTUALENVS=1
+    global:
+        - PIPENV_IGNORE_VIRTUALENVS=1
+        - DJANGO_SETTINGS_MODULE=concordia.settings_test
 dist: xenial
 sudo: required
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ dist: xenial
 sudo: required
 addons:
     sonarcloud:
-        organization: 'libraryofcongress'
+        organization: "libraryofcongress"
 python:
-    - '3.6'
-    - '3.7'
-    - '3.7-dev'
-    - '3.8-dev'
+    - "3.6"
+    - "3.7"
+    - "3.7-dev"
+    - "3.8-dev"
 matrix:
     allow_failures:
         - python: 3.7-dev
@@ -34,6 +34,6 @@ script:
     - coverage run ./manage.py test concordia importer exporter
     - git diff --name-only $TRAVIS_COMMIT_RANGE | xargs pre-commit run --files
     - safety check
-    - sonar-scanner -Dsonar.projectKey=libraryofcongress_concordia -Dsonar.organization=libraryofcongress -Dsonar.sources=. -Dsonar.host.url=https://sonarcloud.io
+    - sonar-scanner
 after_success:
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,17 +26,18 @@ install:
     # We install pre-commit outside of the virtualenv to avoid issues with pipenv / pip
     # in the Travis CI Python 3.6 environment. Once we upgrade to Python 3.7 this will
     # no longer be necessary:
-    - pip install coveralls "pipenv>=2018.11.26" pre-commit safety
+    - pip install coveralls "pipenv>=2018.11.26" pre-commit
     - pipenv install --dev --deploy
+    # We want to have safety available but aren't putting it in the dev tools:
+    - pipenv run pip install safety
 script:
     - mkdir logs
     - touch ./logs/concordia-celery.log
-    - ./manage.py collectstatic --no-input
-    - ./manage.py test concordia importer exporter
-    - coverage run ./manage.py test concordia importer exporter
-    - coverage xml
+    - pipenv run ./manage.py collectstatic --no-input
+    - pipenv run coverage run ./manage.py test concordia importer exporter
     - git diff --name-only $TRAVIS_COMMIT_RANGE | xargs pre-commit run --files
-    - safety check
-    - sonar-scanner
+    - pipenv run safety check
 after_success:
+    - pipenv run coverage xml
     - coveralls
+    - sonar-scanner

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ script:
     - ./manage.py collectstatic --no-input
     - ./manage.py test concordia importer exporter
     - coverage run ./manage.py test concordia importer exporter
+    - coverage xml
     - git diff --name-only $TRAVIS_COMMIT_RANGE | xargs pre-commit run --files
     - safety check
     - sonar-scanner

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 env:
     - DJANGO_SETTINGS_MODULE=concordia.settings_test
+    - PIPENV_IGNORE_VIRTUALENVS=1
 dist: xenial
 sudo: required
 addons:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.exclusions=**/tests/**, node_modules/**, htmlcov/**, static-files/**, concordia/settings_dev*, concordia/settings_test*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,3 +3,4 @@ sonar.sources=.
 sonar.projectKey=LibraryOfCongress_concordia
 sonar.organization=libraryofcongress
 sonar.host.url=https://sonarcloud.io
+sonar.python.coverage.reportPaths=coverage.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,5 @@
 sonar.exclusions=**/tests/**, node_modules/**, htmlcov/**, static-files/**, concordia/settings_dev*, concordia/settings_test*
+sonar.sources=.
+sonar.projectKey=LibraryOfCongress_concordia
+sonar.organization=libraryofcongress
+sonar.host.url=https://sonarcloud.io


### PR DESCRIPTION
This should enable code-quality scans on sonarcloud.io as soon as the Travis job is updated to set the `SONAR_TOKEN` environmental variable.