### PR TITLE
Removing colon from email field

### DIFF
--- a/concordia/templates/emails/contact_us_email.html
+++ b/concordia/templates/emails/contact_us_email.html
@@ -1,4 +1,4 @@
-<p>Contact request from <a href="mailto:{{ email|urlencode }}">{{ email }}</a></p>
+<p>Contact request from <a href="mailto:{{ email|urlencode }}">{{ email }}</a>:</p>
 
 <table>
     <tr>

--- a/concordia/templates/emails/contact_us_email.html
+++ b/concordia/templates/emails/contact_us_email.html
@@ -1,4 +1,4 @@
-<p>Contact request from <a href="mailto:{{ email|urlencode }}">{{ email }}</a>:</p>
+<p>Contact request from <a href="mailto:{{ email|urlencode }}">{{ email }}</a></p>
 
 <table>
     <tr>

--- a/concordia/templates/emails/contact_us_email.txt
+++ b/concordia/templates/emails/contact_us_email.txt
@@ -1,8 +1,8 @@
-Contact request from {{ email }}:
-
+From: {{ email }}
 Subject: {{ subject }}
 Link:  {{ link }}
 Referring Page: {{ referrer|default:"Unspecified" }}
 
 Story:
+
 {{ story }}


### PR DESCRIPTION
Remove colon from email field in the contact us form. The colon makes the email invalid and harder for CM's to reply back to volunteers. 