### PR TITLE
Restore sharing toolbar copy URL function

### DIFF
--- a/concordia/templates/fragments/sharing-button-group.html
+++ b/concordia/templates/fragments/sharing-button-group.html
@@ -1,5 +1,5 @@
 <div class="concordia-share-button-group btn-group" role="navigation" aria-label="Links to share this page">
-    <a class="btn btn-link px-1 py-0" target="_blank" role="button" title="Share this page on Facebook" href="https://www.facebook.com/share.php?u={{ url|urlencode:"" }}"><span class="bitmap-icon facebook-icon"></span></a>
-    <a class="btn btn-link px-1 py-0" target="_blank" role="button" title="Share this page on Twitter" href="https://twitter.com/intent/tweet?text={% filter urlencode %}”{{ title }}” {{ url }} #ByThePeople @Crowd_LOC{% endfilter %}&amp;source=webclient"><span class="bitmap-icon twitter-icon"></span></a>
-    <a class="btn btn-link px-1 py-0" target="_blank" role="button" data-toggle="tooltip" data-trigger="manual" data-placement="bottom" aria-label="Copy this link to your clipboard" href="{{ url }}"><span class="bitmap-icon copy-link-icon"></span></a>
+    <a class="facebook-share-button btn btn-link px-1 py-0" target="_blank" role="button" title="Share this page on Facebook" href="https://www.facebook.com/share.php?u={{ url|urlencode:"" }}"><span class="bitmap-icon facebook-icon"></span></a>
+    <a class="twitter-share-button btn btn-link px-1 py-0" target="_blank" role="button" title="Share this page on Twitter" href="https://twitter.com/intent/tweet?text={% filter urlencode %}”{{ title }}” {{ url }} #ByThePeople @Crowd_LOC{% endfilter %}&amp;source=webclient"><span class="bitmap-icon twitter-icon"></span></a>
+    <a class="copy-url-button btn btn-link px-1 py-0" target="_blank" role="button" data-toggle="tooltip" data-trigger="manual" data-placement="bottom" aria-label="Copy this link to your clipboard" href="{{ url }}"><span class="bitmap-icon copy-link-icon"></span></a>
 </div>


### PR DESCRIPTION
This depends on a class which was removed in c391f04f539940e76b04a0ef739388af4f2a8c62 as part of the styling work in #948 (see #936).

Closes #987 