### PR TITLE
Display campaign & project thumbnails 

### DIFF
--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -69,12 +69,34 @@ class MetadataDetails {
                 text(`${sectionName}: `),
                 html('span.title', text(initialData.title))
             ]),
-            html('div.details-body')
+            html(
+                'div.details-body.clearfix',
+                (this.thumbnailLink = html(
+                    'a',
+                    {target: '_blank', hidden: true},
+                    (this.thumbnailIcon = html(
+                        'img.img-thumbnail.img-fluid.w-25.float-right'
+                    ))
+                )),
+                (this.descriptionContainer = html('div'))
+            )
         ];
         this.el = html('details', {open: true}, this.children);
     }
     update(data) {
-        $('.details-body', this.el).textContent = data.description || '';
+        this.descriptionContainer.textContent = data.description || '';
+
+        if (data.thumbnail_image) {
+            // eslint-disable-next-line unicorn/prevent-abbreviations
+            this.thumbnailIcon.src = data.thumbnail_image;
+            this.thumbnailLink.href = data.url;
+            this.thumbnailLink.removeAttribute('hidden');
+        } else {
+            // eslint-disable-next-line unicorn/prevent-abbreviations
+            this.thumbnailIcon.src = undefined;
+            this.thumbnailLink.href = undefined;
+            this.thumbnailLink.setAttribute('hidden', 'hidden');
+        }
     }
 }
 


### PR DESCRIPTION
This will display a link to the URL property and a thumbnail for any metadata element which has a 
`thumbnail_image` attribute. It makes the assumption that we will continue not to have a project which reuses the campaign thumbnail — fixing that would be slightly more involved since the campaign, project, and item metadata is retrieved asynchronously so we can't rely on any of the either values having been loaded at the time we're populating the image.

See #930