### PR TITLE
Correctly reset metadata thumbnails

### DIFF
--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -113,8 +113,8 @@ class MetadataDetails {
             this.thumbnailLink.removeAttribute('hidden');
         } else {
             // eslint-disable-next-line unicorn/prevent-abbreviations
-            this.thumbnailIcon.src = undefined;
-            this.thumbnailLink.href = undefined;
+            this.thumbnailIcon.src = '';
+            this.thumbnailLink.href = '';
             this.thumbnailLink.setAttribute('hidden', 'hidden');
         }
     }


### PR DESCRIPTION
This got lost in the shuffle and although it didn't have an visible effect it's sloppy