### PR TITLE
Remove scroll-to-active-asset on asset list updates

### DIFF
--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -712,8 +712,6 @@ export class ActionApp {
                 this.assetList.update(visibleAssets);
                 console.timeEnd('Updating asset list');
 
-                this.assetList.scrollToActiveAsset();
-
                 this.attemptAssetLazyLoad();
             });
         });


### PR DESCRIPTION
Two of our three sort modes will cause the list to scroll when you update an asset because doing so will change the last-modification timestamp and, in most cases, the difficulty ranking. This isn't as nice an experience as it could be so we want to test a few ways to reduce the number of times the list jumps position.

Rather than special-casing the sort behaviour this PR starts with simply removing the `scrollToActiveAsset()` call from the update path. It will still happen when the viewer is opened or closed (on the theory that doing so changes the list position anyway since its size changes) and we might want to try some additional approaches before merging any of them.