### PR TITLE
#998 Restyled grid hover text container

### DIFF
--- a/concordia/static/js/action-app/components.js
+++ b/concordia/static/js/action-app/components.js
@@ -1,4 +1,4 @@
-/* global jQuery, OpenSeadragon, Popper */
+/* global jQuery, OpenSeadragon */
 
 import {$, $$} from './utils/dom.js';
 
@@ -369,7 +369,6 @@ export class AssetList extends List {
     setupTooltip(getAssetData) {
         /* Tooltips */
         let tooltip = new AssetTooltip();
-        let popper;
 
         const handleTooltipShowEvent = event => {
             let target = event.target;
@@ -377,15 +376,11 @@ export class AssetList extends List {
                 const asset = getAssetData(target.dataset.id);
                 tooltip.update(asset);
                 mount(target, tooltip);
-                popper = new Popper(target, tooltip.el, {
-                    placement: 'bottom'
-                });
             }
         };
 
         const handleTooltipHideEvent = () => {
             if (tooltip.el.parentNode) {
-                popper.destroy();
                 unmount(tooltip.el.parentNode, tooltip);
             }
         };

--- a/concordia/static/scss/action-app.scss
+++ b/concordia/static/scss/action-app.scss
@@ -117,12 +117,11 @@ main {
 
     .asset {
         display: flex;
+        align-items: flex-start;
         width: var(--asset-thumbnail-size);
         height: var(--asset-thumbnail-size);
         object-fit: contain;
-
         border: $border-width solid $gray-600;
-
         background-color: #f6f6f6;
         background-size: contain;
         background-repeat: no-repeat;
@@ -141,6 +140,8 @@ main {
         &.asset-active {
             outline: 2px solid $orange;
             outline-offset: -2px;
+            position: relative;
+            z-index: 1;
         }
 
         &[data-unavailable] {
@@ -186,23 +187,15 @@ main {
     }
 
     .asset-tooltip {
-        width: calc(100% + ($asset-thumbnail-gap * 2));
-        height: calc(100% + ($asset-thumbnail-gap * 2));
-
-        margin: $asset-thumbnail-gap * -1;
         padding: 14px;
-
-        border: $border-width solid $gray-600;
-
-        overflow: hidden;
-
+        border: 2px solid $blue;
         pointer-events: none;
-
         background-color: $white;
-
-        font-size: $concordia-app-font-size-xs;
+        font-size: $concordia-app-font-size-xxs !important;
         line-height: $concordia-app-line-height-xs;
-
+        position: relative;
+        z-index: 3;
+        margin: ($asset-thumbnail-gap + 1) * -1;
         .item-title {
             font-weight: bold;
             margin-bottom: 1rem;

--- a/concordia/static/scss/action-app.scss
+++ b/concordia/static/scss/action-app.scss
@@ -191,7 +191,7 @@ main {
         border: 2px solid $blue;
         pointer-events: none;
         background-color: $white;
-        font-size: $concordia-app-font-size-xxs !important;
+        font-size: $concordia-app-font-size-xxs;
         line-height: $concordia-app-line-height-xs;
         position: relative;
         z-index: 3;
@@ -273,9 +273,6 @@ main {
                 height: $concordia-app-asset-list-thumbnail-width;
                 margin-bottom: -1px;
             }
-        }
-        .asset-tooltip {
-            font-size: smaller;
         }
         #contribute-container {
             width: 100%;


### PR DESCRIPTION
I worked with @jbresner on this one. It was decided that hover text container should just be extended out if it's larger than the parent container. 

1. Removed Popper script
2. Added hover style
3. Fixed the stacking order of active state grid

Screenshots:
![Screen Shot 2019-06-03 at 3 17 17 PM](https://user-images.githubusercontent.com/3189000/58828629-dfdfd680-8613-11e9-868f-034658192f37.png)
![Screen Shot 2019-06-03 at 3 17 38 PM](https://user-images.githubusercontent.com/3189000/58828634-e2423080-8613-11e9-8f6d-f594eacf0d34.png)
![Screen Shot 2019-06-03 at 3 18 03 PM](https://user-images.githubusercontent.com/3189000/58828643-e40bf400-8613-11e9-95d9-60fd5d2e9ebe.png)


