### PR TITLE
Create url path for new resources page

### DIFF
--- a/concordia/urls.py
+++ b/concordia/urls.py
@@ -91,6 +91,7 @@ urlpatterns = [
     path("help-center/how-to-review/", views.simple_page, name="how-to-review"),
     path("help-center/how-to-tag/", views.simple_page, name="how-to-tag"),
     path("for-educators/", views.simple_page, name="for-educators"),
+    path("resources/", views.simple_page, name="resources"),
     path(
         "latest/",
         RedirectView.as_view(pattern_name="about", permanent=True, query_string=True),


### PR DESCRIPTION
Community managers need to make a general resource static page. If the URL path isn't set ahead of time, CM's can not click back into the page on the admin side. 

We'll add this to the top nav after the content is finished and its ready to expose in a few weeks 


@lalgee 