### PR TITLE
Alerts for transient errors

### DIFF
--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -19,6 +19,31 @@ export function conditionalUnmount(component) {
     }
 }
 
+export class Alert {
+    constructor(level = 'warning') {
+        this.el = html(
+            `.alert alert-${level} alert-dismissible fade show position-fixed fixed-bottom mb-0`,
+            {role: 'alert'},
+            (this.header = html('strong')),
+            (this.body = html('span')),
+            html(
+                'button.close',
+                {
+                    type: 'button',
+                    'data-dismiss': 'alert',
+                    'aria-label': 'Close'
+                },
+                html('span.fas.fa-times-circle', {'aria-hidden': 'true'})
+            )
+        );
+    }
+
+    update(header, body) {
+        this.header.textContent = header;
+        this.body.textContent = body;
+    }
+}
+
 export class AssetTooltip {
     constructor() {
         this.el = html('.asset-tooltip', [

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -87,6 +87,10 @@ export class ActionApp {
         }
     }
 
+    clearAllErrors() {
+        Object.keys(this.alerts).forEach(category => this.clearError(category));
+    }
+
     setupPersistentStateManagement() {
         this.persistentState = new URLSearchParams(
             window.location.hash.replace(/^#/, '')
@@ -909,6 +913,8 @@ export class ActionApp {
         if (this.metadataPanel) {
             conditionalUnmount(this.metadataPanel);
         }
+
+        this.clearAllErrors();
 
         this.assetList.scrollToActiveAsset();
     }

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -1107,20 +1107,35 @@ export class ActionApp {
                 this.actionSubmissionInProgress = false;
                 this.updateViewer();
             })
-            .fail(function(jqXHR, textStatus) {
+            .done(() => {
+                this.clearError('user-action');
+            })
+            .fail((jqXHR, textStatus) => {
                 if (jqXHR.status == 401) {
                     alert(
                         '// FIXME: the CAPTCHA system is not implemented yet. Please hit the main site before returning to this page'
                     );
                 }
 
+                let details = jqXHR.responseJSON
+                    ? jqXHR.responseJSON.error
+                    : jqXHR.responseText;
+
+                if (!details) {
+                    details = textStatus;
+                }
+
                 console.error(
                     'POSTed action to %s failed: %s %s',
                     url,
                     textStatus,
-                    jqXHR.responseJSON
-                        ? jqXHR.responseJSON.error
-                        : jqXHR.responseText
+                    details
+                );
+
+                this.reportError(
+                    'user-action',
+                    'Unable to save your work',
+                    details
                 );
             });
     }

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -953,6 +953,8 @@ export class ActionApp {
                     }`;
                 }
 
+                this.clearError('reservation');
+
                 this.assetReserved = true;
                 this.updateViewer();
             })
@@ -962,6 +964,13 @@ export class ActionApp {
                     textStatus,
                     errorThrown
                 );
+
+                this.reportError(
+                    'reservation',
+                    `Unable to reserve asset`,
+                    errorThrown ? `${textStatus}: ${errorThrown}` : textStatus
+                );
+
                 this.assetReserved = false;
                 this.updateViewer();
             });

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -3,6 +3,7 @@
 
 import {mount} from 'https://cdnjs.cloudflare.com/ajax/libs/redom/3.18.0/redom.es.min.js';
 import {
+    Alert,
     AssetList,
     AssetViewer,
     conditionalUnmount,
@@ -31,6 +32,8 @@ export class ActionApp {
 
         this.appElement = $('#action-app-main');
 
+        this.alerts = {};
+
         /*
             These will store *all* metadata retrieved from the API so it can be
             easily queried and updated.
@@ -57,6 +60,31 @@ export class ActionApp {
         this.restoreOpenAsset();
 
         this.refreshData();
+    }
+
+    reportError(category, header, body) {
+        let alert;
+
+        if (!this.alerts.hasOwnProperty(category)) {
+            alert = new Alert();
+            this.alerts[category] = alert;
+            mount(document.body, alert);
+            jQuery(alert.el)
+                .alert()
+                .on('closed.bs.alert', () => {
+                    delete this.alerts[category];
+                });
+        } else {
+            alert = this.alerts[category];
+        }
+
+        alert.update(header, body);
+    }
+
+    clearError(category) {
+        if (this.alerts.hasOwnProperty(category)) {
+            jQuery(this.alerts[category].el).alert('close');
+        }
     }
 
     setupPersistentStateManagement() {

--- a/concordia/static/scss/action-app.scss
+++ b/concordia/static/scss/action-app.scss
@@ -18,6 +18,10 @@ kbd {
     border: 1px solid $gray-400;
 }
 
+.alert strong + span::before {
+    content: ': ';
+}
+
 .concordia-app-font-size-xxs {
     font-size: $concordia-app-font-size-xxs;
 }


### PR DESCRIPTION
This adds visible alerts for the various XHR-related failure paths:

* [x] The `Alert` component currently uses [Bootstrap alerts](https://getbootstrap.com/docs/4.3/components/alerts/) but is designed to be replaced/customized
* [x] Currently alerts are treated as singletons based on the category (current “reservation” or “user-action”)
* [x] Alerts are currently cleared any time the viewer is closed 

![Screen Shot 2019-05-16 at 16 27 23-fullpage](https://user-images.githubusercontent.com/46565/57884914-c8bd7e00-77f7-11e9-8f75-08c141dbf864.png)
