### PR TITLE
Docker make dev settings overrideable

### DIFF
--- a/concordia/settings_dev.py
+++ b/concordia/settings_dev.py
@@ -1,7 +1,7 @@
 import os
 
 from .settings_template import *  # NOQA ignore=F405
-from .settings_template import DATABASES, INSTALLED_APPS, LOGGING, MIDDLEWARE
+from .settings_template import INSTALLED_APPS, LOGGING, MIDDLEWARE
 
 LOGGING["handlers"]["stream"]["level"] = "DEBUG"
 LOGGING["handlers"]["file"]["level"] = "DEBUG"
@@ -12,8 +12,6 @@ LOGGING["loggers"]["django"]["level"] = "DEBUG"
 LOGGING["loggers"]["celery"]["level"] = "DEBUG"
 
 DEBUG = True
-
-DATABASES["default"]["PORT"] = "54323"
 
 ALLOWED_HOSTS = ["127.0.0.1", "0.0.0.0", "*"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
             POSTGRESQL_PW: ${POSTGRESQL_PW}
             CONCORDIA_ENVIRONMENT: development
             S3_BUCKET_NAME: crowd-dev-content
-            DJANGO_SETTINGS_MODULE: concordia.settings_docker
+            DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE:-concordia.settings_docker}
             DEBUG: ${DEBUG:-}
             REDIS_ADDRESS: redis
             REDIS_PORT: 6379


### PR DESCRIPTION
A few more tweaks needed for @klee72's Docker setup — using settings_docker always meant that it crashes if your environment lacks AWS credentials since settings_docker defaults to the S3 storage backend.