### PR TITLE
Correct latest_transcription retrieval for asset bulk views

### DIFF
--- a/concordia/tests/test_api_views.py
+++ b/concordia/tests/test_api_views.py
@@ -1,0 +1,88 @@
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from concordia.models import Asset, Item, Transcription, TranscriptionStatus
+from concordia.utils import get_anonymous_user
+
+from .utils import JSONAssertMixin, create_asset, create_item, create_project
+
+
+@override_settings(RATELIMIT_ENABLE=False)
+class ConcordiaViewTests(JSONAssertMixin, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        anon_user = get_anonymous_user()
+
+        project = create_project()
+
+        cls.items = [
+            create_item(
+                item_id=f"item_{i}", title=f"Item {i}", project=project, do_save=False
+            )
+            for i in range(0, 3)
+        ]
+        Item.objects.bulk_create(cls.items)
+
+        cls.assets = []
+        for item in cls.items:
+            for i in range(0, 15):
+                cls.assets.append(
+                    create_asset(title=f"{item.id} — {i}", item=item, do_save=False)
+                )
+        Asset.objects.bulk_create(cls.assets)
+
+        cls.transcriptions = []
+        for asset in cls.assets:
+            last_t = None
+
+            for n in range(0, 3):
+                cls.transcriptions.append(
+                    Transcription(
+                        asset=asset,
+                        supersedes=last_t,
+                        text=f"{asset} — {n}",
+                        user=anon_user,
+                    )
+                )
+        Transcription.objects.bulk_create(cls.transcriptions)
+
+    def get_asset_list(self, url, page_size=23):
+        resp = self.client.get(url, {"per_page": page_size})
+        data = self.assertValidJSON(resp)
+
+        self.assertIn("objects", data)
+        object_count = len(data["objects"])
+        self.assertLessEqual(object_count, 23)
+
+        if object_count >= page_size:
+            self.assertIn("pagination", data)
+        else:
+            self.assertNotIn("pagination", data)
+
+        return resp, data
+
+    def assertAssetStatuses(self, asset_list, expected_statuses):
+        asset_pks = [i["id"] for i in asset_list]
+
+        self.assertQuerysetEqual(
+            Asset.objects.filter(pk__in=asset_pks).exclude(
+                transcription_status__in=expected_statuses
+            ),
+            [],
+        )
+
+    def test_asset_list(self):
+        resp, data = self.get_asset_list(reverse("assets-list-json"))
+
+    def test_transcribable_asset_list(self):
+        resp, data = self.get_asset_list(reverse("transcribe-assets-json"))
+
+        self.assertAssetStatuses(
+            data["objects"],
+            [TranscriptionStatus.NOT_STARTED, TranscriptionStatus.IN_PROGRESS],
+        )
+
+    def test_reviewable_asset_list(self):
+        resp, data = self.get_asset_list(reverse("review-assets-json"))
+
+        self.assertAssetStatuses(data["objects"], [TranscriptionStatus.SUBMITTED])

--- a/concordia/tests/utils.py
+++ b/concordia/tests/utils.py
@@ -3,7 +3,7 @@ from functools import wraps
 
 from django.utils.text import slugify
 
-from concordia.models import Campaign, MediaType
+from concordia.models import Asset, Campaign, Item, MediaType, Project
 
 
 def ensure_slug(original_function):
@@ -27,13 +27,15 @@ def create_campaign(
     short_description="Short Description",
     description="Test Description",
     published=True,
+    do_save=True,
     **kwargs,
 ):
     campaign = Campaign(
         title=title, slug=slug, description=description, published=published, **kwargs
     )
     campaign.full_clean()
-    campaign.save()
+    if do_save:
+        campaign.save()
     return campaign
 
 
@@ -45,16 +47,18 @@ def create_project(
     slug="test-project",
     description="Test Description",
     published=True,
+    do_save=True,
     **kwargs,
 ):
     if campaign is None:
         campaign = create_campaign()
 
-    project = campaign.project_set.create(
-        title=title, slug=slug, published=True, **kwargs
+    project = Project(
+        campaign=campaign, title=title, slug=slug, published=True, **kwargs
     )
     project.full_clean()
-    project.save()
+    if do_save:
+        project.save()
     return project
 
 
@@ -65,16 +69,23 @@ def create_item(
     item_id="testitem.0123456789",
     item_url="http://example.com/item/testitem.0123456789/",
     published=True,
+    do_save=True,
     **kwargs,
 ):
     if project is None:
         project = create_project()
 
-    item = project.item_set.create(
-        title=title, item_id=item_id, item_url=item_url, published=True, **kwargs
+    item = Item(
+        project=project,
+        title=title,
+        item_id=item_id,
+        item_url=item_url,
+        published=True,
+        **kwargs,
     )
     item.full_clean()
-    item.save()
+    if do_save:
+        item.save()
     return item
 
 
@@ -87,11 +98,13 @@ def create_asset(
     media_type=MediaType.IMAGE,
     media_url="1.jpg",
     published=True,
+    do_save=True,
     **kwargs,
 ):
     if item is None:
         item = create_item()
-    asset = item.asset_set.create(
+    asset = Asset(
+        item=item,
         title=title,
         slug=slug,
         media_type=media_type,
@@ -100,7 +113,8 @@ def create_asset(
         **kwargs,
     )
     asset.full_clean()
-    asset.save()
+    if do_save:
+        asset.save()
     return asset
 
 

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -1392,9 +1392,10 @@ def redirect_to_next_transcribable_asset(request, *, campaign_slug):
 class AssetListView(APIListView):
     context_object_name = "assets"
     paginate_by = 50
+    queryset = Asset.objects.published()
 
     def get_queryset(self, *args, **kwargs):
-        qs = Asset.objects.published()
+        qs = super().get_queryset()
 
         pks = self.request.GET.getlist("pk")
 

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -23,17 +23,7 @@ from django.core.exceptions import ValidationError
 from django.core.mail import EmailMultiAlternatives, send_mail
 from django.core.paginator import Paginator
 from django.db import connection
-from django.db.models import (
-    Case,
-    Count,
-    F,
-    IntegerField,
-    Max,
-    OuterRef,
-    Q,
-    Subquery,
-    When,
-)
+from django.db.models import Case, Count, IntegerField, Max, OuterRef, Q, Subquery, When
 from django.db.transaction import atomic
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -1407,11 +1397,20 @@ class AssetListView(APIListView):
         qs = Asset.objects.published()
 
         pks = self.request.GET.getlist("pk")
+
         if pks:
             try:
                 qs = qs.filter(pk__in=pks)
             except (ValueError, TypeError):
                 raise Http404
+
+        latest_transcription_qs = (
+            Transcription.objects.filter(asset=OuterRef("pk"))
+            .order_by("-pk")
+            .values_list("pk", flat=True)
+        )
+
+        qs = qs.annotate(latest_transcription_pk=Subquery(latest_transcription_qs[:1]))
 
         return qs.prefetch_related("item", "item__project", "item__project__campaign")
 
@@ -1425,22 +1424,13 @@ class AssetListView(APIListView):
         ctx = super().get_context_data(**kwargs)
 
         assets = ctx["assets"]
-
         asset_pks = [i.pk for i in assets]
 
-        latest_transcription_qs = (
-            Transcription.objects.filter(asset__in=asset_pks)
-            .annotate(max_pk=Max("pk"))
-            .filter(pk=F("max_pk"))
-        )
-
-        # n.b. we use this as an opportunity to rename the user_id field to match
-        # what's being sent by the WebSocket update messages
         latest_transcriptions = {
-            asset_id: {"id": pk, "text": text, "submitted_by": user_id}
-            for asset_id, pk, user_id, text in latest_transcription_qs.values_list(
-                "asset_id", "pk", "user_id", "text"
-            )
+            asset_id: {"id": id, "submitted_by": user_id, "text": text}
+            for id, asset_id, user_id, text in Transcription.objects.filter(
+                pk__in=[i.latest_transcription_pk for i in assets]
+            ).values_list("id", "asset_id", "user_id", "text")
         }
 
         adjacent_asset_qs = Asset.objects.filter(
@@ -1469,7 +1459,7 @@ class AssetListView(APIListView):
         }
 
         for asset in assets:
-            asset.latest_transcription = latest_transcriptions.get(asset.id, None)
+            asset.latest_transcription = latest_transcriptions.get(asset.pk, None)
 
             asset.previous_sequence, asset.next_sequence = adjacent_seqs.get(
                 asset.id, (None, None)


### PR DESCRIPTION
The previous version of this did not calculate the latest transcription PK  correctly and so the retrieved values didn’t match what you’d receive through other views. 

Closes #986