### PR TITLE
DB scripts: Add region to aws command, use python instead of python3

### DIFF
--- a/cloudformation/infrastructure/bastion-hosts.yaml
+++ b/cloudformation/infrastructure/bastion-hosts.yaml
@@ -1,16 +1,14 @@
-Description:
-  This template deploys a bastion host in each of the public subnets.
+Description: This template deploys a bastion host in each of the public subnets.
 
 Parameters:
-
     EnvironmentName:
         Description: An environment name that will be prefixed to resource names
         Type: String
         AllowedValues:
-          - dev
-          - test
-          - stage
-          - prod
+            - dev
+            - test
+            - stage
+            - prod
 
     KeyPairName:
         Description: key pair (within this region) for ECS instances access
@@ -53,16 +51,15 @@ Mappings:
             prod: sg-066c68e77787b2a10
 
 Resources:
-
     Bastion1:
         Type: AWS::EC2::Instance
         Properties:
             ImageId:
                 Fn::FindInMap:
-                - AWSRegionToAMI
-                - Ref: "AWS::Region"
-                - "AMI"
-            InstanceType: "t1.micro"
+                    - AWSRegionToAMI
+                    - Ref: 'AWS::Region'
+                    - 'AMI'
+            InstanceType: 't1.micro'
             IamInstanceProfile:
                 Fn::FindInMap:
                     - EnvironmentMapping
@@ -72,25 +69,27 @@ Resources:
                 Ref: KeyPairName
             NetworkInterfaces:
                 - AssociatePublicIpAddress: true
-                  DeviceIndex: "0"
+                  DeviceIndex: '0'
                   GroupSet:
-                    - Fn::FindInMap:
-                        - EnvironmentMapping
-                        - BastionHostsSecurityGroup
-                        - Ref: EnvironmentName
+                      - Fn::FindInMap:
+                            - EnvironmentMapping
+                            - BastionHostsSecurityGroup
+                            - Ref: EnvironmentName
                   SubnetId:
-                    Fn::FindInMap:
-                        - EnvironmentMapping
-                        - PublicSubnet1
-                        - Ref: EnvironmentName
+                      Fn::FindInMap:
+                          - EnvironmentMapping
+                          - PublicSubnet1
+                          - Ref: EnvironmentName
             UserData:
                 Fn::Base64: !Sub |
-                  #!/bin/bash -xe
-                  echo "Running userdata for ${EnvironmentName}"
-                  yum -y update
-                  yum -y install https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-6-x86_64/pgdg-ami201503-96-9.6-2.noarch.rpm
-                  yum -y install postgresql96
-                  aws s3 cp s3://crowd-deployment/database-dumps/concordia.latest.dmp concordia.dmp
+                    #!/bin/bash -xe
+                    echo "Running userdata for ${EnvironmentName}"
+                    echo "export ENV_NAME=${EnvironmentName}" >> /home/ec2-user/.bash_profile
+                    source /home/ec2-user/.bash_profile
+                    yum -y update
+                    yum -y install https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-6-x86_64/pgdg-ami201503-96-9.6-2.noarch.rpm
+                    yum -y install postgresql96
+                    aws s3 cp s3://crowd-deployment/database-dumps/concordia.latest.dmp concordia.dmp
 
             Tags:
                 - Key: Name
@@ -101,10 +100,10 @@ Resources:
         Properties:
             ImageId:
                 Fn::FindInMap:
-                - AWSRegionToAMI
-                - Ref: "AWS::Region"
-                - "AMI"
-            InstanceType: "t1.micro"
+                    - AWSRegionToAMI
+                    - Ref: 'AWS::Region'
+                    - 'AMI'
+            InstanceType: 't1.micro'
             IamInstanceProfile:
                 Fn::FindInMap:
                     - EnvironmentMapping
@@ -114,25 +113,27 @@ Resources:
                 Ref: KeyPairName
             NetworkInterfaces:
                 - AssociatePublicIpAddress: true
