### PR TITLE
#963 Styling for tabs active and inactive states and adding ARIA attributes

### DIFF
--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -175,6 +175,11 @@ export class ActionApp {
             let target = document.getElementById(button.dataset.target);
             let hidden = target.toggleAttribute('hidden', force);
             button.classList.toggle('active', !hidden);
+            if (button.classList.contains('active')) {
+                button.setAttribute('aria-selected', 'true');
+            } else {
+                button.setAttribute('aria-selected', 'false');
+            }
             return hidden;
         };
 

--- a/concordia/static/scss/action-app.scss
+++ b/concordia/static/scss/action-app.scss
@@ -285,15 +285,15 @@ main {
     border-right: 1px solid $concordia-app-toolbar-border;
     background-color: $concordia-app-toolbar-background;
     button {
-        border: 1px solid $concordia-app-toolbar-border;
-        border-right-color: $concordia-app-active-color;
+        border: 1px solid transparent;
         border-radius: 0;
         margin: -1px -1px 5px;
-        background-color: $concordia-app-active-color;
+        background-color: transparent;
         font-size: 20px;
-        &.hidden {
-            border-color: transparent;
-            background-color: transparent;
+        &.active {
+            border-color: $concordia-app-toolbar-border;
+            background-color: $concordia-app-active-color;
+            border-right-color: $concordia-app-active-color;
         }
     }
 }

--- a/concordia/templates/action-app.html
+++ b/concordia/templates/action-app.html
@@ -175,17 +175,17 @@
                 </div>
             </div>
         </div>
-        <div id="action-app-sidebar">
-            <button id="asset-list-toggle" class="btn btn-link" title="Open asset list" data-target="asset-list-container" data-toggleable-only-when-open>
+        <div id="action-app-sidebar" role="tablist" aria-label="Tabs">
+            <button id="asset-list-toggle" class="btn btn-link active" title="Open asset list" role="tab" aria-controls="asset-list-container" aria-selected="true" data-target="asset-list-container" data-toggleable-only-when-open>
                 <span class="fas fa-th"></span>
                 <span class="sr-only">Open asset list</span>
             </button>
-            <button id="help-toggle" class="btn btn-link" title="Open Help" data-target="help-panel">
+            <button id="help-toggle" class="btn btn-link" title="Open Help" role="tab" aria-controls="help-panel"  aria-selected="false" data-target="help-panel">
                 <span class="fas fa-question-circle"></span>
                 <span class="sr-only">Help</span>
             </button>
         </div>
-        <div id="asset-list-container">
+        <div id="asset-list-container" role="tabpanel" aria-labelledby="asset-list-toggle">
             <form id="asset-list-controls" class="sticky-top form-inline flex-nowrap justify-content-center mb-3 py-3" role="navigation">
                 <div class="input-group input-group-sm mx-2 flex-nowrap">
                     <div class="input-group-prepend">
@@ -232,7 +232,7 @@
 
             <button id="load-more-assets" class="btn btn-secondary btn-block btn-sm">Load more…</button>
         </div>
-        <aside id="help-panel" hidden>
+        <aside id="help-panel" role="tabpanel" aria-labelledby="help-toggle" hidden>
             <h2 class="sr-only">Help</h2>
             <section>
                 <h3>Transcription tips</h3>


### PR DESCRIPTION
* Styling for tabs active and inactive states.
* Added `tablist`, `tab` and `tabpanel` roles attributes to let screen reader know that this is a tabbed component.
* Added 'aria-controls`, 'aria-labelledby` and 'aria-selected` attributes to let screen reader know the relationships between elements are clear.