### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,12 +24,12 @@ repos:
           - id: mixed-line-ending
             args: ['--fix=lf']
     - repo: https://github.com/prettier/prettier
-      rev: 1.16.1
+      rev: 1.16.2
       hooks:
           - id: prettier
             files: \.(css|less|scss|ts|tsx|graphql|gql|json|js|jsx|md)$
     - repo: https://github.com/pre-commit/mirrors-eslint
-      rev: v5.12.1
+      rev: v5.15.1
       hooks:
           - id: eslint
             additional_dependencies:
@@ -37,7 +37,7 @@ repos:
                 - eslint-plugin-prettier@3.0.0
                 - prettier@1.14.3
     - repo: https://github.com/awslabs/cfn-python-lint
-      rev: v0.12.1
+      rev: v0.15.0
       hooks:
           - id: cfn-python-lint
             files: cloudformation/.*\.(json|yml|yaml)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,9 @@
 exclude: '.*/vendor/.*'
 repos:
+    - repo: https://github.com/pre-commit/mirrors-isort
+      rev: v4.3.15
+      hooks:
+          - id: isort
     - repo: https://github.com/ambv/black
       rev: 18.9b0
       hooks:


### PR DESCRIPTION
Since we have isort configured to match Black this should not cause any churn on commits now