### PR TITLE
Use pikaweb to pull in ES6 modules

### DIFF
--- a/concordia/static/.gitignore
+++ b/concordia/static/.gitignore
@@ -1,0 +1,1 @@
+web_modules

--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -11,7 +11,7 @@ import {
     setChildren,
     setAttr,
     List
-} from 'https://cdnjs.cloudflare.com/ajax/libs/redom/3.18.0/redom.es.min.js';
+} from '../../web_modules/redom.js';
 
 export function conditionalUnmount(component) {
     if (component.el.parentNode) {

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -1,7 +1,9 @@
-/* global Split jQuery URITemplate sortBy */
+/* global Split jQuery URITemplate */
 /* eslint-disable no-console */
 
-import {mount} from 'https://cdnjs.cloudflare.com/ajax/libs/redom/3.18.0/redom.es.min.js';
+import {mount} from '../../web_modules/redom.js';
+import sortBy from '../../web_modules/array-sort-by.js';
+
 import {
     Alert,
     AssetList,

--- a/concordia/templates/action-app.html
+++ b/concordia/templates/action-app.html
@@ -33,7 +33,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/openseadragon/2.4.0/openseadragon.min.js" integrity="sha256-grVJpqgDSGBx1q2llmvY+J5zU9hEHbO7UvftFY2bK1w=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.19.1/URI.min.js" integrity="sha256-D3tK9Rf/fVqBf6YDM8Q9NCNf/6+F2NOKnYSXHcl0keU=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.19.1/URITemplate.min.js" integrity="sha256-LIw9ihYxDmHK4yHsnaQuuH6vWWX+2PtEYqj/EcEJNfg=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/array-sort-by@1.2.1/dist/sort-by.min.js" integrity="sha256-ZSshktBu+pa8OKW2vtaIS5DmOklB9+p7OMhVwhjJAlA=" crossorigin="anonymous"></script>
 
     {{ app_parameters|json_script:"app-parameters" }}
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -231,10 +231,52 @@
             "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
             "dev": true
         },
+        "@pika/web": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@pika/web/-/web-0.4.2.tgz",
+            "integrity": "sha512-TCovGI1anNYPbMTuZ8L2S/gW/1irDk6Xc5WCl8vTOrkH2wXZUOebaY4dUzTm6Lt9w9e7CytBj2gJsj/dhxsOxw==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.2",
+                "ora": "^3.1.0",
+                "rimraf": "^2.6.3",
+                "rollup": "^1.2.3",
+                "rollup-plugin-commonjs": "^9.2.1",
+                "rollup-plugin-json": "^3.1.0",
+                "rollup-plugin-node-resolve": "^4.2.3",
+                "rollup-plugin-replace": "^2.1.0",
+                "rollup-plugin-terser": "^4.0.4",
+                "yargs-parser": "^13.0.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                    "dev": true
+                },
+                "yargs-parser": {
+                    "version": "13.1.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.0.tgz",
+                    "integrity": "sha512-Yq+32PrijHRri0vVKQEm+ys8mbqWjLiwQkMFNXEENutzLPP0bE4Lcd4iA3OQY5HF+GD3xXxf0MEHb8E4/SA3AA==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
         "@sindresorhus/is": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
             "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
+            "dev": true
+        },
+        "@types/estree": {
+            "version": "0.0.39",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+            "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
             "dev": true
         },
         "@types/events": {
@@ -271,6 +313,15 @@
             "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
             "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
             "dev": true
+        },
+        "@types/resolve": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
+            "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "@types/unist": {
             "version": "2.0.3",
@@ -1153,6 +1204,12 @@
                 }
             }
         },
+        "builtin-modules": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
+            "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+            "dev": true
+        },
         "cache-base": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -1433,6 +1490,12 @@
             "requires": {
                 "restore-cursor": "^2.0.0"
             }
