### PR TITLE
Simple typo - repetition of word "and"

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -59,5 +59,5 @@ Before you submit a pull request, check that it meets these guidelines:
    the top-level LICENSE file
 1. The pull request should include tests.
 1. If the pull request adds functionality it should be described at a technical
-   level in the code and and user-visible changes should be described in the
+   level in the code and user-visible changes should be described in the
    main README


### PR DESCRIPTION
The word "and" was repeated in the final sentence.