### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: '.*/vendor/.*'
 repos:
     - repo: https://github.com/pre-commit/mirrors-isort
-      rev: v4.3.17
+      rev: v4.3.18
       hooks:
           - id: isort
     - repo: https://github.com/ambv/black
@@ -61,7 +61,7 @@ repos:
                 - stylelint-config-prettier@5.1.0
                 - stylelint-config-recommended@2.2.0
     - repo: https://github.com/awslabs/cfn-python-lint
-      rev: v0.19.1
+      rev: v0.20.1
       hooks:
           - id: cfn-python-lint
             files: cloudformation/.*\.(json|yml|yaml)$


### PR DESCRIPTION
The main change here is cfn-lint which has a couple of useful checks, including one which has a PR incoming shortly:

https://github.com/aws-cloudformation/cfn-python-lint/releases/tag/v0.20.0
https://github.com/aws-cloudformation/cfn-python-lint/releases/tag/v0.20.1