### PR TITLE
Improved contention display

### DIFF
--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -1,4 +1,4 @@
-/* global Split jQuery URITemplate sortBy */
+/* global Split jQuery URITemplate sortBy Sentry */
 /* eslint-disable no-console */
 
 import {mount} from 'https://cdnjs.cloudflare.com/ajax/libs/redom/3.18.0/redom.es.min.js';
@@ -191,6 +191,8 @@ export class ActionApp {
             $$('button', this.modeSelection).forEach(button => {
                 button.classList.toggle('active', button.value == mode);
             });
+        } else {
+            Sentry.captureMessage(`Setup requested for unknown ${mode} mode`);
         }
     }
 

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -187,21 +187,23 @@ export class ActionApp {
 
         let mode = this.persistentState.get('mode') || 'review';
         if (mode == 'transcribe' || mode == 'review') {
-            this.currentMode = mode;
-            $$('button', this.modeSelection).forEach(button => {
-                button.classList.toggle('active', button.value == mode);
-            });
+            this.switchMode(mode);
         } else {
             Sentry.captureMessage(`Setup requested for unknown ${mode} mode`);
         }
     }
 
     switchMode(newMode) {
-        console.info(`Switch mode from ${this.currentMode} to ${newMode}`);
+        // We'll distinguish between the initial mode setup and transitions:
+        let modeChanged = this.currentMode && this.currentMode != newMode;
+
+        console.info(
+            `switching to mode ${newMode} (previously ${this.currentMode})`
+        );
+
         this.currentMode = newMode;
         this.appElement.dataset.mode = this.currentMode;
         this.addToState('mode', this.currentMode);
-        this.queuedAssetPageURLs.length = 0;
 
         $$('button', this.modeSelection).forEach(button => {
             button.classList.toggle('active', button.value == newMode);
@@ -210,8 +212,12 @@ export class ActionApp {
         $$('.current-mode').forEach(i => (i.textContent = this.currentMode));
 
         this.updateAvailableCampaignFilters();
-        this.closeViewer();
-        this.refreshData();
+
+        if (modeChanged) {
+            this.queuedAssetPageURLs.length = 0;
+            this.closeViewer();
+            this.refreshData();
+        }
     }
 
     setupSidebar() {

--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -349,6 +349,12 @@ export class ActionApp {
                     );
             }
 
+            if (this.openAssetId && assetId == this.openAssetId) {
+                // Someone may be looking at an asset even if they have not
+                // locked it and this provides real-time updates:
+                this.updateViewer();
+            }
+
             let assetListItem = this.assetList.lookup[assetId];
             if (assetListItem) {
                 // If this is visible, we want to update the displayed asset


### PR DESCRIPTION
While attempting to reproduce #986, I noticed a couple of areas where the UI can be nicer:

* [x] The viewer can display updated transcription text immediately even if you can't make changes (currently it updates as soon as you get the reservation).
* [ ] Handle the 409 reservation errors more gracefully than the generic error banner — probably just by suppressing them unless we want to do something like display a “Will try again in n seconds…” timer message with a “try right now” button
