### PR TITLE
Set CONN_MAX_AGE for celery 4.2.1 when using Docker Postgres DB

### DIFF
--- a/concordia/settings_dev.py
+++ b/concordia/settings_dev.py
@@ -45,3 +45,15 @@ SHELL_PLUS_PRE_IMPORTS = [
     ("concordia.utils", "get_anonymous_user"),
     ("concordia.models", "TranscriptionStatus"),
 ]
+
+S3_BUCKET_NAME = "crowd-dev-content"
+EXPORT_S3_BUCKET_NAME = "crowd-dev-export"
+DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+AWS_STORAGE_BUCKET_NAME = S3_BUCKET_NAME
+AWS_DEFAULT_ACL = None  # Don't set an ACL on the files, inherit the bucket ACLs
+MEDIA_URL = "https://%s.s3.amazonaws.com/" % S3_BUCKET_NAME
+
+# Celery 4.2.1 needs this when using docker DB
+# see https://github.com/celery/celery/issues/4878
+# For some reason, in AWS it doesn't seem to be an issue
+DATABASES["default"]["CONN_MAX_AGE"] = 0

--- a/concordia/settings_dev.py
+++ b/concordia/settings_dev.py
@@ -46,13 +46,6 @@ SHELL_PLUS_PRE_IMPORTS = [
     ("concordia.models", "TranscriptionStatus"),
 ]
 
-S3_BUCKET_NAME = "crowd-dev-content"
-EXPORT_S3_BUCKET_NAME = "crowd-dev-export"
-DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
-AWS_STORAGE_BUCKET_NAME = S3_BUCKET_NAME
-AWS_DEFAULT_ACL = None  # Don't set an ACL on the files, inherit the bucket ACLs
-MEDIA_URL = "https://%s.s3.amazonaws.com/" % S3_BUCKET_NAME
-
 # Celery 4.2.1 needs this when using docker DB
 # see https://github.com/celery/celery/issues/4878
 # For some reason, in AWS it doesn't seem to be an issue

--- a/concordia/settings_docker.py
+++ b/concordia/settings_docker.py
@@ -3,7 +3,7 @@ import os
 from django.core.management.utils import get_random_secret_key
 
 from .settings_template import *  # NOQA ignore=F405
-from .settings_template import INSTALLED_APPS, LOGGING
+from .settings_template import DATABASES, INSTALLED_APPS, LOGGING
 
 LOGGING["handlers"]["stream"]["level"] = "INFO"
 LOGGING["handlers"]["file"]["level"] = "INFO"
@@ -52,3 +52,8 @@ ATTRIBUTION_TEXT = (
     "Transcribed and reviewed by volunteers participating in the "
     "By The People project at crowd.loc.gov."
 )
+
+# Celery 4.2.1 needs this when using docker DB
+# see https://github.com/celery/celery/issues/4878
+# For some reason, in AWS it doesn't seem to be an issue
+DATABASES["default"]["CONN_MAX_AGE"] = 0


### PR DESCRIPTION
See https://github.com/celery/celery/issues/4878

Doesn't seem to be a problem in AWS - I couldn't reproduce it in crowd-dev. Only when using a docker container as the Postgres DB.