### PR TITLE
Polyfill Element.toggleAttribute for MS Edge < 18

### DIFF
--- a/concordia/templates/action-app.html
+++ b/concordia/templates/action-app.html
@@ -20,6 +20,24 @@
             document.head.appendChild(s);
         })();
     </script>
+    <script>
+        // Used from https://developer.mozilla.org/en-US/docs/Web/API/Element/toggleAttribute#Polyfill under the MDN license
+        if (!Element.prototype.toggleAttribute) {
+            Element.prototype.toggleAttribute = function(name, force) {
+                if (force !== void 0) force = !!force;
+
+                if (this.getAttribute(name) !== null) {
+                    if (force) return true;
+                    this.removeAttribute(name);
+                    return false;
+                } else {
+                    if (force === false) return false;
+                    this.setAttribute(name, '');
+                    return true;
+                }
+            };
+        }
+    </script>
 {% endblock head_content %}
 
 {% block body_scripts %}


### PR DESCRIPTION
This was implemented in [Edge 18 (Windows 10 October 2018 Update)](https://docs.microsoft.com/en-us/microsoft-edge/dev-guide#whats-new-in-edgehtml-18):

https://developer.mozilla.org/en-US/docs/Web/API/Element/toggleAttribute#Browser_compatibility