### PR TITLE
Implement Well-Known URL for Changing Passwords

### DIFF
--- a/concordia/urls.py
+++ b/concordia/urls.py
@@ -152,6 +152,10 @@ urlpatterns = [
     path("account/profile/", views.AccountProfileView.as_view(), name="user-profile"),
     path("account/", include("django_registration.backends.activation.urls")),
     path("account/", include("django.contrib.auth.urls")),
+    path(
+        ".well-known/change-password",  # https://wicg.github.io/change-password-url/
+        RedirectView.as_view(pattern_name="password_change"),
+    ),
     path("captcha/ajax/", views.ajax_captcha, name="ajax-captcha"),
     path("captcha/", include("captcha.urls")),
     path("admin/", admin.site.urls),


### PR DESCRIPTION
This WICG spec offers a streamlined UI for user-agents to help users
change passwords. This is currently supported by Safari 12+ and Safari
13 will extend that to offer to help users replace weak passwords with
strong ones:

https://wicg.github.io/change-password-url/index.html