### PR TITLE
Basic Popper.js re-implementation of asset tooltips

### DIFF
--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -378,7 +378,7 @@ export class AssetList extends List {
                 tooltip.update(asset);
                 mount(target, tooltip);
                 popper = new Popper(target, tooltip.el, {
-                    placement: 'left'
+                    placement: 'bottom'
                 });
             }
         };

--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -1,4 +1,4 @@
-/* global jQuery, OpenSeadragon */
+/* global jQuery, OpenSeadragon, Popper */
 
 import {$, $$} from './utils/dom.js';
 
@@ -369,6 +369,7 @@ export class AssetList extends List {
     setupTooltip(getAssetData) {
         /* Tooltips */
         let tooltip = new AssetTooltip();
+        let popper;
 
         const handleTooltipShowEvent = event => {
             let target = event.target;
@@ -376,11 +377,15 @@ export class AssetList extends List {
                 const asset = getAssetData(target.dataset.id);
                 tooltip.update(asset);
                 mount(target, tooltip);
+                popper = new Popper(target, tooltip.el, {
+                    placement: 'left'
+                });
             }
         };
 
         const handleTooltipHideEvent = () => {
             if (tooltip.el.parentNode) {
+                popper.destroy();
                 unmount(tooltip.el.parentNode, tooltip);
             }
         };

--- a/concordia/static/scss/action-app.scss
+++ b/concordia/static/scss/action-app.scss
@@ -133,8 +133,13 @@ main {
         transition-property: height, width;
         transition-duration: 0.1s;
 
+        &:hover {
+            outline: 2px solid $blue;
+            outline-offset: -2px;
+        }
+
         &.asset-active {
-            outline: 2px auto $orange;
+            outline: 2px solid $orange;
             outline-offset: -2px;
         }
 

--- a/concordia/static/scss/action-app.scss
+++ b/concordia/static/scss/action-app.scss
@@ -181,15 +181,23 @@ main {
     }
 
     .asset-tooltip {
-        margin: $asset-thumbnail-gap * -1;
-        padding: 14px;
-        background-color: $white;
-        font-size: $concordia-app-font-size-xs;
-        line-height: $concordia-app-line-height-xs;
-        pointer-events: none;
-        overflow: hidden;
         width: calc(100% + ($asset-thumbnail-gap * 2));
         height: calc(100% + ($asset-thumbnail-gap * 2));
+
+        margin: $asset-thumbnail-gap * -1;
+        padding: 14px;
+
+        border: $border-width solid $gray-600;
+
+        overflow: hidden;
+
+        pointer-events: none;
+
+        background-color: $white;
+
+        font-size: $concordia-app-font-size-xs;
+        line-height: $concordia-app-line-height-xs;
+
         .item-title {
             font-weight: bold;
             margin-bottom: 1rem;


### PR DESCRIPTION
This attempts to display the tooltip to the left of the current asset, but Popper.js is smart enough not to fix it there if that would keep it offscreen. 

There’s just enough CSS to add a border — this could probably use some additional TLC for more distinct colors and we probably want to adjust widths and font sizes, too, along with possibly using some of [the available options](https://github.com/FezVrasta/popper.js/blob/master/docs/_includes/popper-documentation.md) to adjust offsets for some of the overlap situations.

See #998

## Before

![image](https://user-images.githubusercontent.com/46565/58286832-98d52400-7d7d-11e9-8b9f-2a9fa96ee617.png)

## After

![image](https://user-images.githubusercontent.com/46565/58286734-63303b00-7d7d-11e9-9711-f59b4e922f6a.png)
![image](https://user-images.githubusercontent.com/46565/58286746-6d523980-7d7d-11e9-901a-9a5b2fba7da3.png)
