### PR TITLE
setup.cfg: bring isort settings in-line with Black

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,17 +4,19 @@ ignore =
 max-line-length = 88
 
 [tool:pytest]
-DJANGO_SETTINGS_MODULE=concordia.settings_test
-addopts=-rf
+DJANGO_SETTINGS_MODULE = concordia.settings_test
+addopts = -rf
 
 [isort]
-line_length = 88
-known_first_party = concordia,importer,exporter
 default_section = THIRDPARTY
+force_grid_wrap = 0
+include_trailing_comma = True
+known_first_party = concordia,importer,exporter
+line_length = 88
+multi_line_output = 3
 not_skip = __init__.py
 skip = .venv
 use_parentheses = True
-multi_line_output = 3
 
 [flake8]
 exclude = .venv


### PR DESCRIPTION
The main change here is adding the option to add a trailing comma so it doesn’t get removed until Black restores it. I also sorted the block so it's easier to keep it aligned in the future.