### PR TITLE
Retry fetch errors

### DIFF
--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -518,6 +518,13 @@ export class ActionApp {
         let startingMode = this.currentMode;
 
         return fetchJSON(url)
+            .catch(error => {
+                console.warn(
+                    `Failed to retrieve ${url}: ${error} — returning it to the queue`
+                );
+                this.queuedAssetPageURLs.push(url);
+                throw error;
+            })
             .then(data => {
                 data.objects.forEach(i => {
                     i.sent = data.sent;


### PR DESCRIPTION
We can improve the experience for transient failures (see #1032) by retrying failed fetches automatically rather than waiting for user action. This PR currently does a basic implementation which makes `fetchJSON()` retry a certain number of times before aborting but I marked this as a draft because a) it's non-trivial to test and we should probably build in some tricks to make that easier (I've been wondering about having a debug mode for awhile) and b) I was debating whether the best answer is “retry n times”, “keep retrying endlessly with a cap at a suitably large back-off value”, “retry n times before triggering a UI cue and restarting the process”, etc.