### PR TITLE
coverage: workaround for XML reporting bug

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,20 @@
 [run]
 branch = true
-source =
-    concordia
-    importer
-    exporter
+include =
+    concordia/*
+    importer/*
+    exporter/*
+ omit =
+    */migrations/*
+    */tests/*
+    concordia/settings*
+
+[report]
+include =
+    concordia/*
+    importer/*
+    exporter/*
+omit =
+    */migrations/*
+    */tests/*
+    concordia/settings*

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ script:
     - git diff --name-only $TRAVIS_COMMIT_RANGE | xargs pre-commit run --files
     - pipenv run safety check
 after_success:
+    - git fetch --unshallow --tags
     - pipenv run coverage xml
     - sonar-scanner
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ script:
     - mkdir logs
     - touch ./logs/concordia-celery.log
     - pipenv run ./manage.py collectstatic --no-input
-    - pipenv run coverage run ./manage.py test concordia importer exporter
+    # n.b.
+    - pipenv run coverage run ./manage.py test
     - git diff --name-only $TRAVIS_COMMIT_RANGE | xargs pre-commit run --files
     - pipenv run safety check
 after_success:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
-sonar.exclusions=**/tests/**, node_modules/**, htmlcov/**, static-files/**, concordia/settings_dev*, concordia/settings_test*
+sonar.exclusions=**/tests/**, node_modules/**, htmlcov/**, static-files/**, concordia/settings_dev*, concordia/settings_test*, coverage.xml
 sonar.sources=.
 sonar.projectKey=LibraryOfCongress_concordia
 sonar.organization=libraryofcongress
 sonar.host.url=https://sonarcloud.io
 sonar.python.coverage.reportPaths=coverage.xml
-sonar.coverage.exclusions=cloudformation/**, coverage.xml, setup.py, **/static/**, **/templates/**, **/vendor/**
+sonar.coverage.exclusions=cloudformation/**, setup.py, **/static/**, **/templates/**, **/vendor/**


### PR DESCRIPTION
There’s a bug in coverage.py when using the source specifier which causes the XML reports to omit the first element of the directory name, breaking some tools (this does not affect the HTML or text format reports).

Using include instead avoids this problem until the upstream bug is resolved: https://github.com/nedbat/coveragepy/issues/578

Before merging, we should see a big jump up in the coverage numbers on https://sonarcloud.io/dashboard?id=LibraryOfCongress_concordia because the values in the coverage.xml file will have the full file paths it's looking for.