### PR TITLE
Use official Python 3.7 Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
-FROM ubuntu:18.04
+FROM python:3.7
 
 ENV DEBIAN_FRONTEND="noninteractive"
+
+RUN echo "deb http://deb.debian.org/debian stretch-backports main" >> /etc/apt/sources.list.d/stretch-backports.list
 
 # Pillow/Imaging: https://pillow.readthedocs.io/en/latest/installation.html#external-libraries
 RUN apt-get update -qy && apt-get dist-upgrade -qy && apt-get install -o Dpkg::Options::='--force-confnew' -qy \
     git curl \
-    python3.7 python3.7-dev python3-pip \
     libz-dev libfreetype6-dev \
     libmemcached-dev \
     libtiff-dev libjpeg-dev libopenjp2-7-dev libwebp-dev zlib1g-dev \
+    jpegoptim libjpeg-turbo-progs optipng advancecomp \
     graphviz \
     locales && apt-get -qy autoremove && apt-get -qy autoclean
 


### PR DESCRIPTION
This avoids us needing to manage the Python 3.7 installation and, as a bonus, adds a couple of pre-compiled development tools for our image optimization pipeline.