### PR TITLE
Activity UI info panel cleanup

### DIFF
--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -13,6 +13,12 @@ import {
     List
 } from 'https://cdnjs.cloudflare.com/ajax/libs/redom/3.18.0/redom.es.min.js';
 
+export function conditionalUnmount(component) {
+    if (component.el.parentNode) {
+        unmount(component.el.parentNode, component);
+    }
+}
+
 export class AssetTooltip {
     constructor() {
         this.el = html('.asset-tooltip', [
@@ -738,12 +744,6 @@ class ImageViewer {
         }
 
         this.seadragon.open(tileSources, initialPage);
-    }
-}
-
-function conditionalUnmount(component) {
-    if (component.el.parentNode) {
-        unmount(component.el.parentNode, component);
     }
 }
 

--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -54,7 +54,7 @@ export class MetadataPanel {
         this.itemMetadata = new ItemMetadataDetails('Item', asset.item);
 
         this.el = html(
-            'div',
+            '#asset-metadata-panel',
             this.campaignMetadata,
             this.projectMetadata,
             this.itemMetadata

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -1,14 +1,15 @@
 /* global Split jQuery URITemplate */
 /* eslint-disable no-console */
 
+import {mount} from 'https://cdnjs.cloudflare.com/ajax/libs/redom/3.18.0/redom.es.min.js';
 import {
-    mount,
-    unmount
-} from 'https://cdnjs.cloudflare.com/ajax/libs/redom/3.18.0/redom.es.min.js';
-
-import {$, $$, setSelectValue} from './utils/dom.js';
+    AssetList,
+    AssetViewer,
+    conditionalUnmount,
+    MetadataPanel
+} from './components.js';
 import {fetchJSON, getCachedData} from './utils/api.js';
-import {MetadataPanel, AssetList, AssetViewer} from './components.js';
+import {$, $$, setSelectValue} from './utils/dom.js';
 
 export class ActionApp {
     constructor(config) {
@@ -759,7 +760,7 @@ export class ActionApp {
 
     openViewer(assetElement) {
         if (this.openAssetElement) {
-            this.releaseAsset();
+            this.closeViewer();
         }
 
         let asset = this.assets.get(assetElement.dataset.id);
@@ -856,8 +857,8 @@ export class ActionApp {
             window.clearInterval(this.reservationTimer);
         }
 
-        if (this.metadataPanel && this.metadataPanel.el.parentNode) {
-            unmount(this.metadataPanel.el.parentNode, this.metadataPanel);
+        if (this.metadataPanel) {
+            conditionalUnmount(this.metadataPanel);
         }
 
         this.assetList.scrollToActiveAsset();


### PR DESCRIPTION
This forces the full openViewer/closeViewer cycle to cleanup things like the metadata panels when transitioning without closing the viewer. We should keep an eye on the performance implications of re-instantiating OpenSeadragon like this.