### PR TITLE
Review mode: restore “nothing to transcribe badging”

### DIFF
--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -514,10 +514,10 @@ class ReviewerView {
 
         this.el.classList.toggle(
             'nothing-to-transcribe',
-            !asset.latest_transcription
+            !asset.latest_transcription.text
         );
 
-        if (asset.latest_transcription) {
+        if (asset.latest_transcription.text) {
             this.displayText.textContent = asset.latest_transcription.text;
         } else {
             this.displayText.innerHTML = 'Nothing to transcribe';


### PR DESCRIPTION
This code needed updating for the changed message format so it will display “nothing to transcribe” when the text value is empty.