### PR TITLE
Overhaul image viewer controls

### DIFF
--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -768,7 +768,6 @@ class ImageViewer {
             },
             showRotationControl: true,
             showFlipControl: true,
-            sequenceMode: true,
             toolbar: 'viewer-controls',
             zoomInButton: 'viewer-zoom-in',
             zoomOutButton: 'viewer-zoom-out',
@@ -776,8 +775,6 @@ class ImageViewer {
             fullPageButton: 'viewer-full-page',
             rotateLeftButton: 'viewer-rotate-left',
             rotateRightButton: 'viewer-rotate-right',
-            nextButton: 'viewer-next-page',
-            previousButton: 'viewer-previous-page',
             flipButton: 'viewer-flip'
         });
     }

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -464,6 +464,10 @@ export class ActionApp {
             this.closeViewer();
         });
 
+        $('#viewer-help').addEventListener('click', () => {
+            document.getElementById('help-toggle').click();
+        });
+
         this.assetViewSplitter = Split(['#viewer-column', '#editor-column'], {
             sizes: [50, 50],
             minSize: 300,

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -155,8 +155,8 @@ export class ActionApp {
                 case 'F1':
                     if (!event.target.tagName.match(/(INPUT|TEXTAREA)/i)) {
                         // Either the F1 or ? keys were pressed outside of a
-                        // text field so we'll open the global help modal:
-                        window.jQuery('#help-modal').modal('show');
+                        // text field so we'll open the help sidebar:
+                        document.getElementById('help-toggle').click();
                         return false;
                     }
                     break;

--- a/concordia/templates/action-app.html
+++ b/concordia/templates/action-app.html
@@ -114,14 +114,6 @@
                                     </button>
                                 </div>
                                 <div class="d-flex btn-group btn-group-sm m-1">
-                                    <button id="viewer-previous-page" class="btn btn-default" title="Previous Page">
-                                        <span class="fas fa-arrow-left"></span>
-                                    </button>
-                                    <button id="viewer-next-page" class="btn btn-default" title="Next Page">
-                                        <span class="fas fa-arrow-right"></span>
-                                    </button>
-                                </div>
-                                <div class="d-flex btn-group btn-group-sm m-1">
                                     <button type="button" class="btn btn-default" data-toggle="modal" data-target="#keyboard-help-modal">
                                         <span class="fas fa-question-circle" aria-label="Open Help"></span>
                                     </button>

--- a/concordia/templates/action-app.html
+++ b/concordia/templates/action-app.html
@@ -112,7 +112,7 @@
                                     </button>
                                 </div>
                                 <div class="d-flex btn-group btn-group-sm m-1">
-                                    <button type="button" class="btn btn-default" data-toggle="modal" data-target="#keyboard-help-modal">
+                                    <button id="viewer-help" type="button" class="btn btn-default">
                                         <span class="fas fa-question-circle" aria-label="Open Help"></span>
                                     </button>
                                 </div>

--- a/concordia/templates/action-app.html
+++ b/concordia/templates/action-app.html
@@ -91,8 +91,6 @@
                                     <button id="viewer-home" class="btn btn-default" title="Fit Image to Viewport">
                                         <span class="fas fa-compress"></span>
                                     </button>
-                                </div>
-                                <div class="d-flex btn-group btn-group-sm m-1">
                                     <button id="viewer-zoom-in" class="btn btn-default" title="Zoom In">
                                         <span class="fas fa-search-plus"></span>
                                     </button>


### PR DESCRIPTION
Some minor tweaks from #930 

* [x] Remove the next/previous buttons in the image viewer
* [x] Combine the fit-to-viewport button with the zoom in/out buttons
* [x] Viewer help opens the help panel

## Before

![image](https://user-images.githubusercontent.com/46565/58108835-8b237100-7bba-11e9-8f80-ec6a455140d9.png)

## After

![image](https://user-images.githubusercontent.com/46565/58108863-95456f80-7bba-11e9-925b-80da6a3a740c.png)