+        },
+        "cli-spinners": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.1.0.tgz",
+            "integrity": "sha512-8B00fJOEh1HPrx4fo5eW16XmE1PcL1tGpGrxy63CXGP9nHdPBN63X75hA1zhvQuhVztJWLqV58Roj2qlNM7cAA==",
+            "dev": true
         },
         "cli-width": {
             "version": "2.2.0",
@@ -2565,6 +2628,23 @@
             "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
             "dev": true
         },
+        "defaults": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+            "dev": true,
+            "requires": {
+                "clone": "^1.0.2"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+                    "dev": true
+                }
+            }
+        },
         "define-properties": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -3372,6 +3452,12 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
             "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+            "dev": true
+        },
+        "estree-walker": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.0.tgz",
+            "integrity": "sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw==",
             "dev": true
         },
         "esutils": {
@@ -5994,6 +6080,12 @@
             "integrity": "sha1-LhmX+m6RZuqsAkLarkQ0A+TvHZc=",
             "dev": true
         },
+        "is-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+            "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+            "dev": true
+        },
         "is-natural-number": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz",
@@ -6273,6 +6365,27 @@
             "requires": {
                 "has-to-string-tag-x": "^1.2.0",
                 "is-object": "^1.0.1"
+            }
+        },
+        "jest-worker": {
+            "version": "24.6.0",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
+            "integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
+            "dev": true,
+            "requires": {
+                "merge-stream": "^1.0.1",
+                "supports-color": "^6.1.0"
+            },
+            "dependencies": {
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "jpegoptim-bin": {
@@ -7865,6 +7978,15 @@
             "dev": true,
             "requires": {
                 "es5-ext": "~0.10.2"
+            }
+        },
+        "magic-string": {
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
+            "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
+            "dev": true,
+            "requires": {
+                "sourcemap-codec": "^1.4.4"
             }
         },
         "make-dir": {
@@ -9734,6 +9856,37 @@
                 }
             }
         },
+        "ora": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
+            "integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.2",
+                "cli-cursor": "^2.1.0",
+                "cli-spinners": "^2.0.0",
+                "log-symbols": "^2.2.0",
+                "strip-ansi": "^5.2.0",
+                "wcwidth": "^1.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
         "ordered-read-streams": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
@@ -10950,6 +11103,11 @@
                 "strip-indent": "^1.0.1"
             }
         },
+        "redom": {
+            "version": "3.20.1",
+            "resolved": "https://registry.npmjs.org/redom/-/redom-3.20.1.tgz",
+            "integrity": "sha512-hexuqDFiwXPQdUUrQxPHUROE5dIdr2/ZtwnRSnMnedi7/icbCohkUzbT8Y230eU4PUinLLY8xi9mo9nJbcNJdw=="
+        },
         "regenerator-runtime": {
             "version": "0.11.1",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -11228,6 +11386,90 @@
                 "glob": "^7.1.3"
             }
         },