-                  DeviceIndex: "0"
+                  DeviceIndex: '0'
                   GroupSet:
-                    - Fn::FindInMap:
-                        - EnvironmentMapping
-                        - BastionHostsSecurityGroup
-                        - Ref: EnvironmentName
+                      - Fn::FindInMap:
+                            - EnvironmentMapping
+                            - BastionHostsSecurityGroup
+                            - Ref: EnvironmentName
                   SubnetId:
-                    Fn::FindInMap:
-                        - EnvironmentMapping
-                        - PublicSubnet2
-                        - Ref: EnvironmentName
+                      Fn::FindInMap:
+                          - EnvironmentMapping
+                          - PublicSubnet2
+                          - Ref: EnvironmentName
             UserData:
                 Fn::Base64: !Sub |
-                  #!/bin/bash -xe
-                  echo "Running userdata for ${EnvironmentName}"
-                  yum -y update
-                  yum -y install https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-6-x86_64/pgdg-ami201503-96-9.6-2.noarch.rpm
-                  yum -y install postgresql96
-                  aws s3 cp s3://crowd-deployment/database-dumps/concordia.latest.dmp concordia.dmp
+                    #!/bin/bash -xe
+                    echo "Running userdata for ${EnvironmentName}"
+                    echo "export ENV_NAME=${EnvironmentName}" >> /home/ec2-user/.bash_profile
+                    source /home/ec2-user/.bash_profile
+                    yum -y update
+                    yum -y install https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-6-x86_64/pgdg-ami201503-96-9.6-2.noarch.rpm
+                    yum -y install postgresql96
+                    aws s3 cp s3://crowd-deployment/database-dumps/concordia.latest.dmp concordia.dmp
             Tags:
                 - Key: Name
                   Value: !Sub ${EnvironmentName}-BastionHost-2

--- a/cloudformation/infrastructure/data-load.yaml
+++ b/cloudformation/infrastructure/data-load.yaml
@@ -1,17 +1,16 @@
 Description:
-  This template deploys a host in a private subnet and loads the most recent
-  database dump to the specified database server.
+    This template deploys a host in a private subnet and loads the most recent
+    database dump to the specified database server.
 
 Parameters:
-
     EnvironmentName:
         Description: An environment name that will be prefixed to resource names
         Type: String
         AllowedValues:
-          - dev
-          - test
-          - stage
-          - prod
+            - dev
+            - test
+            - stage
+            - prod
 
     PostgresqlHost:
         Description: the end point of the RDS database host to restore
@@ -49,16 +48,15 @@ Mappings:
             prod: sg-066c68e77787b2a10
 
 Resources:
-
     DataLoadHost:
         Type: AWS::EC2::Instance
         Properties:
             ImageId:
                 Fn::FindInMap:
-                - AWSRegionToAMI
-                - Ref: "AWS::Region"
-                - "AMI"
-            InstanceType: "t1.micro"
+                    - AWSRegionToAMI
+                    - Ref: 'AWS::Region'
+                    - 'AMI'
+            InstanceType: 't1.micro'
             IamInstanceProfile:
                 Fn::FindInMap:
                     - EnvironmentMapping
@@ -67,29 +65,31 @@ Resources:
             InstanceInitiatedShutdownBehavior: terminate
             NetworkInterfaces:
                 - AssociatePublicIpAddress: true
-                  DeviceIndex: "0"
+                  DeviceIndex: '0'
                   GroupSet:
-                    - Fn::FindInMap:
-                        - EnvironmentMapping
-                        - BastionHostsSecurityGroup
-                        - Ref: EnvironmentName
+                      - Fn::FindInMap:
+                            - EnvironmentMapping
+                            - BastionHostsSecurityGroup
+                            - Ref: EnvironmentName
                   SubnetId:
