### PR TITLE
“More info” improvements

### DIFF
--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -147,7 +147,7 @@ class RelatedLink {
         this.el = html(
             'li.link',
             (this.title = html('h5.title')),
-            (this.link = html('a'))
+            (this.link = html('a', {target: '_blank'}))
         );
     }
     update(relatedLink) {

--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -877,8 +877,13 @@ export class AssetViewer {
 
         this.imageView.update(asset);
 
+        let external_link = new URL(asset.resource_url);
+        if (external_link.hostname == 'www.loc.gov') {
+            external_link.searchParams.set('sp', asset.sequence);
+        }
+
         $$('a.asset-external-view', this.el).forEach(i => {
-            i.href = asset.resource_url;
+            i.href = external_link;
         });
 
         [

--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -124,7 +124,7 @@ class CampaignMetadataDetails extends MetadataDetails {
     constructor(sectionName, initialData) {
         super(sectionName, initialData);
 
-        this.relatedLinkTable = new RelatedLinkTable();
+        this.relatedLinkTable = new RelatedLinks();
     }
 
     onmount() {
@@ -142,32 +142,33 @@ class CampaignMetadataDetails extends MetadataDetails {
     }
 }
 
-class RelatedLinkTableRow {
+class RelatedLink {
     constructor() {
-        this.el = html('tr', html('th'), html('td'));
+        this.el = html(
+            'li.link',
+            (this.title = html('h5.title')),
+            (this.link = html('a'))
+        );
     }
     update(relatedLink) {
-        this.el.querySelector('th').textContent = relatedLink.title;
-        setChildren(
-            this.el.querySelector('td'),
-            html('a', {href: relatedLink.url}, text(relatedLink.url))
-        );
+        this.title.textContent = relatedLink.title;
+        this.link.href = relatedLink.url;
+        this.link.textContent = relatedLink.url;
     }
 }
 
-class RelatedLinkTable {
+class RelatedLinks {
     constructor() {
-        this.tbody = list('tbody', RelatedLinkTableRow);
         this.el = html(
-            'table.related-links.table-sm',
+            '.related-links',
             {hidden: true},
-            html('caption', text('Related Links')),
-            this.tbody
+            html('h4.title', text('Related Links')),
+            (this.linkList = list('ul.list-unstyled', RelatedLink))
         );
     }
-    update(data) {
-        this.tbody.update(data);
-        setAttr(this.el, {hidden: data.length < 1});
+    update(links) {
+        this.linkList.update(links);
+        setAttr(this.el, {hidden: links.length < 1});
     }
 }
 

--- a/concordia/static/scss/action-app.scss
+++ b/concordia/static/scss/action-app.scss
@@ -317,15 +317,26 @@ main {
 }
 
 #asset-info-modal {
+    .modal-dialog {
+        max-width: 60rem;
+    }
+
     .modal-body {
         max-height: 80vh;
         overflow-y: auto;
     }
+
     *:not(.asset-title) {
         font-size: 1rem !important;
     }
     .asset-title {
         font-size: $h4-font-size !important;
+    }
+
+    .details-body {
+        .description {
+            max-width: 40rem;
+        }
     }
 }
 

--- a/concordia/static/scss/action-app.scss
+++ b/concordia/static/scss/action-app.scss
@@ -338,6 +338,35 @@ main {
             max-width: 40rem;
         }
     }
+
+    .related-links {
+        background-color: unset;
+        border: unset;
+
+        .title {
+            text-align: center;
+        }
+
+        .link {
+            .title {
+                display: inline;
+
+                &::after {
+                    content: ': ';
+                }
+            }
+
+            a {
+                display: inline-block;
+                max-width: 100%;
+                vertical-align: top;
+
+                text-overflow: ellipsis;
+                white-space: nowrap;
+                overflow: hidden;
+            }
+        }
+    }
 }
 
 #asset-metadata {
@@ -410,24 +439,6 @@ main {
 
 .current-mode {
     text-transform: capitalize;
-}
-
-.related-links {
-    table-layout: fixed;
-    caption {
-        caption-side: top-outside;
-        text-align: center;
-    }
-    td {
-        width: 50%;
-        max-width: 50%;
-        overflow: hidden;
-    }
-    a {
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        overflow: hidden;
-    }
 }
 
 .metadata-list .title {


### PR DESCRIPTION
# Changes

* Increases the width of the “More Info” dialog to reduce text wrapping. This is a modest increase because making it wider would require us to start setting maximum sizes & responsiveness thresholds but there might be a merit to doing that to improve the raw metadata viewing experience.
* Changes the related links display to a list display to make better use of horizontal space by allowing long URLs to wrap under the titles when necessary. URLs will still be truncated with an ellipsis when they cannot fit on one line.
* Set max-width on the description text for readability

## Before 

![More Info - before](https://user-images.githubusercontent.com/46565/57941993-5ce22080-789e-11e9-8b42-1f7996eb260a.png)

## After

![More Info - after](https://user-images.githubusercontent.com/46565/57941998-610e3e00-789e-11e9-9ae2-0e53f1d55263.png)

