### PR TITLE
Sidebar tab exclusion behaviour

### DIFF
--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -47,7 +47,7 @@ export class ActionApp {
 
         this.setupGlobalKeyboardEvents();
 
-        this.setupToolbars();
+        this.setupSidebar();
 
         this.setupSharing();
         this.setupPersistentStateManagement();
@@ -167,22 +167,40 @@ export class ActionApp {
         this.refreshData();
     }
 
-    // FIXME: replace with a generic function since we need to both show these side panels and hide the inactive ones
-    setupToolbars() {
-        let helpToggle = $('#help-toggle');
-        let helpPanel = $('#help-panel');
+    setupSidebar() {
+        let sidebar = $('#action-app-sidebar');
+        let buttons = $$('.btn', sidebar);
 
-        helpToggle.addEventListener('click', () => {
-            helpPanel.toggleAttribute('hidden');
-            return false;
-        });
+        let hideTarget = (button, force) => {
+            let target = document.getElementById(button.dataset.target);
+            let hidden = target.toggleAttribute('hidden', force);
+            button.classList.toggle('active', !hidden);
+            return hidden;
+        };
 
-        let assetListToggle = $('#asset-list-toggle');
-        let assetList = $('#asset-list-container');
+        let toggleButton = clickedButton => {
+            let hidden = hideTarget(clickedButton);
 
-        assetListToggle.addEventListener('click', () => {
-            assetList.toggleAttribute('hidden');
-            return false;
+            if (!hidden) {
+                // If we just made something visible we'll hide any other button's targets
+                // as long as they aren't pinned to apply only when an asset is open:
+                buttons
+                    .filter(button => button != clickedButton)
+                    .filter(
+                        button =>
+                            this.openAssetElement ||
+                            !('toggleableOnlyWhenOpen' in button.dataset)
+                    )
+                    .forEach(button => {
+                        hideTarget(button, true);
+                    });
+            }
+        };
+
+        buttons.forEach(button => {
+            button.addEventListener('click', event => {
+                toggleButton(event.currentTarget);
+            });
         });
     }
 

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -174,7 +174,6 @@ export class ActionApp {
 
         helpToggle.addEventListener('click', () => {
             helpPanel.toggleAttribute('hidden');
-            helpToggle.classList.toggle('hidden');
             return false;
         });
 
@@ -183,7 +182,6 @@ export class ActionApp {
 
         assetListToggle.addEventListener('click', () => {
             assetList.toggleAttribute('hidden');
-            assetListToggle.classList.toggle('hidden');
             return false;
         });
     }

--- a/concordia/static/scss/action-app.scss
+++ b/concordia/static/scss/action-app.scss
@@ -193,7 +193,7 @@ main {
     #editor-main {
         display: none !important;
     }
-    #action-app-toolbar {
+    #action-app-sidebar {
         order: 2;
     }
     #asset-list-container {
@@ -264,7 +264,7 @@ main {
             height: 100%;
         }
 
-        #action-app-toolbar {
+        #action-app-sidebar {
             order: 1;
         }
         #help-panel {
@@ -280,7 +280,7 @@ main {
     }
 }
 
-#action-app-toolbar {
+#action-app-sidebar {
     border-left: 1px solid $concordia-app-toolbar-border;
     border-right: 1px solid $concordia-app-toolbar-border;
     background-color: $concordia-app-toolbar-background;

--- a/concordia/templates/action-app.html
+++ b/concordia/templates/action-app.html
@@ -175,7 +175,7 @@
                 </div>
             </div>
         </div>
-        <div id="action-app-sidebar" class="asset-toolbar">
+        <div id="action-app-sidebar">
             <button id="asset-list-toggle" class="btn btn-link" href="{% url 'help-center' %}" title="Open Help">
                 <span class="fas fa-th"></span>
                 <span class="sr-only">Grid list</span>

--- a/concordia/templates/action-app.html
+++ b/concordia/templates/action-app.html
@@ -180,7 +180,7 @@
                 <span class="fas fa-th"></span>
                 <span class="sr-only">Open asset list</span>
             </button>
-            <button id="help-toggle" class="btn btn-link hidden" title="Open Help">
+            <button id="help-toggle" class="btn btn-link" title="Open Help">
                 <span class="fas fa-question-circle"></span>
                 <span class="sr-only">Help</span>
             </button>

--- a/concordia/templates/action-app.html
+++ b/concordia/templates/action-app.html
@@ -176,11 +176,11 @@
             </div>
         </div>
         <div id="action-app-sidebar">
-            <button id="asset-list-toggle" class="btn btn-link" href="{% url 'help-center' %}" title="Open Help">
+            <button id="asset-list-toggle" class="btn btn-link" title="Open asset list">
                 <span class="fas fa-th"></span>
-                <span class="sr-only">Grid list</span>
+                <span class="sr-only">Open asset list</span>
             </button>
-            <button id="help-toggle" class="btn btn-link hidden" href="{% url 'help-center' %}" title="Open Help">
+            <button id="help-toggle" class="btn btn-link hidden" title="Open Help">
                 <span class="fas fa-question-circle"></span>
                 <span class="sr-only">Help</span>
             </button>

--- a/concordia/templates/action-app.html
+++ b/concordia/templates/action-app.html
@@ -175,7 +175,7 @@
                 </div>
             </div>
         </div>
-        <div id="action-app-toolbar" class="asset-toolbar">
+        <div id="action-app-sidebar" class="asset-toolbar">
             <button id="asset-list-toggle" class="btn btn-link" href="{% url 'help-center' %}" title="Open Help">
                 <span class="fas fa-th"></span>
                 <span class="sr-only">Grid list</span>

--- a/concordia/templates/action-app.html
+++ b/concordia/templates/action-app.html
@@ -176,11 +176,11 @@
             </div>
         </div>
         <div id="action-app-sidebar">
-            <button id="asset-list-toggle" class="btn btn-link" title="Open asset list">
+            <button id="asset-list-toggle" class="btn btn-link" title="Open asset list" data-target="asset-list-container" data-toggleable-only-when-open>
                 <span class="fas fa-th"></span>
                 <span class="sr-only">Open asset list</span>
             </button>
-            <button id="help-toggle" class="btn btn-link" title="Open Help">
+            <button id="help-toggle" class="btn btn-link" title="Open Help" data-target="help-panel">
                 <span class="fas fa-question-circle"></span>
                 <span class="sr-only">Help</span>
             </button>


### PR DESCRIPTION
The main point of this is the exclusive behaviour (see #930) which hides the other tab(s) when a new one is opened but it also makes a few cleanups to the sidebar button markup.