### PR TITLE
Allow admins to set the path for new simple pages

### DIFF
--- a/concordia/admin/__init__.py
+++ b/concordia/admin/__init__.py
@@ -398,7 +398,7 @@ class TranscriptionAdmin(admin.ModelAdmin):
 @admin.register(SimplePage)
 class SimplePageAdmin(admin.ModelAdmin):
     list_display = ("path", "title", "created_on", "updated_on")
-    readonly_fields = ("path", "created_on", "updated_on")
+    readonly_fields = ("created_on", "updated_on")
 
     fieldsets = (
         (None, {"fields": ("created_on", "updated_on", "path", "title")}),


### PR DESCRIPTION
This bug fix will allow you to be able to set the path for the new resources page.