### PR TITLE
Remove settings from docker config that require AWS credentials 

### DIFF
--- a/concordia/settings_docker.py
+++ b/concordia/settings_docker.py
@@ -19,14 +19,6 @@ DJANGO_SECRET_KEY = os.getenv("DJANGO_SECRET_KEY", get_random_secret_key())
 
 EMAIL_BACKEND = "django.core.mail.backends.dummy.EmailBackend"
 
-S3_BUCKET_NAME = os.getenv("S3_BUCKET_NAME")
-
-DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
-AWS_STORAGE_BUCKET_NAME = S3_BUCKET_NAME
-AWS_DEFAULT_ACL = None  # Don't set an ACL on the files, inherit the bucket ACLs
-
-MEDIA_URL = "https://%s.s3.amazonaws.com/" % S3_BUCKET_NAME
-
 ELASTICSEARCH_DSL_AUTOSYNC = os.getenv("ELASTICSEARCH_DSL_AUTOSYNC", False)
 
 INSTALLED_APPS += ["django_elasticsearch_dsl"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,6 @@ services:
             POSTGRESQL_HOST: db
             POSTGRESQL_PW: ${POSTGRESQL_PW}
             CONCORDIA_ENVIRONMENT: development
-            S3_BUCKET_NAME: crowd-dev-content
             DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE:-concordia.settings_docker}
             DEBUG: ${DEBUG:-}
             REDIS_ADDRESS: redis


### PR DESCRIPTION
This takes out the S3 bucket settings that require AWS credentials to be present when running as a docker container.