### PR TITLE
Transcription View: avoid updates for unmodified sources

### DIFF
--- a/concordia/api_views.py
+++ b/concordia/api_views.py
@@ -13,7 +13,7 @@ behaviour for the non-JSON endpoint:
 The base APIViewMixin implements a base implementation of serialize_object which
 uses the generic django.forms.models.model_to_dict and can be overridden as needed.
 """
-import time
+from time import time
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.forms.models import model_to_dict
@@ -107,7 +107,7 @@ class APIListView(APIViewMixin, ListView):
     def serialize_context(self, context):
         data = {
             "objects": [self.serialize_object(i) for i in context["object_list"]],
-            "sent": int(time.time()),
+            "sent": time(),
         }
 
         page_obj = context["page_obj"]

--- a/concordia/signals/handlers.py
+++ b/concordia/signals/handlers.py
@@ -1,3 +1,5 @@
+from time import time
+
 from asgiref.sync import AsyncToSync
 from channels.layers import get_channel_layer
 from django.conf import settings
@@ -105,5 +107,6 @@ def send_asset_reservation_message(
             "type": message_type,
             "asset_pk": asset_pk,
             "reservation_token": reservation_token,
+            "sent": time(),
         },
     )

--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -620,6 +620,23 @@ class TranscriberView {
     }
 
     update(asset) {
+        if (
+            this.currentAsset &&
+            this.currentAsset.id == asset.id &&
+            asset.latest_transcription &&
+            this.currentAsset.latest_transcription &&
+            this.currentAsset.latest_transcription.id ==
+                asset.latest_transcription.id &&
+            this.currentAsset.latest_transcription.text ==
+                asset.latest_transcription.text
+        ) {
+            // eslint-disable-next-line no-console
+            console.debug(
+                `Asset ${asset.id} unmodified; not resetting transcription view`
+            );
+            return;
+        }
+
         this.currentAsset = asset;
         let text = '';
         if (asset.latest_transcription && asset.latest_transcription.text) {

--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -259,7 +259,7 @@ class Li {
 class AssetListItem {
     constructor([assetListObserver]) {
         this.el = html('li', {
-            class: 'asset border',
+            class: 'asset',
             tabIndex: 0
         });
 
@@ -279,7 +279,7 @@ class AssetListItem {
         }
 
         this.el.id = assetData.id;
-        this.el.classList.add('asset', 'border');
+        this.el.classList.add('asset');
         this.el.dataset.image = thumbnailUrl;
         this.el.dataset.id = assetData.id;
         this.el.dataset.status = assetData.status;
@@ -397,14 +397,13 @@ export class AssetList extends List {
     }
 
     setActiveAsset(assetElement) {
-        // TODO: stop using Bootstrap classes directly and toggle semantic classes only
         $$('.asset.asset-active', this.el).forEach(element => {
             if (element != assetElement) {
-                element.classList.remove('asset-active', 'border-primary');
+                element.classList.remove('asset-active');
             }
         });
 
-        assetElement.classList.add('asset-active', 'border-primary');
+        assetElement.classList.add('asset-active');
 
         this.scrollToActiveAsset();
     }

--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -295,7 +295,7 @@ class AssetListItem {
 }
 
 export class AssetList extends List {
-    constructor(assets, callbacks) {
+    constructor(callbacks) {
         // TODO: refactor this into a utility function
         let assetListObserver = new IntersectionObserver(entries => {
             entries
@@ -337,17 +337,17 @@ export class AssetList extends List {
             }
         });
 
-        this.setupTooltip(assets);
+        this.setupTooltip(callbacks.getAssetData);
     }
 
-    setupTooltip(assets) {
+    setupTooltip(getAssetData) {
         /* Tooltips */
         let tooltip = new AssetTooltip();
 
         const handleTooltipShowEvent = event => {
             let target = event.target;
             if (target && target.classList.contains('asset')) {
-                const asset = assets.get(target.dataset.id);
+                const asset = getAssetData(target.dataset.id);
                 tooltip.update(asset);
                 mount(target, tooltip);
             }

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -787,22 +787,15 @@ export class ActionApp {
 
         // FIXME: refactor openAssetElement into a single open asset ID property & pass it to the respective list & viewer components
         this.openAssetElement = assetElement;
+        this.assetReservationURL = this.urlTemplates.assetReservation.expand({
+            assetId: encodeURIComponent(asset.id)
+        });
 
-        let {canEdit} = this.canEditAsset(asset);
-
-        if (canEdit) {
-            this.assetReservationURL = this.urlTemplates.assetReservation.expand(
-                {
-                    assetId: encodeURIComponent(asset.id)
-                }
-            );
-
-            this.reserveAsset();
-            this.reservationTimer = window.setInterval(
-                this.reserveAsset.bind(this),
-                30000
-            );
-        }
+        this.reserveAsset();
+        this.reservationTimer = window.setInterval(
+            this.reserveAsset.bind(this),
+            30000
+        );
 
         this.metadataPanel = new MetadataPanel(asset);
         mount(
@@ -881,8 +874,22 @@ export class ActionApp {
     }
 
     reserveAsset() {
+        // TODO: refactor open asset DOM/class references
+        if (!this.appElement.dataset.openAssetId) {
+            console.warn('reserveAsset called without an open asset?');
+            return;
+        }
+
         if (!this.assetReservationURL) {
             console.warn('reserveAsset called without asset reservation URL!');
+            return;
+        }
+
+        let asset = this.assets.get(this.appElement.dataset.openAssetId);
+        let {canEdit, reason} = this.canEditAsset(asset);
+
+        if (!canEdit) {
+            console.info(`Asset ${asset.id} cannot be edited: ${reason}`);
             return;
         }
 

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -844,7 +844,7 @@ export class ActionApp {
 
         let {canEdit, reason} = this.canEditAsset(asset);
 
-        if (!this.assetReserved) {
+        if (canEdit && !this.assetReserved) {
             canEdit = false;
             reason = 'Asset reservation in progress';
         }

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -936,7 +936,6 @@ export class ActionApp {
 
     releaseAsset() {
         if (!this.assetReservationURL) {
-            console.warn('releaseAsset called without asset reservation URL!');
             return;
         }
 

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -994,6 +994,7 @@ export class ActionApp {
                     asset.latest_transcription.id = responseData.id;
                     asset.latest_transcription.text = responseData.text;
                     this.mergeAssetUpdate(responseData.asset.id, {
+                        sent: responseData.sent,
                         status: responseData.asset.status
                     });
                     updateViews();
@@ -1009,6 +1010,7 @@ export class ActionApp {
                     })
                 ).done(responseData => {
                     this.mergeAssetUpdate(responseData.asset.id, {
+                        sent: responseData.sent,
                         status: responseData.asset.status
                     });
                     updateViews();
@@ -1022,6 +1024,7 @@ export class ActionApp {
                     {action: 'accept'}
                 ).done(responseData => {
                     this.mergeAssetUpdate(responseData.asset.id, {
+                        sent: responseData.sent,
                         status: responseData.asset.status
                     });
                     this.releaseAsset();
@@ -1036,6 +1039,7 @@ export class ActionApp {
                     {action: 'reject'}
                 ).done(responseData => {
                     this.mergeAssetUpdate(responseData.asset.id, {
+                        sent: responseData.sent,
                         status: responseData.asset.status
                     });
                 });

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -280,6 +280,13 @@ export class ActionApp {
                         reservationToken: null
                     });
 
+                    if (
+                        this.appElement.dataset.openAssetId &&
+                        this.appElement.dataset.openAssetId == assetId
+                    ) {
+                        this.reserveAsset();
+                    }
+
                     break;
                 default:
                     console.warn(
@@ -894,6 +901,8 @@ export class ActionApp {
         }
 
         let reservationURL = this.assetReservationURL;
+
+        // TODO: record the last asset renewal time and don't renew early unless the ID has changed
 
         jQuery
             .ajax({

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -580,7 +580,7 @@ export class ActionApp {
         let reason = '';
 
         if (asset.status == 'completed') {
-            reason = 'This page has already been completed';
+            reason = 'This page has been completed';
             canEdit = false;
         } else if (this.currentMode == 'review') {
             if (asset.status != 'submitted') {

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -886,16 +886,16 @@ export class ActionApp {
             return;
         }
 
-        if (!this.assetReservationURL) {
-            console.warn('reserveAsset called without asset reservation URL!');
-            return;
-        }
-
         let asset = this.getAssetData(this.openAssetId);
         let {canEdit, reason} = this.canEditAsset(asset);
 
         if (!canEdit) {
             console.info(`Asset ${asset.id} cannot be edited: ${reason}`);
+            return;
+        }
+
+        if (!this.assetReservationURL) {
+            console.warn('reserveAsset called without asset reservation URL!');
             return;
         }
 

--- a/concordia/static/scss/action-app.scss
+++ b/concordia/static/scss/action-app.scss
@@ -110,12 +110,15 @@ main {
     grid-template-columns: repeat(auto-fill, var(--asset-thumbnail-size));
     grid-template-rows: auto;
     justify-content: center;
+
     .asset {
         display: flex;
         width: var(--asset-thumbnail-size);
         height: var(--asset-thumbnail-size);
         object-fit: contain;
-        border-color: $gray-600 !important;
+
+        border: $border-width solid $gray-600;
+
         background-color: #f6f6f6;
         background-size: contain;
         background-repeat: no-repeat;

--- a/concordia/static/scss/action-app.scss
+++ b/concordia/static/scss/action-app.scss
@@ -129,6 +129,11 @@ main {
         transition-property: height, width;
         transition-duration: 0.1s;
 
+        &.asset-active {
+            outline: 2px auto $orange;
+            outline-offset: -2px;
+        }
+
         &[data-unavailable] {
             position: relative;
             &::before {


### PR DESCRIPTION
This avoids the problem in #949 where the update triggered by the reservation system would cause
the transcription view to replace any unsaved text with the original starting text. Now the update
method will not replace the text when the upstream value has not changed.

* [x] Confirm that text changes are not replaced by the reservation renewal updates
* [x] Confirm that updates made by another user are reflected when the reservation is eventually obtained
* [x] Confirm that unavailable assets will be retried 
* [ ] Confirm that the UI does not unlock before it has been updated to the latest transcription made by someone else