### PR TITLE
Suppress conflict warnings for failed reservations

### DIFF
--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -978,17 +978,21 @@ export class ActionApp {
                 this.updateViewer();
             })
             .fail((jqXHR, textStatus, errorThrown) => {
-                console.error(
-                    'Unable to reserve asset: %s %s',
-                    textStatus,
-                    errorThrown
-                );
+                if (jqXHR.status != 409) {
+                    console.error(
+                        'Unable to reserve asset: %s %s',
+                        textStatus,
+                        errorThrown
+                    );
 
-                this.reportError(
-                    'reservation',
-                    `Unable to reserve asset`,
-                    errorThrown ? `${textStatus}: ${errorThrown}` : textStatus
-                );
+                    this.reportError(
+                        'reservation',
+                        `Unable to reserve asset`,
+                        errorThrown
+                            ? `${textStatus}: ${errorThrown}`
+                            : textStatus
+                    );
+                }
 
                 this.assetReserved = false;
                 this.updateViewer();


### PR DESCRIPTION
This is normal any time you open an asset someone else is working on.

Closes #995