### PR TITLE
Remove .json alternate endpoints

### DIFF
--- a/concordia/tests/test_api_views.py
+++ b/concordia/tests/test_api_views.py
@@ -165,12 +165,12 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
                 )
 
     def test_asset_list(self):
-        resp, data = self.get_api_list_response(reverse("assets-list-json"))
+        resp, data = self.get_api_list_response(reverse("asset-list"))
 
         self.assertAssetsHaveLatestTranscriptions(data["objects"])
 
     def test_transcribable_asset_list(self):
-        resp, data = self.get_api_list_response(reverse("transcribe-assets-json"))
+        resp, data = self.get_api_list_response(reverse("transcribe-asset-list"))
 
         self.assertAssetStatuses(
             data["objects"],
@@ -180,7 +180,7 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
         self.assertAssetsHaveLatestTranscriptions(data["objects"])
 
     def test_reviewable_asset_list(self):
-        resp, data = self.get_api_list_response(reverse("review-assets-json"))
+        resp, data = self.get_api_list_response(reverse("review-asset-list"))
 
         self.assertAssetStatuses(data["objects"], [TranscriptionStatus.SUBMITTED])
 

--- a/concordia/urls.py
+++ b/concordia/urls.py
@@ -117,17 +117,11 @@ urlpatterns = [
         name="review-transcription",
     ),
     path("assets/<int:asset_pk>/tags/submit/", views.submit_tags, name="submit-tags"),
-    path("assets/", views.AssetListView.as_view(), name="assets-list"),
-    # TODO: decide whether we want to keep the .json URL formats or rely on ?format=json
-    path("assets.json", views.AssetListView.as_view(), name="assets-list-json"),
-    path("transcribe/", views.TranscribeListView.as_view(), name="transcribe-assets"),
+    path("assets/", views.AssetListView.as_view(), name="asset-list"),
     path(
-        "transcribe.json",
-        views.TranscribeListView.as_view(),
-        name="transcribe-assets-json",
+        "transcribe/", views.TranscribeListView.as_view(), name="transcribe-asset-list"
     ),
-    path("review/", views.ReviewListView.as_view(), name="review-assets"),
-    path("review.json", views.ReviewListView.as_view(), name="review-assets-json"),
+    path("review/", views.ReviewListView.as_view(), name="review-asset-list"),
     path("account/ajax-status/", views.ajax_session_status, name="ajax-session-status"),
     path("account/ajax-messages/", views.ajax_messages, name="ajax-messages"),
     path(

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -1600,7 +1600,7 @@ def action_app(request):
                     "campaignList": reverse("transcriptions:campaign-list"),
                 },
                 "urlTemplates": {
-                    "assetData": "/{action}.json?per_page=500",
+                    "assetData": "/{action}/?per_page=500",
                     "assetReservation": "/reserve-asset/{assetId}/",
                     "saveTranscription": "/assets/{assetId}/transcriptions/save/",
                     "submitTranscription": "/transcriptions/{transcriptionId}/submit/",


### PR DESCRIPTION
This reduces the number of things we need to test and we don't currently have a clear use-case for the alternate form.

Closes #997 