### PR TITLE
Fix link to topic detail from campaigns-topics list page

### DIFF
--- a/concordia/templates/transcriptions/campaign_topic_list.html
+++ b/concordia/templates/transcriptions/campaign_topic_list.html
@@ -20,7 +20,13 @@
             <li class="p-4 mb-1 bg-footer">
                 <h2 class="h1 mb-3">{{ campaign.title }}</h2>
                 <div class="row">
-                    <a class="col-md-5 order-md-2" href="{{ campaign.get_absolute_url }}">
+                    <a class="col-md-5 order-md-2"
+                    {% if campaign.model_type == "Campaign" %}
+                        href="{% url 'transcriptions:campaign-detail' campaign.slug %}"
+                    {% else %}
+                        href="{% url 'topic-detail' campaign.slug %}"
+                    {% endif %}
+                    >
                         <p class="mb-2 text-center"><img src="{{ MEDIA_URL }}{{ campaign.thumbnail_image }}" class="img-fluid" alt="{{ campaign.title }} image"></p>
                     </a>
                     <div class="col-md">

--- a/concordia/templates/transcriptions/campaign_topic_list.html
+++ b/concordia/templates/transcriptions/campaign_topic_list.html
@@ -20,13 +20,7 @@
             <li class="p-4 mb-1 bg-footer">
                 <h2 class="h1 mb-3">{{ campaign.title }}</h2>
                 <div class="row">
-                    <a class="col-md-5 order-md-2"
-                    {% if campaign.model_type == "Campaign" %}
-                        href="{% url 'transcriptions:campaign-detail' campaign.slug %}"
-                    {% else %}
-                        href="{% url 'topic-detail' campaign.slug %}"
-                    {% endif %}
-                    >
+                    <a class="col-md-5 order-md-2" href="{{ campaign.get_absolute_url }}">
                         <p class="mb-2 text-center"><img src="{{ MEDIA_URL }}{{ campaign.thumbnail_image }}" class="img-fluid" alt="{{ campaign.title }} image"></p>
                     </a>
                     <div class="col-md">

--- a/concordia/templates/transcriptions/campaign_topic_list.html
+++ b/concordia/templates/transcriptions/campaign_topic_list.html
@@ -25,7 +25,7 @@
                     </a>
                     <div class="col-md">
                         <p>{{ campaign.short_description|linebreaksbr }}</p>
-                        <a class="btn btn-primary" href="{% url 'transcriptions:campaign-detail' campaign.slug %}">View Projects</a>
+                        <a class="btn btn-primary" href="{{ campaign.get_absolute_url }}">View Projects</a>
                     </div>
                 </div>
             </li>

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -528,13 +528,6 @@ class CampaignTopicListView(TemplateView):
         data = {}
         data["campaigns"] = Campaign.objects.published().order_by("ordering", "title")
         data["topics"] = Topic.objects.published().order_by("ordering", "title")
-
-        for campaign in data["campaigns"]:
-            campaign.model_type = "Campaign"
-
-        for topic in data["topics"]:
-            topic.model_type = "Topic"
-
         data["campaigns_topics"] = sorted(
             [*data["campaigns"], *data["topics"]], key=attrgetter("ordering", "title")
         )

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -528,6 +528,13 @@ class CampaignTopicListView(TemplateView):
         data = {}
         data["campaigns"] = Campaign.objects.published().order_by("ordering", "title")
         data["topics"] = Topic.objects.published().order_by("ordering", "title")
+
+        for campaign in data["campaigns"]:
+            campaign.model_type = "Campaign"
+
+        for topic in data["topics"]:
+            topic.model_type = "Topic"
+
         data["campaigns_topics"] = sorted(
             [*data["campaigns"], *data["topics"]], key=attrgetter("ordering", "title")
         )


### PR DESCRIPTION
~~Unfortunately using `get_absolute_url()` in the campaigns-topics list view only ever gives us the URL for a campaign detail page, not a topic detail page. Putting this ugly hack back in until we can figure out a more elegant solution.~~  It actually works if you use it in all the places where it's required