### PR TITLE
#812 Fix for review transcription text box and list asset thumbnail

### DIFF
--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -423,7 +423,7 @@ class ConditionalToolbar {
 class ReviewerView {
     constructor(submitActionCallback) {
         this.el = html(
-            'div#reviewer-column.flex-column.flex-grow-1',
+            'div#reviewer-column.d-flex.flex-column.flex-grow-1',
             (this.displayText = html('#review-transcription-text')),
             (this.toolbar = new ConditionalToolbar([
                 (this.rejectButton = html(

--- a/concordia/static/scss/action-app.scss
+++ b/concordia/static/scss/action-app.scss
@@ -204,9 +204,6 @@ main {
             order: 2;
             flex-grow: 0;
             flex-shrink: 0;
-            display: block;
-            width: ($concordia-app-asset-list-thumbnail-gap * 2) +
-                $concordia-app-asset-list-thumbnail-width;
             padding: 0 $concordia-app-asset-list-thumbnail-gap
                 $concordia-app-asset-list-thumbnail-gap;
         }
@@ -318,9 +315,7 @@ main {
 #review-transcription-text {
     border: 1px solid $gray-800;
     padding: 10px;
-    flex-grow: 1;
-    flex-shrink: 1;
-    max-height: 100%;
+    flex: 1 1 0;
     overflow-y: scroll;
     white-space: pre-wrap;
     .nothing-to-transcribe & {


### PR DESCRIPTION
* Fix for review transcription text box breaking the layout when the content is long
* Adjusted list asset thumbnail strip to have correct padding values applied.

![Screen Shot 2019-05-09 at 10 40 40 AM](https://user-images.githubusercontent.com/3189000/57462573-1578e600-7247-11e9-8502-f4146b3442bd.png)