-                    Fn::FindInMap:
-                        - EnvironmentMapping
-                        - PrivateSubnet1
-                        - Ref: EnvironmentName
+                      Fn::FindInMap:
+                          - EnvironmentMapping
+                          - PrivateSubnet1
+                          - Ref: EnvironmentName
             UserData:
                 Fn::Base64: !Sub |
-                  #!/bin/bash -xe
-                  echo "Running userdata for ${EnvironmentName}"
-                  yum -y update
-                  yum -y install https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-6-x86_64/pgdg-ami201503-96-9.6-2.noarch.rpm
-                  yum -y install postgresql96
-                  aws s3 cp s3://crowd-deployment/database-dumps/concordia.latest.dmp concordia.dmp
-                  echo "${PostgresqlHost}:5432:*:concordia:${PostgresqlPassword}" >> /root/.pgpass
-                  chmod 0600 /root/.pgpass
-                  pg_restore --create --clean -Fc -U concordia -h ${PostgresqlHost} --dbname=postgres --no-password --no-owner --no-acl concordia.dmp
-                  shutdown -h now
+                    #!/bin/bash -xe
+                    echo "Running userdata for ${EnvironmentName}"
+                    echo "export ENV_NAME=${EnvironmentName}" >> /home/ec2-user/.bash_profile
+                    source /home/ec2-user/.bash_profile
+                    yum -y update
+                    yum -y install https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-6-x86_64/pgdg-ami201503-96-9.6-2.noarch.rpm
+                    yum -y install postgresql96
+                    aws s3 cp s3://crowd-deployment/database-dumps/concordia.latest.dmp concordia.dmp
+                    echo "${PostgresqlHost}:5432:*:concordia:${PostgresqlPassword}" >> /root/.pgpass
+                    chmod 0600 /root/.pgpass
+                    pg_restore --create --clean -Fc -U concordia -h ${PostgresqlHost} --dbname=postgres --no-password --no-owner --no-acl concordia.dmp
+                    shutdown -h now
             Tags:
                 - Key: Name
                   Value: !Sub ${EnvironmentName}-DataLoadHost

--- a/db_scripts/dump.sh
+++ b/db_scripts/dump.sh
@@ -2,10 +2,13 @@
 
 set -eu -o pipefail
 
-ENV_NAME=prod
-
 # aws cloudformation create-stack --region us-east-1 --stack-name $ENV_NAME-bastionhosts --template-url https://s3.amazonaws.com/crowd-deployment/infrastructure/bastion-hosts.yaml --parameters ParameterKey=EnvironmentName,ParameterValue=$ENV_NAME ParameterKey=KeyPairName,ParameterValue=rstorey@loc.gov --disable-rollback
 # aws cloudformation delete-stack --region us-east-1 --stack-name $ENV_NAME-bastionhosts
+
+if [[ -z "${ENV_NAME}" ]]; then
+    echo "ENV_NAME must be set prior to running this script."
+    exit 1
+fi
 
 if [ $ENV_NAME != "prod" ]; then
     echo "This script should only be run in the production environment."

--- a/db_scripts/dump.sh
+++ b/db_scripts/dump.sh
@@ -13,7 +13,7 @@ if [ $ENV_NAME != "prod" ]; then
 fi
 
 TODAY=$(date +%Y%m%d)
-POSTGRESQL_PW="$(aws secretsmanager get-secret-value --secret-id crowd/${ENV_NAME}/DB/MasterUserPassword | python3 -c 'import json,sys;Secret=json.load(sys.stdin);SecretString=json.loads(Secret["SecretString"]);print(SecretString["password"])')"
+POSTGRESQL_PW="$(aws secretsmanager get-secret-value --region us-east-1 --secret-id crowd/${ENV_NAME}/DB/MasterUserPassword | python -c 'import json,sys;Secret=json.load(sys.stdin);SecretString=json.loads(Secret["SecretString"]);print(SecretString["password"])')"
 # TODO: look up the RDS endpoint for this environment
 POSTGRESQL_HOST=${POSTGRESQL_HOST:-localhost}
 DUMP_FILE=concordia.dmp

