### PR TITLE
Use source instead of tileSource when checking OSD

### DIFF
--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -787,19 +787,16 @@ class ImageViewer {
     }
 
     update(asset) {
-        let tileSource = [
-            {
-                type: 'image',
-                url: asset.imageUrl
-            }
-        ];
-
+        let tileSource = {
+            type: 'image',
+            url: asset.imageUrl
+        };
         // We want to reload if the tile source has actually changed but
         // otherwise avoid interrupting the user
 
         let tilesChanged =
-            !this.seadragon.tileSources ||
-            tileSource[0].url != this.seadragon.tileSources[0].url;
+            !this.seadragon.source ||
+            tileSource[0].url != this.seadragon.source.url;
 
         if (tilesChanged) {
             if (this.seadragon.isOpen()) {


### PR DESCRIPTION
When only one tile is loaded in openseadragon, the Viewer.tileSources property is always null. So use the Viewer.source property instead.