+        "rollup": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.12.2.tgz",
+            "integrity": "sha512-ePehZfVMIE4eO0/LV6VaMY8kp0D9sbziUabpBeJbHAHa2WJPxuS0lYLmiLamb02e098RIRyq1F2yjM4O08dQVA==",
+            "dev": true,
+            "requires": {
+                "@types/estree": "0.0.39",
+                "@types/node": "^12.0.2",
+                "acorn": "^6.1.1"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "12.0.2",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz",
+                    "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA==",
+                    "dev": true
+                }
+            }
+        },
+        "rollup-plugin-commonjs": {
+            "version": "9.3.4",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.3.4.tgz",
+            "integrity": "sha512-DTZOvRoiVIHHLFBCL4pFxOaJt8pagxsVldEXBOn6wl3/V21wVaj17HFfyzTsQUuou3sZL3lEJZVWKPFblJfI6w==",
+            "dev": true,
+            "requires": {
+                "estree-walker": "^0.6.0",
+                "magic-string": "^0.25.2",
+                "resolve": "^1.10.0",
+                "rollup-pluginutils": "^2.6.0"
+            }
+        },
+        "rollup-plugin-json": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-json/-/rollup-plugin-json-3.1.0.tgz",
+            "integrity": "sha512-BlYk5VspvGpjz7lAwArVzBXR60JK+4EKtPkCHouAWg39obk9S61hZYJDBfMK+oitPdoe11i69TlxKlMQNFC/Uw==",
+            "dev": true,
+            "requires": {
+                "rollup-pluginutils": "^2.3.1"
+            }
+        },
+        "rollup-plugin-node-resolve": {
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.2.4.tgz",
+            "integrity": "sha512-t/64I6l7fZ9BxqD3XlX4ZeO6+5RLKyfpwE2CiPNUKa+GocPlQhf/C208ou8y3AwtNsc6bjSk/8/6y/YAyxCIvw==",
+            "dev": true,
+            "requires": {
+                "@types/resolve": "0.0.8",
+                "builtin-modules": "^3.1.0",
+                "is-module": "^1.0.0",
+                "resolve": "^1.10.0"
+            }
+        },
+        "rollup-plugin-replace": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz",
+            "integrity": "sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==",
+            "dev": true,
+            "requires": {
+                "magic-string": "^0.25.2",
+                "rollup-pluginutils": "^2.6.0"
+            }
+        },
+        "rollup-plugin-terser": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-4.0.4.tgz",
+            "integrity": "sha512-wPANT5XKVJJ8RDUN0+wIr7UPd0lIXBo4UdJ59VmlPCtlFsE20AM+14pe+tk7YunCsWEiuzkDBY3QIkSCjtrPXg==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "jest-worker": "^24.0.0",
+                "serialize-javascript": "^1.6.1",
+                "terser": "^3.14.1"
+            }
+        },
+        "rollup-pluginutils": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.7.1.tgz",
+            "integrity": "sha512-3nRf3buQGR9qz/IsSzhZAJyoK663kzseps8itkYHr+Z7ESuaffEPfgRinxbCRA0pf0gzLqkNKkSb8aNVTq75NA==",
+            "dev": true,
+            "requires": {
+                "estree-walker": "^0.6.0",
+                "micromatch": "^3.1.10"
+            }
+        },
         "run-async": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -11367,6 +11609,12 @@
             "requires": {
                 "semver": "^5.3.0"
             }
+        },
+        "serialize-javascript": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
+            "integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==",
+            "dev": true
         },
         "set-blocking": {
             "version": "2.0.0",
@@ -11585,10 +11833,34 @@
                 "urix": "^0.1.0"
             }
         },
+        "source-map-support": {
+            "version": "0.5.12",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+            "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
         "source-map-url": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
             "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+            "dev": true
+        },
+        "sourcemap-codec": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
+            "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
             "dev": true
         },
         "sparkles": {
@@ -12552,6 +12824,25 @@
                 "uuid": "^3.0.1"
             }
         },
+        "terser": {
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+            "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+            "dev": true,
+            "requires": {
+                "commander": "^2.19.0",
+                "source-map": "~0.6.1",
+                "source-map-support": "~0.5.10"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
         "text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -13243,6 +13534,15 @@
             "dev": true,
             "requires": {
                 "wrap-fn": "^0.1.0"
+            }
+        },
+        "wcwidth": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+            "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+            "dev": true,
+            "requires": {
+                "defaults": "^1.0.3"
             }
         },
         "which": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "devDependencies": {
+        "@pika/web": "^0.4.2",
         "axe-cli": "^3.0.0",
         "child_process": "^1.0.2",
         "eslint": "^5.16.0",
@@ -27,7 +28,8 @@
         "array-sort-by": "^1.2.1",
         "bootstrap": "4.3.1",
         "jquery": "^3.4.1",
-        "popper.js": "^1.14.7"
+        "popper.js": "^1.14.7",
+        "redom": "^3.20.1"
     },
     "name": "concordia",
     "version": "1.0.0",


### PR DESCRIPTION
These can be served natively in an HTTP/2-friendly manner while still getting the usual NPM process for audits & updates.

## TODO

* [ ] Decide whether we'll handle old packages through any means other than continuing to use CDNJS
* [ ] Decide whether we want to bundle our code or workaround Django staticfiles not rewriting ESM imports.