### PR TITLE
Update insecure NPM dependencies

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4606,9 +4606,9 @@
             }
         },
         "fstream": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
@@ -12484,13 +12484,13 @@
             }
         },
         "tar": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+            "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
             "dev": true,
             "requires": {
                 "block-stream": "*",
-                "fstream": "^1.0.2",
+                "fstream": "^1.0.12",
                 "inherits": "2"
             }
         },


### PR DESCRIPTION
This updates the easily fixed ones automatically. I'm tempted to remove `imagemin` since it appears to have stalled and it's one of the more tedious parts to support with the various platform package dependencies, and we can simply have developers run ImageOptim.com when we update assets, which is infrequent.