### PR TITLE
Finish activity UI asset reservations

### DIFF
--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -346,14 +346,6 @@ export class AssetList extends List {
 
         this.el.addEventListener('mouseout', handleTooltipHideEvent);
         this.el.addEventListener('focusout', handleTooltipHideEvent);
-
-        $('#asset-list-thumbnail-size').addEventListener('input', event => {
-            this.el.style.setProperty(
-                '--asset-thumbnail-size',
-                event.target.value + 'px'
-            );
-            this.attemptAssetLazyLoad();
-        });
     }
 
     update(assets) {

--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -261,6 +261,13 @@ class AssetListItem {
         this.el.dataset.id = assetData.id;
         this.el.dataset.difficulty = assetData.difficulty;
         this.el.dataset.status = assetData.status;
+
+        if (!assetData.editable.canEdit) {
+            this.el.dataset.unavailable = assetData.editable.reason;
+        } else {
+            delete this.el.dataset.unavailable;
+        }
+
         this.el.title = `${assetData.title} (${assetData.project.title})`;
     }
 }

--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -297,6 +297,9 @@ export class AssetList extends List {
             assetListObserver
         ]);
 
+        // These will be processed after the next asset list update completes (possibly after a rAF / rIC chain)
+        this.updateCallbacks = [];
+
         let assetOpenHandler = event => {
             let target = event.target;
             if (target && target.classList.contains('asset')) {
@@ -355,6 +358,11 @@ export class AssetList extends List {
 
     update(assets) {
         super.update(assets);
+
+        while (this.updateCallbacks.length) {
+            let callback = this.updateCallbacks.pop();
+            callback();
+        }
     }
 
     scrollToActiveAsset() {

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -258,7 +258,6 @@ export class ActionApp {
                     );
             }
 
-            // TODO: consider parking this behind requestAnimationFrame?
             let assetListItem = this.assetList.lookup[assetId];
             if (assetListItem) {
                 // If this is visible, we want to update the displayed asset
@@ -703,7 +702,6 @@ export class ActionApp {
             currentCampaignId = parseInt(currentCampaignId, 10);
         }
 
-        // TODO: We should have a cleaner way to filter the assets which are in scope due to the current status & having been fully loaded
         let currentStatuses;
         let currentMode = this.currentMode;
         if (currentMode == 'review') {

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -485,12 +485,6 @@ export class ActionApp {
             }
         }
 
-        console.debug(
-            `Changing asset ${assetId} from ${JSON.stringify(
-                oldData
-            )} to ${JSON.stringify(mergedData)}`
-        );
-
         mergedData.editable = this.canEditAsset(mergedData);
 
         this.assets.set(assetId, mergedData);

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -423,8 +423,6 @@ export class ActionApp {
                     this.createAsset(i);
                 });
 
-                $('#asset-count').textContent = this.assets.size;
-
                 if (this.currentMode != startingMode) {
                     console.warn(
                         `Mode changed from ${startingMode} to ${
@@ -625,8 +623,6 @@ export class ActionApp {
                 console.time('Updating asset list');
                 this.assetList.update(visibleAssets);
                 console.timeEnd('Updating asset list');
-
-                $('#visible-asset-count').textContent = visibleAssets.length;
 
                 this.assetList.scrollToActiveAsset();
 

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -240,29 +240,30 @@ export class ActionApp {
                     is not the same as the user who obtained the reservation,
                     then mark it unavailable
                     */
-                    if (
-                        !this.config.currentUser ||
-                        (this.config.currentUser &&
-                            this.config.currentUser != message.user_pk)
-                    ) {
-                        console.error(
-                            '// FIXME: handle asset reservation updates'
-                        );
-                        this.markAssetAsUnavailable(
-                            assetId,
-                            'Someone else is working on this'
-                        );
-                    }
+
+                    this.mergeAssetUpdate(assetId, {
+                        reservationToken: message.reservation_token
+                    });
+
                     break;
                 case 'asset_reservation_released':
-                    // FIXME: we need to test whether the user who reserved it is different than the user we're running as!
-                    console.error('// FIXME: handle asset reservation updates');
-                    this.markAssetAsAvailable(assetId);
+                    this.mergeAssetUpdate(assetId, {
+                        reservationToken: null
+                    });
+
                     break;
                 default:
                     console.warn(
                         `Unknown message type ${message.type}: ${message}`
                     );
+            }
+
+            // TODO: consider parking this behind requestAnimationFrame?
+            let assetListItem = this.assetList.lookup[assetId];
+            if (assetListItem) {
+                // If this is visible, we want to update the displayed asset
+                // list icon using the current value:
+                assetListItem.update(this.assets.get(assetId));
             }
         });
 

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -342,6 +342,14 @@ export class ActionApp {
             this.addToState('campaign', this.campaignSelect.value);
             this.updateAssetList();
         });
+
+        $('#asset-list-thumbnail-size').addEventListener('input', event => {
+            this.assetList.el.style.setProperty(
+                '--asset-thumbnail-size',
+                event.target.value + 'px'
+            );
+            this.attemptAssetLazyLoad();
+        });
     }
 
     updateAvailableCampaignFilters() {

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -95,7 +95,7 @@ export class ActionApp {
         });
 
         this.fetchAssetPage(allAssetsURL + '?pk=' + assetId).then(() => {
-            this.assetListUpdateCallbacks.push(() => {
+            this.assetList.updateCallbacks.push(() => {
                 let element = document.getElementById(assetId);
                 if (!element) {
                     console.warn('Expected to load asset with ID %s', assetId);
@@ -286,9 +286,6 @@ export class ActionApp {
         // We have a simple queue of URLs for asset pages which have not yet
         // been fetched which fetchNextAssetPage will empty:
         this.queuedAssetPageURLs = [];
-
-        // These will be processed after the next asset list update completes (possibly after a rAF / rIC chain)
-        this.assetListUpdateCallbacks = [];
 
         let loadMoreButton = $('#load-more-assets');
         loadMoreButton.addEventListener('click', () =>
@@ -616,17 +613,9 @@ export class ActionApp {
 
                 this.assetList.scrollToActiveAsset();
 
-                this.runAssetListUpdateCallbacks();
                 this.attemptAssetLazyLoad();
             });
         });
-    }
-
-    runAssetListUpdateCallbacks() {
-        while (this.assetListUpdateCallbacks.length) {
-            let callback = this.assetListUpdateCallbacks.pop();
-            callback();
-        }
     }
 
     attemptAssetLazyLoad() {

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -229,7 +229,9 @@ export class ActionApp {
                         latest_transcription: message.latest_transcription,
                         status: message.status
                     };
+
                     this.mergeAssetUpdate(assetId, assetUpdate);
+
                     break;
                 }
                 case 'asset_reservation_obtained':
@@ -480,6 +482,8 @@ export class ActionApp {
                 oldData
             )} to ${JSON.stringify(mergedData)}`
         );
+
+        mergedData.editable = this.canEditAsset(mergedData);
 
         this.assets.set(assetId, mergedData);
     }

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -746,6 +746,10 @@ export class ActionApp {
     }
 
     openViewer(assetElement) {
+        if (this.openAssetElement) {
+            this.releaseAsset();
+        }
+
         let asset = this.assets.get(assetElement.dataset.id);
 
         this.addToState('asset', asset.id);

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -278,6 +278,14 @@ export class ActionApp {
     }
 
     refreshData() {
+        console.time('Refreshing asset editability');
+
+        this.assets.forEach(asset => {
+            asset.editable = this.canEditAsset(asset);
+        });
+
+        console.timeEnd('Refreshing asset editability');
+
         this.updateAssetList();
         this.fetchAssetData(); // This starts the fetch process going by calculating the appropriate base URL
     }
@@ -521,7 +529,6 @@ export class ActionApp {
         }
 
         // FIXME: mergeAssetUpdate() should trigger a call to this
-        // FIXME: mode changes should trigger reprocessing for the entire asset list
 
         if (!asset) {
             throw `No information for an asset with ID ${assetID}`;

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -581,7 +581,7 @@ export class ActionApp {
             reason = 'Another person is working on this asset';
         }
 
-        console.info(
+        console.debug(
             'Asset ID %s: editable=%s, reason="%s"',
             assetID,
             canEdit,

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -528,8 +528,6 @@ export class ActionApp {
             assetID = asset.id;
         }
 
-        // FIXME: mergeAssetUpdate() should trigger a call to this
-
         if (!asset) {
             throw `No information for an asset with ID ${assetID}`;
         }

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -474,7 +474,9 @@ export class ActionApp {
         }
 
         for (let k of ['status', 'difficulty', 'latest_transcription']) {
-            mergedData[k] = freshestCopy[k];
+            if (k in freshestCopy) {
+                mergedData[k] = freshestCopy[k];
+            }
         }
 
         console.debug(

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -520,8 +520,8 @@ export class ActionApp {
             assetID = asset.id;
         }
 
-        // FIXME: the mergeAssetUpdate() process should trigger a call to this & update the asset list & viewer
-        // FIXME: decide what call signature will support specifying the displayed reason
+        // FIXME: mergeAssetUpdate() should trigger a call to this
+        // FIXME: mode changes should trigger reprocessing for the entire asset list
 
         if (!asset) {
             throw `No information for an asset with ID ${assetID}`;
@@ -560,10 +560,20 @@ export class ActionApp {
                 asset.status != 'in_progress'
             ) {
                 canEdit = false;
-                reason = 'this asset is not available for transcription';
+                reason = `assets with status ${
+                    asset.status
+                } are not available for transcription`;
             }
         } else {
             throw `Unexpected mode ${this.currentMode}`;
+        }
+
+        if (
+            asset.reservationToken &&
+            asset.reservationToken != this.config.reservationToken
+        ) {
+            canEdit = false;
+            reason = 'Another person is working on this asset';
         }
 
         console.info(

--- a/concordia/templates/action-app.html
+++ b/concordia/templates/action-app.html
@@ -288,11 +288,4 @@
             </p>
         </div>
     </main>
-    <footer id="action-app-footer" class="footer fixed-bottom bg-light">
-        <div class="container">
-            <div class="m-auto text-center text-muted">
-                Displaying <span id="visible-asset-count">0</span> of <span id="asset-count">0</span> assets
-            </div>
-        </div>
-    </footer>
 {% endblock site-main %}

--- a/concordia/tests/test_view.py
+++ b/concordia/tests/test_view.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 from captcha.models import CaptchaStore
 from django.conf import settings
-from django.test import TestCase, TransactionTestCase
+from django.test import TestCase, TransactionTestCase, override_settings
 from django.urls import reverse
 from django.utils.timezone import now
 
@@ -25,6 +25,7 @@ from .utils import (
 )
 
 
+@override_settings(RATELIMIT_ENABLE=False)
 class ConcordiaViewTests(JSONAssertMixin, TestCase):
     """
     This class contains the unit tests for the view in the concordia app.
@@ -361,6 +362,7 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
         self.assertIn("no-cache", resp["Cache-Control"])
 
 
+@override_settings(RATELIMIT_ENABLE=False)
 class TransactionalViewTests(JSONAssertMixin, TransactionTestCase):
     def login_user(self):
         """

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -1585,6 +1585,7 @@ class ReviewListView(AssetListView):
 
 
 @flag_required("ACTIVITY_UI_ENABLED")
+@login_required
 def action_app(request):
     return render(
         request,

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -1586,6 +1586,7 @@ class ReviewListView(AssetListView):
 
 @flag_required("ACTIVITY_UI_ENABLED")
 @login_required
+@never_cache
 def action_app(request):
     return render(
         request,

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -1603,7 +1603,7 @@ def action_app(request):
                     "campaignList": reverse("transcriptions:campaign-list"),
                 },
                 "urlTemplates": {
-                    "assetData": "/{action}.json",
+                    "assetData": "/{action}.json?per_page=500",
                     "assetReservation": "/reserve-asset/{assetId}/",
                     "saveTranscription": "/assets/{assetId}/transcriptions/save/",
                     "submitTranscription": "/transcriptions/{transcriptionId}/submit/",

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -1593,6 +1593,7 @@ def action_app(request):
             "campaigns": Campaign.objects.published().order_by("title"),
             "app_parameters": {
                 "currentUser": request.user.pk,
+                "reservationToken": get_or_create_reservation_token(request),
                 "urls": {
                     "assetUpdateSocket": request.build_absolute_uri(
                         "/ws/asset/asset_updates/"


### PR DESCRIPTION
This is based on #890 and assumes that will be merged first

* [x] Save reservation tokens from WebSocket updates
* [x] canEdit checks whether an asset is reserved using our token
* [x] Asset list is updated as soon as we receive a status update using the full canEdit check
* [x] Asset list & viewer update when a reservation has been obtained
* [ ] Asset list & viewer update when a reservation cannot be obtained due to a conflict