### PR TITLE
Fix the celery conn_max_age problem in ECS environment

### DIFF
--- a/concordia/db_routers.py
+++ b/concordia/db_routers.py
@@ -1,0 +1,21 @@
+class AppRouter:
+    def db_for_read(self, model, **hints):
+        if model._meta.app_label == "importer":
+            return "celery"
+        return "default"
+
+    def db_for_write(self, model, **hints):
+        if model._meta.app_label == "importer":
+            return "celery"
+        return "default"
+
+    def allow_relation(self, obj1, obj2, **hints):
+        if obj1._meta.app_label == "importer" or obj2._meta.app_label == "importer":
+            return "celery"
+        return "default"
+
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+
+        if app_label == "importer":
+            return db == "celery"
+        return "default"

--- a/concordia/db_routers.py
+++ b/concordia/db_routers.py
@@ -10,12 +10,7 @@ class AppRouter:
         return "default"
 
     def allow_relation(self, obj1, obj2, **hints):
-        if obj1._meta.app_label == "importer" or obj2._meta.app_label == "importer":
-            return "celery"
         return "default"
 
     def allow_migrate(self, db, app_label, model_name=None, **hints):
-
-        if app_label == "importer":
-            return db == "celery"
         return "default"

--- a/concordia/settings_dev.py
+++ b/concordia/settings_dev.py
@@ -14,6 +14,7 @@ LOGGING["loggers"]["celery"]["level"] = "DEBUG"
 DEBUG = True
 
 DATABASES["default"]["PORT"] = "54323"
+DATABASES["celery"]["PORT"] = "54323"
 
 ALLOWED_HOSTS = ["127.0.0.1", "0.0.0.0", "*"]
 

--- a/concordia/settings_dev.py
+++ b/concordia/settings_dev.py
@@ -45,8 +45,3 @@ SHELL_PLUS_PRE_IMPORTS = [
     ("concordia.utils", "get_anonymous_user"),
     ("concordia.models", "TranscriptionStatus"),
 ]
-
-# Celery 4.2.1 needs this when using docker DB
-# see https://github.com/celery/celery/issues/4878
-# For some reason, in AWS it doesn't seem to be an issue
-DATABASES["default"]["CONN_MAX_AGE"] = 0

--- a/concordia/settings_docker.py
+++ b/concordia/settings_docker.py
@@ -3,7 +3,7 @@ import os
 from django.core.management.utils import get_random_secret_key
 
 from .settings_template import *  # NOQA ignore=F405
-from .settings_template import DATABASES, INSTALLED_APPS, LOGGING
+from .settings_template import INSTALLED_APPS, LOGGING
 
 LOGGING["handlers"]["stream"]["level"] = "INFO"
 LOGGING["handlers"]["file"]["level"] = "INFO"
@@ -52,8 +52,3 @@ ATTRIBUTION_TEXT = (
     "Transcribed and reviewed by volunteers participating in the "
     "By The People project at crowd.loc.gov."
 )
-
-# Celery 4.2.1 needs this when using docker DB
-# see https://github.com/celery/celery/issues/4878
-# For some reason, in AWS it doesn't seem to be an issue
-DATABASES["default"]["CONN_MAX_AGE"] = 0

--- a/concordia/settings_ecs.py
+++ b/concordia/settings_ecs.py
@@ -26,6 +26,7 @@ if os.getenv("AWS"):
     postgres_secret = json.loads(postgres_secret_json)
 
     DATABASES["default"].update({"PASSWORD": postgres_secret["password"]})
+    DATABASES["celery"].update({"PASSWORD": postgres_secret["password"]})
 
     smtp_secret_json = get_secret("concordia/SMTP")
     smtp_secret = json.loads(smtp_secret_json)

--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -55,7 +55,7 @@ DATABASES = {
         "PASSWORD": os.getenv("POSTGRESQL_PW"),
         "HOST": os.getenv("POSTGRESQL_HOST", "localhost"),
         "PORT": os.getenv("POSTGRESQL_PORT", "5432"),
-        "CONN_MAX_AGE": 0,
+        "CONN_MAX_AGE": 15 * 60,  # Keep database connections open for 15 minutes,
     }
 }
 

--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -45,6 +45,8 @@ USE_L10N = True
 USE_TZ = True
 WSGI_APPLICATION = "concordia.wsgi.application"
 
+
+# see https://github.com/celery/celery/issues/4878 re: conn_max_age
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
@@ -53,7 +55,7 @@ DATABASES = {
         "PASSWORD": os.getenv("POSTGRESQL_PW"),
         "HOST": os.getenv("POSTGRESQL_HOST", "localhost"),
         "PORT": os.getenv("POSTGRESQL_PORT", "5432"),
-        "CONN_MAX_AGE": 15 * 60,  # Keep database connections open for 15 minutes
+        "CONN_MAX_AGE": 0,
     }
 }
 

--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -45,8 +45,6 @@ USE_L10N = True
 USE_TZ = True
 WSGI_APPLICATION = "concordia.wsgi.application"
 
-
-# see https://github.com/celery/celery/issues/4878 re: conn_max_age
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
@@ -56,8 +54,20 @@ DATABASES = {
         "HOST": os.getenv("POSTGRESQL_HOST", "localhost"),
         "PORT": os.getenv("POSTGRESQL_PORT", "5432"),
         "CONN_MAX_AGE": 15 * 60,  # Keep database connections open for 15 minutes,
-    }
+    },
+    "celery": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "concordia",
+        "USER": "concordia",
+        "PASSWORD": os.getenv("POSTGRESQL_PW"),
+        "HOST": os.getenv("POSTGRESQL_HOST", "localhost"),
+        "PORT": os.getenv("POSTGRESQL_PORT", "5432"),
+        # see https://github.com/celery/celery/issues/4878 re: conn_max_age
+        "CONN_MAX_AGE": 0,
+    },
 }
+
+DATABASE_ROUTERS = ["concordia.db_routers.AppRouter"]
 
 
 INSTALLED_APPS = [

--- a/concordia/settings_test.py
+++ b/concordia/settings_test.py
@@ -12,6 +12,7 @@ LOGGING["loggers"]["celery"]["level"] = "INFO"
 DEBUG = False
 
 DATABASES["default"].update({"PASSWORD": "", "USER": "postgres"})
+DATABASES["celery"].update({"PASSWORD": "", "USER": "postgres"})
 
 DEFAULT_TO_EMAIL = "rstorey@loc.gov"
 


### PR DESCRIPTION
Now the same celery issue is happening in ECS. I'm not sure why. See https://crowd-sentry.loc.gov/loc/crowd-backend/issues/264