--- a/db_scripts/restore.sh
+++ b/db_scripts/restore.sh
@@ -11,7 +11,7 @@ if [ $ENV_NAME = "prod" ]; then
     exit 1
 fi
 
-POSTGRESQL_PW="$(aws secretsmanager get-secret-value --secret-id crowd/${ENV_NAME}/DB/MasterUserPassword | python -c 'import json,sys;Secret=json.load(sys.stdin);SecretString=json.loads(Secret["SecretString"]);print(SecretString["password"])')"
+POSTGRESQL_PW="$(aws secretsmanager get-secret-value --region us-east-1 --secret-id crowd/${ENV_NAME}/DB/MasterUserPassword | python -c 'import json,sys;Secret=json.load(sys.stdin);SecretString=json.loads(Secret["SecretString"]);print(SecretString["password"])')"
 # TODO: look up the RDS endpoint for this environment
 POSTGRESQL_HOST=${POSTGRESQL_HOST:-localhost}
 DUMP_FILE=/concordia.dmp

--- a/db_scripts/restore.sh
+++ b/db_scripts/restore.sh
@@ -2,7 +2,7 @@
 
 set -eu -o pipefail
 
-ENV_NAME=dev
+ENV_NAME=test
 
 # aws cloudformation create-stack --region us-east-1 --stack-name $ENV_NAME-bastionhosts --template-url https://s3.amazonaws.com/crowd-deployment/infrastructure/bastion-hosts.yaml --parameters ParameterKey=EnvironmentName,ParameterValue=$ENV_NAME ParameterKey=KeyPairName,ParameterValue=rstorey@loc.gov --disable-rollback
 # aws cloudformation delete-stack --region us-east-1 --stack-name $ENV_NAME-bastionhosts
@@ -11,7 +11,7 @@ if [ $ENV_NAME = "prod" ]; then
     exit 1
 fi
 
-POSTGRESQL_PW="$(aws secretsmanager get-secret-value --secret-id crowd/${ENV_NAME}/DB/MasterUserPassword | python3 -c 'import json,sys;Secret=json.load(sys.stdin);SecretString=json.loads(Secret["SecretString"]);print(SecretString["password"])')"
+POSTGRESQL_PW="$(aws secretsmanager get-secret-value --secret-id crowd/${ENV_NAME}/DB/MasterUserPassword | python -c 'import json,sys;Secret=json.load(sys.stdin);SecretString=json.loads(Secret["SecretString"]);print(SecretString["password"])')"
 # TODO: look up the RDS endpoint for this environment
 POSTGRESQL_HOST=${POSTGRESQL_HOST:-localhost}
 DUMP_FILE=/concordia.dmp

--- a/db_scripts/restore.sh
+++ b/db_scripts/restore.sh
@@ -2,10 +2,14 @@
 
 set -eu -o pipefail
 
-ENV_NAME=test
-
 # aws cloudformation create-stack --region us-east-1 --stack-name $ENV_NAME-bastionhosts --template-url https://s3.amazonaws.com/crowd-deployment/infrastructure/bastion-hosts.yaml --parameters ParameterKey=EnvironmentName,ParameterValue=$ENV_NAME ParameterKey=KeyPairName,ParameterValue=rstorey@loc.gov --disable-rollback
 # aws cloudformation delete-stack --region us-east-1 --stack-name $ENV_NAME-bastionhosts
+
+if [[ -z "${ENV_NAME}" ]]; then
+    echo "ENV_NAME must be set prior to running this script."
+    exit 1
+fi
+
 if [ $ENV_NAME = "prod" ]; then
     echo "This script should not be run in the production environment."
     exit 1


### PR DESCRIPTION
Still need to make a couple more changes before this is ready:
 
- [x] make `ENV_NAME` come from outside so it's set by the CloudFormation template rather than at the top of the script
- [x]  add region to the restore script