### PR TITLE
Put celery regression fix back in

### DIFF
--- a/concordia/settings_ecs.py
+++ b/concordia/settings_ecs.py
@@ -87,3 +87,6 @@ ATTRIBUTION_TEXT = (
     "Transcribed and reviewed by volunteers participating in the "
     "By The People project at crowd.loc.gov."
 )
+
+if os.getenv("USE_PERSISTENT_DATABASE_CONNECTIONS"):
+    DATABASES["default"].update({"CONN_MAX_AGE": 15 * 60})

--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -53,7 +53,9 @@ DATABASES = {
         "PASSWORD": os.getenv("POSTGRESQL_PW"),
         "HOST": os.getenv("POSTGRESQL_HOST", "localhost"),
         "PORT": os.getenv("POSTGRESQL_PORT", "5432"),
-        "CONN_MAX_AGE": 15 * 60,  # 15 minutes
+        # Change this back to 15 minutes (15*60) once celery regression
+        # is fixed  see https://github.com/celery/celery/issues/4878
+        "CONN_MAX_AGE": 0,  # 15 minutes
     }
 }
 


### PR DESCRIPTION
Seems like the AWS ECS log viewer is having some bugs / I didn't wait long enough for my celery tasks to get picked up by the new stuff after doing the 4.3 upgrade.