### PR TITLE
add banner to classic asset detail page 

### DIFF
--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -3,6 +3,7 @@
 {% load staticfiles %}
 {% load concordia_media_tags %}
 {% load concordia_sharing_tags %}
+{% load feature_flags %}
 
 {% block title %}
 {{ asset.title }} ({{ asset.item.project.campaign.title }}: {{ asset.item.project.title }})
@@ -28,6 +29,20 @@
 {% block extra_main_classes %}flex-grow-1 d-flex flex-column{% endblock %}
 
 {% block main_content %}
+{% flag_enabled 'ADVERTISE_ACTIVITY_UI' as ADVERTISE_ACTIVITY_UI %}
+
+{% if ADVERTISE_ACTIVITY_UI and activity_mode %}
+    <div class="alert alert-dark alert-dismissible w-100" role="alert">
+        <a href="{% url 'action-app' %}#mode={{ activity_mode }}&asset={{ asset.pk }}" target="_blank">
+            Try this page in our new interface
+        </a>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+{% endif %}
+
+
 <div id="contribute-main-content" class="container-fluid flex-grow-1 d-flex flex-column d-print-block">
     <div id="navigation-container" class="row p-2 d-print-none">
         <nav id="asset-navigation" class="d-flex flex-grow-1 justify-content-between align-items-center d-print-block" role="navigation">

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -721,6 +721,14 @@ class AssetDetailView(APIDetailView):
             transcription_status = TranscriptionStatus.NOT_STARTED
         ctx["transcription_status"] = transcription_status
 
+        if (
+            transcription_status == TranscriptionStatus.NOT_STARTED
+            or transcription_status == TranscriptionStatus.IN_PROGRESS
+        ):
+            ctx["activity_mode"] = "transcribe"
+        if transcription_status == TranscriptionStatus.SUBMITTED:
+            ctx["activity_mode"] = "review"
+
         previous_asset = (
             item.asset_set.published()
             .filter(sequence__lt=asset.sequence)


### PR DESCRIPTION
Refs #920

"Try the new interface" banner added to asset detail page for transcribe-able and review-able pages only.