### PR TITLE
Stable asset list sorting

### DIFF
--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -707,7 +707,7 @@ export class ActionApp {
                 keyFromAsset = asset => asset.item.item_id;
                 break;
             case 'recent':
-                keyFromAsset = asset => [asset.sent, asset.id];
+                keyFromAsset = asset => [-asset.sent, asset.id];
                 break;
             case 'year':
                 keyFromAsset = asset => asset.year;

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -1,4 +1,4 @@
-/* global Split jQuery URITemplate */
+/* global Split jQuery URITemplate sortBy */
 /* eslint-disable no-console */
 
 import {mount} from 'https://cdnjs.cloudflare.com/ajax/libs/redom/3.18.0/redom.es.min.js';
@@ -717,17 +717,7 @@ export class ActionApp {
                 keyFromAsset = asset => asset.id;
         }
 
-        return assetList.sort((a, b) => {
-            let aKey = keyFromAsset(a),
-                bKey = keyFromAsset(b);
-            if (aKey < bKey) {
-                return -1;
-            } else if (aKey > bKey) {
-                return 1;
-            } else {
-                return 0;
-            }
-        });
+        return sortBy(assetList, keyFromAsset);
     }
 
     getVisibleAssets(alwaysIncludedAssetIDs) {

--- a/concordia/templates/action-app.html
+++ b/concordia/templates/action-app.html
@@ -33,6 +33,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/openseadragon/2.4.0/openseadragon.min.js" integrity="sha256-grVJpqgDSGBx1q2llmvY+J5zU9hEHbO7UvftFY2bK1w=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.19.1/URI.min.js" integrity="sha256-D3tK9Rf/fVqBf6YDM8Q9NCNf/6+F2NOKnYSXHcl0keU=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.19.1/URITemplate.min.js" integrity="sha256-LIw9ihYxDmHK4yHsnaQuuH6vWWX+2PtEYqj/EcEJNfg=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/array-sort-by@1.2.1/dist/sort-by.min.js" integrity="sha256-ZSshktBu+pa8OKW2vtaIS5DmOklB9+p7OMhVwhjJAlA=" crossorigin="anonymous"></script>
 
     {{ app_parameters|json_script:"app-parameters" }}
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -332,7 +332,6 @@
             "version": "6.10.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
             "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-            "dev": true,
             "requires": {
                 "fast-deep-equal": "^2.0.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -576,6 +575,15 @@
                     "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
                     "dev": true
                 }
+            }
+        },
+        "array-sort-by": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/array-sort-by/-/array-sort-by-1.2.1.tgz",
+            "integrity": "sha512-n9/QOUEHspBsztm1rzKPQx0+tVIpAJf7QTTciLIArb6P4dvZ8fNlk8fhGGuCHkU1+oZtsnZAuPPYtaFEjEofIw==",
+            "requires": {
+                "ajv": "^6.1.1",
+                "core-js": "^2.5.3"
             }
         },
         "array-union": {
@@ -1703,8 +1711,7 @@
         "core-js": {
             "version": "2.6.5",
             "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-            "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
-            "dev": true
+            "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -3713,8 +3720,7 @@
         "fast-deep-equal": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-            "dev": true
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
         },
         "fast-diff": {
             "version": "1.2.0",
@@ -3739,8 +3745,7 @@
         "fast-json-stable-stringify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-            "dev": true
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
         },
         "fast-levenshtein": {
             "version": "2.0.6",
@@ -7382,8 +7387,7 @@
         "json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -10800,8 +10804,7 @@
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-            "dev": true
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         },
         "q": {
             "version": "1.5.1",
@@ -13013,7 +13016,6 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-            "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
             }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "stylelint-config-recommended": "^2.2.0"
     },
     "dependencies": {
+        "array-sort-by": "^1.2.1",
         "bootstrap": "4.3.1",
         "jquery": "^3.4.1",
         "popper.js": "^1.14.7"


### PR DESCRIPTION
This improves the asset list sorting by making it stable for arrays which contain a mix of strings & numbers (which also matters for the Campaign sort after https://github.com/LibraryOfCongress/concordia/pull/964/commits/dd82245de33c5ddeacc9abbc612ee501e8420602 since that uses the asset ID as the final tie-breaker), fixes the most recent sort option to be most rather than least recent, and should be more efficient on larger lists, although it's likely that that will only be noticeable looking at the console timing reports.

I added an NPM dependency even though we're not bundling it yet so we'll get update/vulnerability alerts.