### PR TITLE
Bug fix for asset reservation modal that pops up multiple times

### DIFF
--- a/concordia/static/js/asset-reservation.js
+++ b/concordia/static/js/asset-reservation.js
@@ -1,7 +1,12 @@
 /* global jQuery displayMessage displayHtmlMessage buildErrorMessage */
 /* exported attemptToReserveAsset */
 
-function attemptToReserveAsset(reservationURL, findANewPageURL, actionType) {
+function attemptToReserveAsset(
+    reservationURL,
+    findANewPageURL,
+    actionType,
+    firstTime
+) {
     var $transcriptionEditor = jQuery('#transcription-editor');
 
     jQuery
@@ -21,7 +26,9 @@ function attemptToReserveAsset(reservationURL, findANewPageURL, actionType) {
                     $transcriptionEditor
                         .data('hasReservation', false)
                         .trigger('update-ui-state');
-                    jQuery('#asset-reservation-failure-modal').modal();
+                    if (firstTime) {
+                        jQuery('#asset-reservation-failure-modal').modal();
+                    }
                 } else {
                     displayHtmlMessage(
                         'warning',
@@ -40,11 +47,17 @@ function attemptToReserveAsset(reservationURL, findANewPageURL, actionType) {
                     'transcription-reservation'
                 );
             }
-        })
-        .always(function() {
-            window.setTimeout(attemptToReserveAsset, 60000, reservationURL);
         });
-
+    /*
+        // TODO: implement UI updates for when the transcription has been updated and / or status changed
+        // by the user who has the asset reservation. This type of timed update (below) only works correctly when
+        // the user who has the asset reservation navigates away from the page without doing anything.
+        // e.g. we don't want to re-enable a blank textarea when the user with the reservation has already
+        // updated the transcription (and even possibly the asset status) in the background.
+        .always(function() {
+            window.setTimeout(attemptToReserveAsset, 60000, reservationURL, findANewPageURL, actionType, false);
+        });
+        */
     window.addEventListener('beforeunload', function() {
         var payload = {
             release: true,

--- a/concordia/static/js/asset-reservation.js
+++ b/concordia/static/js/asset-reservation.js
@@ -19,6 +19,16 @@ function attemptToReserveAsset(
             $transcriptionEditor
                 .data('hasReservation', true)
                 .trigger('update-ui-state');
+
+            // If the asset was successfully reserved, continue reserving it
+            window.setTimeout(
+                attemptToReserveAsset,
+                60000,
+                reservationURL,
+                findANewPageURL,
+                actionType,
+                false
+            );
         })
         .fail(function(jqXHR, textStatus, errorThrown) {
             if (jqXHR.status == 409) {
@@ -48,16 +58,7 @@ function attemptToReserveAsset(
                 );
             }
         });
-    /*
-        // TODO: implement UI updates for when the transcription has been updated and / or status changed
-        // by the user who has the asset reservation. This type of timed update (below) only works correctly when
-        // the user who has the asset reservation navigates away from the page without doing anything.
-        // e.g. we don't want to re-enable a blank textarea when the user with the reservation has already
-        // updated the transcription (and even possibly the asset status) in the background.
-        .always(function() {
-            window.setTimeout(attemptToReserveAsset, 60000, reservationURL, findANewPageURL, actionType, false);
-        });
-        */
+
     window.addEventListener('beforeunload', function() {
         var payload = {
             release: true,

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -543,11 +543,11 @@
     {% if transcription_status == "not_started" or transcription_status == "in_progress" %}
         attemptToReserveAsset("{% url 'reserve-asset' asset.pk %}",
         "",
-        "transcribe");
+        "transcribe", true);
     {% elif user.is_authenticated %}
         attemptToReserveAsset("{% url 'reserve-asset' asset.pk %}",
         "{% url 'transcriptions:redirect-to-next-reviewable-asset' asset.item.project.campaign.slug %}",
-        "review");
+        "review", true);
     {% endif %}
 </script>
 {% endblock body_scripts %}


### PR DESCRIPTION
Refs #853

Removes the timed check for asset reservation update since we don't properly handle most of the possible result cases - the only way it works correctly is if the user who has the asset reservation navigates away from the page without entering any transcription text or changing the asset status. The user really needs to reload the page to try again at getting an asset reservation, until/unless we are going to update all the UI elements that related to latest transcription text and asset status - not just enable the text area. If the current asset detail page continues its life much longer, perhaps we should consider doing just that.