### PR TITLE
Basic front-end testing setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,7 @@ repos:
                 - eslint-plugin-prettier@3.1.0
                 - prettier@1.17.1
                 - eslint-plugin-unicorn@9.0.0
+                - eslint-plugin-jest@^22.6.4
     - repo: https://github.com/awebdeveloper/pre-commit-stylelint
       rev: 0.0.2
       hooks:

--- a/concordia/static/js/base.js
+++ b/concordia/static/js/base.js
@@ -282,3 +282,17 @@ $twitterShareButton.on('click', function() {
     trackShareInteraction($twitterShareButton, 'Twitter Share');
     return true;
 });
+
+$('form.custom-validation').each(function(_, form) {
+    form.addEventListener(
+        'submit',
+        function(event) {
+            if (form.checkValidity() === false) {
+                event.preventDefault();
+                event.stopPropagation();
+            }
+            form.classList.add('was-validated');
+        },
+        false
+    );
+});

--- a/concordia/templates/contact.html
+++ b/concordia/templates/contact.html
@@ -14,7 +14,8 @@
                 </p>
                 <p>Experiencing a technical issue? Send us a message using the form below.</p>
             </div>
-            <form method="post" action="{% url 'contact' %}" id="contact-form" class="col-10 mx-auto">
+
+            <form method="post" action="{% url 'contact' %}" id="contact-form" class="col-10 mx-auto custom-validation" novalidate>
                 {% csrf_token %}
 
                 {% bootstrap_form form %}
@@ -29,12 +30,3 @@
     </div>
 </div>
 {% endblock main_content %}
-
-{% block body_scripts %}
-<script>
-    var $contactForm = $("#contact-form");
-    $contactForm.on("submit", function () {
-        $contactForm.addClass("was-validated");
-    });
-</script>
-{% endblock body_scripts %}

--- a/concordia/tests/frontend/.eslintrc.yaml
+++ b/concordia/tests/frontend/.eslintrc.yaml
@@ -1,0 +1,14 @@
+env:
+    jest: true
+    node: true
+    browser: true
+extends:
+    - ../../../.eslintrc.yaml
+    - plugin:jest/recommended
+plugins:
+    - jest
+globals:
+    page: true
+    browser: true
+    context: true
+    jestPuppeteer: true

--- a/concordia/tests/frontend/action-app.test.js
+++ b/concordia/tests/frontend/action-app.test.js
@@ -1,0 +1,22 @@
+require('dotenv').config();
+
+describe('action-app', () => {
+    beforeEach(async () => {
+        await page.goto('http://localhost:8000/account/login/?next=/act/');
+        await page.type('#id_username', process.env.TEST_USERNAME);
+        await page.type('#id_password', process.env.TEST_PASSWORD);
+        await page.click('[type=submit]');
+        await page.waitForNavigation();
+    });
+
+    it('The page should have a basic title', async () => {
+        await expect(page.title()).resolves.toMatch('Crowd: By the People');
+    });
+
+    it('The page define the actionApp object', async () => {
+        const result = await page.evaluate(() => {
+            return 'actionApp' in window;
+        });
+        expect(result).toBeTruthy();
+    });
+});

--- a/concordia/tests/frontend/action-app.test.js
+++ b/concordia/tests/frontend/action-app.test.js
@@ -1,3 +1,5 @@
+/* global actionApp */
+
 require('dotenv').config();
 
 describe('action-app', () => {
@@ -18,5 +20,22 @@ describe('action-app', () => {
             return 'actionApp' in window;
         });
         expect(result).toBeTruthy();
+    });
+
+    it('The actionApp should load data', async () => {
+        await Promise.all([
+            page.waitForRequest(request => request.url().includes('/review/')),
+            page.evaluate(() => actionApp.fetchAssetData())
+        ]);
+        const loadedAssetCount = await page.evaluate(
+            () => actionApp.assets.size
+        );
+        expect(loadedAssetCount).toBeGreaterThan(0);
+    });
+
+    it('The actionApp should connect a web socket', async () => {
+        await page.waitForRequest(request =>
+            request.url().includes('/ws/asset/asset_updates/')
+        );
     });
 });

--- a/concordia/tests/frontend/contact.test.js
+++ b/concordia/tests/frontend/contact.test.js
@@ -1,0 +1,28 @@
+describe('contact-us', () => {
+    beforeEach(async () => {
+        await page.goto('http://localhost:8000/contact/');
+    });
+
+    it('The page should have the expected title', async () => {
+        await expect(page.title()).resolves.toMatch('Crowd: Contact Us');
+    });
+
+    it('The contact form should not be valid by default', async () => {
+        const contactForm = await expect(page).toMatchElement(
+            '#contact-form:invalid'
+        );
+        await expect(contactForm).toClick('[type="submit"]');
+        await expect(page).toMatchElement(
+            '#contact-form.was-validated:invalid'
+        );
+    });
+
+    it('The contact form should become valid after filling', async () => {
+        await expect(page).toFillForm('#contact-form:invalid', {
+            email: 'test@example.com',
+            story: 'test message',
+            subject: 'test subject'
+        });
+        await expect(page).toMatchElement('#contact-form:valid');
+    });
+});

--- a/concordia/tests/frontend/homepage.test.js
+++ b/concordia/tests/frontend/homepage.test.js
@@ -1,0 +1,9 @@
+describe('homepage', () => {
+    beforeEach(async () => {
+        await page.goto('http://localhost:8000/');
+    });
+
+    it('The page should have a basic title', async () => {
+        await expect(page.title()).resolves.toMatch('Crowd: Home');
+    });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,15 @@
+// For a detailed explanation regarding each configuration property, visit:
+// https://jestjs.io/docs/en/configuration.html
+
+// n.b. this cannot be an ES6 module yet — see e.g. https://github.com/facebook/jest/issues/4126
+
+// eslint-disable-next-line no-undef
+module.exports = {
+    preset: 'jest-puppeteer',
+
+    collectCoverage: true,
+    coverageDirectory: 'coverage',
+    coveragePathIgnorePatterns: ['/node_modules/'],
+
+    notifyMode: 'failure-change'
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -85,6 +85,12 @@
                 "@babel/types": "^7.0.0"
             }
         },
+        "@babel/helper-plugin-utils": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+            "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+            "dev": true
+        },
         "@babel/helper-split-export-declaration": {
             "version": "7.4.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
@@ -121,6 +127,15 @@
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
             "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
             "dev": true
+        },
+        "@babel/plugin-syntax-object-rest-spread": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+            "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
         },
         "@babel/template": {
             "version": "7.4.4",
@@ -178,6 +193,24 @@
                 "to-fast-properties": "^2.0.0"
             }
         },
+        "@cnakazawa/watch": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
+            "integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+            "dev": true,
+            "requires": {
+                "exec-sh": "^0.3.2",
+                "minimist": "^1.2.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
+        },
         "@gulp-sourcemaps/identity-map": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.2.tgz",
@@ -215,6 +248,213 @@
                 "through2": "^2.0.3"
             }
         },
+        "@jest/console": {
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
+            "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
+            "dev": true,
+            "requires": {
+                "@jest/source-map": "^24.3.0",
+                "chalk": "^2.0.1",
+                "slash": "^2.0.0"
+            }
+        },
+        "@jest/core": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.8.0.tgz",
+            "integrity": "sha512-R9rhAJwCBQzaRnrRgAdVfnglUuATXdwTRsYqs6NMdVcAl5euG8LtWDe+fVkN27YfKVBW61IojVsXKaOmSnqd/A==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^24.7.1",
+                "@jest/reporters": "^24.8.0",
+                "@jest/test-result": "^24.8.0",
+                "@jest/transform": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.1",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.1.15",
+                "jest-changed-files": "^24.8.0",
+                "jest-config": "^24.8.0",
+                "jest-haste-map": "^24.8.0",
+                "jest-message-util": "^24.8.0",
+                "jest-regex-util": "^24.3.0",
+                "jest-resolve-dependencies": "^24.8.0",
+                "jest-runner": "^24.8.0",
+                "jest-runtime": "^24.8.0",
+                "jest-snapshot": "^24.8.0",
+                "jest-util": "^24.8.0",
+                "jest-validate": "^24.8.0",
+                "jest-watcher": "^24.8.0",
+                "micromatch": "^3.1.10",
+                "p-each-series": "^1.0.0",
+                "pirates": "^4.0.1",
+                "realpath-native": "^1.1.0",
+                "rimraf": "^2.5.4",
+                "strip-ansi": "^5.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
+        "@jest/environment": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.8.0.tgz",
+            "integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
+            "dev": true,
+            "requires": {
+                "@jest/fake-timers": "^24.8.0",
+                "@jest/transform": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "jest-mock": "^24.8.0"
+            }
+        },
+        "@jest/fake-timers": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.8.0.tgz",
+            "integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^24.8.0",
+                "jest-message-util": "^24.8.0",
+                "jest-mock": "^24.8.0"
+            }
+        },
+        "@jest/reporters": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.8.0.tgz",
+            "integrity": "sha512-eZ9TyUYpyIIXfYCrw0UHUWUvE35vx5I92HGMgS93Pv7du+GHIzl+/vh8Qj9MCWFK/4TqyttVBPakWMOfZRIfxw==",
+            "dev": true,
+            "requires": {
+                "@jest/environment": "^24.8.0",
+                "@jest/test-result": "^24.8.0",
+                "@jest/transform": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "chalk": "^2.0.1",
+                "exit": "^0.1.2",
+                "glob": "^7.1.2",
+                "istanbul-lib-coverage": "^2.0.2",
+                "istanbul-lib-instrument": "^3.0.1",
+                "istanbul-lib-report": "^2.0.4",
+                "istanbul-lib-source-maps": "^3.0.1",
+                "istanbul-reports": "^2.1.1",
+                "jest-haste-map": "^24.8.0",
+                "jest-resolve": "^24.8.0",
+                "jest-runtime": "^24.8.0",
+                "jest-util": "^24.8.0",
+                "jest-worker": "^24.6.0",
+                "node-notifier": "^5.2.1",
+                "slash": "^2.0.0",
+                "source-map": "^0.6.0",
+                "string-length": "^2.0.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "@jest/source-map": {
+            "version": "24.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
+            "integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0",
+                "graceful-fs": "^4.1.15",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "@jest/test-result": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.8.0.tgz",
+            "integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^24.7.1",
+                "@jest/types": "^24.8.0",
+                "@types/istanbul-lib-coverage": "^2.0.0"
+            }
+        },
+        "@jest/test-sequencer": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.8.0.tgz",
+            "integrity": "sha512-OzL/2yHyPdCHXEzhoBuq37CE99nkme15eHkAzXRVqthreWZamEMA0WoetwstsQBCXABhczpK03JNbc4L01vvLg==",
+            "dev": true,
+            "requires": {
+                "@jest/test-result": "^24.8.0",
+                "jest-haste-map": "^24.8.0",
+                "jest-runner": "^24.8.0",
+                "jest-runtime": "^24.8.0"
+            }
+        },
+        "@jest/transform": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.8.0.tgz",
+            "integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.1.0",
+                "@jest/types": "^24.8.0",
+                "babel-plugin-istanbul": "^5.1.0",
+                "chalk": "^2.0.1",
+                "convert-source-map": "^1.4.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "graceful-fs": "^4.1.15",
+                "jest-haste-map": "^24.8.0",
+                "jest-regex-util": "^24.3.0",
+                "jest-util": "^24.8.0",
+                "micromatch": "^3.1.10",
+                "realpath-native": "^1.1.0",
+                "slash": "^2.0.0",
+                "source-map": "^0.6.1",
+                "write-file-atomic": "2.4.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "@jest/types": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz",
+            "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
+            "dev": true,
+            "requires": {
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^1.1.1",
+                "@types/yargs": "^12.0.9"
+            }
+        },
         "@mrmlnc/readdir-enhanced": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -230,6 +470,47 @@
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
             "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
             "dev": true
+        },
+        "@types/babel__core": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
+            "integrity": "sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0",
+                "@types/babel__generator": "*",
+                "@types/babel__template": "*",
+                "@types/babel__traverse": "*"
+            }
+        },
+        "@types/babel__generator": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
+            "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@types/babel__template": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+            "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@types/babel__traverse": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.6.tgz",
+            "integrity": "sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.3.0"
+            }
         },
         "@types/events": {
             "version": "3.0.0",
@@ -248,6 +529,31 @@
                 "@types/node": "*"
             }
         },
+        "@types/istanbul-lib-coverage": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+            "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
+            "dev": true
+        },
+        "@types/istanbul-lib-report": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+            "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+            "dev": true,
+            "requires": {
+                "@types/istanbul-lib-coverage": "*"
+            }
+        },
+        "@types/istanbul-reports": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+            "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+            "dev": true,
+            "requires": {
+                "@types/istanbul-lib-coverage": "*",
+                "@types/istanbul-lib-report": "*"
+            }
+        },
         "@types/minimatch": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -258,6 +564,12 @@
             "version": "12.0.4",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.4.tgz",
             "integrity": "sha512-j8YL2C0fXq7IONwl/Ud5Kt0PeXw22zGERt+HSSnwbKOJVsAGkEz3sFCYwaF9IOuoG1HOtE0vKCj6sXF7Q0+Vaw==",
+            "dev": true
+        },
+        "@types/stack-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+            "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
             "dev": true
         },
         "@types/unist": {
@@ -287,6 +599,18 @@
                 "@types/unist": "*"
             }
         },
+        "@types/yargs": {
+            "version": "12.0.12",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.12.tgz",
+            "integrity": "sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==",
+            "dev": true
+        },
+        "abab": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+            "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
+            "dev": true
+        },
         "abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -299,11 +623,36 @@
             "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
             "dev": true
         },
+        "acorn-globals": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
+            "integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
+            "dev": true,
+            "requires": {
+                "acorn": "^6.0.1",
+                "acorn-walk": "^6.0.1"
+            }
+        },
         "acorn-jsx": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
             "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
             "dev": true
+        },
+        "acorn-walk": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+            "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+            "dev": true
+        },
+        "agent-base": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+            "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+            "dev": true,
+            "requires": {
+                "es6-promisify": "^5.0.0"
+            }
         },
         "ajv": {
             "version": "6.10.0",
@@ -457,6 +806,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
             "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
+            "dev": true
+        },
+        "array-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+            "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
             "dev": true
         },
         "array-find-index": {
@@ -620,6 +975,12 @@
             "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
             "dev": true
         },
+        "async-limiter": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+            "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+            "dev": true
+        },
         "async-settle": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
@@ -696,6 +1057,102 @@
                 "axe-core": "^3.1.2",
                 "babel-runtime": "^6.26.0",
                 "depd": "^2.0.0"
+            }
+        },
+        "babel-jest": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.8.0.tgz",
+            "integrity": "sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==",
+            "dev": true,
+            "requires": {
+                "@jest/transform": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "@types/babel__core": "^7.1.0",
+                "babel-plugin-istanbul": "^5.1.0",
+                "babel-preset-jest": "^24.6.0",
+                "chalk": "^2.4.2",
+                "slash": "^2.0.0"
+            }
+        },
+        "babel-plugin-istanbul": {
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
+            "integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
+            "dev": true,
+            "requires": {
+                "find-up": "^3.0.0",
+                "istanbul-lib-instrument": "^3.3.0",
+                "test-exclude": "^5.2.3"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                }
+            }
+        },
+        "babel-plugin-jest-hoist": {
+            "version": "24.6.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
+            "integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
+            "dev": true,
+            "requires": {
+                "@types/babel__traverse": "^7.0.6"
+            }
+        },
+        "babel-preset-jest": {
+            "version": "24.6.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
+            "integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
+            "dev": true,
+            "requires": {
+                "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+                "babel-plugin-jest-hoist": "^24.6.0"
             }
         },
         "babel-runtime": {
@@ -860,6 +1317,29 @@
                 }
             }
         },
+        "browser-process-hrtime": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+            "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+            "dev": true
+        },
+        "browser-resolve": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+            "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+            "dev": true,
+            "requires": {
+                "resolve": "1.1.7"
+            },
+            "dependencies": {
+                "resolve": {
+                    "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+                    "dev": true
+                }
+            }
+        },
         "browserslist": {
             "version": "4.6.1",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.1.tgz",
@@ -869,6 +1349,15 @@
                 "caniuse-lite": "^1.0.30000971",
                 "electron-to-chromium": "^1.3.137",
                 "node-releases": "^1.1.21"
+            }
+        },
+        "bser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+            "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+            "dev": true,
+            "requires": {
+                "node-int64": "^0.4.0"
             }
         },
         "buffer-equal": {
@@ -967,6 +1456,15 @@
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000971.tgz",
             "integrity": "sha512-TQFYFhRS0O5rdsmSbF1Wn+16latXYsQJat66f7S7lizXW1PVpWJeZw9wqqVLIjuxDRz7s7xRUj13QCfd8hKn6g==",
             "dev": true
+        },
+        "capture-exit": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+            "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
+            "dev": true,
+            "requires": {
+                "rsvp": "^4.8.4"
+            }
         },
         "caseless": {
             "version": "0.12.0",
@@ -1067,6 +1565,12 @@
                 "request": "^2.88.0",
                 "tcp-port-used": "^1.0.1"
             }
+        },
+        "ci-info": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+            "dev": true
         },
         "class-utils": {
             "version": "0.3.6",
@@ -1175,6 +1679,39 @@
             "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
             "dev": true
         },
+        "clone-deep": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+            "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
+            "dev": true,
+            "requires": {
+                "for-own": "^0.1.3",
+                "is-plain-object": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "lazy-cache": "^1.0.3",
+                "shallow-clone": "^0.1.2"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                    "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+                    "dev": true,
+                    "requires": {
+                        "for-in": "^1.0.1"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
         "clone-regexp": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
@@ -1201,6 +1738,12 @@
                 "process-nextick-args": "^2.0.0",
                 "readable-stream": "^2.3.5"
             }
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
         },
         "code-point-at": {
             "version": "1.1.0",
@@ -1416,6 +1959,21 @@
                 }
             }
         },
+        "cssom": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+            "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+            "dev": true
+        },
+        "cssstyle": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.2.tgz",
+            "integrity": "sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==",
+            "dev": true,
+            "requires": {
+                "cssom": "0.3.x"
+            }
+        },
         "currently-unhandled": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -1423,6 +1981,16 @@
             "dev": true,
             "requires": {
                 "array-find-index": "^1.0.1"
+            }
+        },
+        "cwd": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
+            "integrity": "sha1-FyQAaUBXwioTsM8WFix+S3p/5Wc=",
+            "dev": true,
+            "requires": {
+                "find-pkg": "^0.1.2",
+                "fs-exists-sync": "^0.1.0"
             }
         },
         "d": {
@@ -1441,6 +2009,30 @@
             "dev": true,
             "requires": {
                 "assert-plus": "^1.0.0"
+            }
+        },
+        "data-urls": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+            "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+            "dev": true,
+            "requires": {
+                "abab": "^2.0.0",
+                "whatwg-mimetype": "^2.2.0",
+                "whatwg-url": "^7.0.0"
+            },
+            "dependencies": {
+                "whatwg-url": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+                    "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+                    "dev": true,
+                    "requires": {
+                        "lodash.sortby": "^4.7.0",
+                        "tr46": "^1.0.1",
+                        "webidl-conversions": "^4.0.2"
+                    }
+                }
             }
         },
         "debug": {
@@ -1625,6 +2217,12 @@
             "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
             "dev": true
         },
+        "diff-sequences": {
+            "version": "24.3.0",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
+            "integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
+            "dev": true
+        },
         "dir-glob": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
@@ -1670,6 +2268,15 @@
             "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
             "dev": true
         },
+        "domexception": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+            "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+            "dev": true,
+            "requires": {
+                "webidl-conversions": "^4.0.2"
+            }
+        },
         "domhandler": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
@@ -1697,6 +2304,12 @@
             "requires": {
                 "is-obj": "^1.0.0"
             }
+        },
+        "dotenv": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
+            "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg==",
+            "dev": true
         },
         "duplexify": {
             "version": "3.7.1",
@@ -1766,6 +2379,31 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "es-abstract": {
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+            "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+            "dev": true,
+            "requires": {
+                "es-to-primitive": "^1.2.0",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "is-callable": "^1.1.4",
+                "is-regex": "^1.0.4",
+                "object-keys": "^1.0.12"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+            "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+            "dev": true,
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
         "es5-ext": {
             "version": "0.10.49",
             "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.49.tgz",
@@ -1786,6 +2424,21 @@
                 "d": "1",
                 "es5-ext": "^0.10.35",
                 "es6-symbol": "^3.1.1"
+            }
+        },
+        "es6-promise": {
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+            "dev": true
+        },
+        "es6-promisify": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+            "dev": true,
+            "requires": {
+                "es6-promise": "^4.0.3"
             }
         },
         "es6-symbol": {
@@ -1815,6 +2468,34 @@
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true
+        },
+        "escodegen": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+            "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+            "dev": true,
+            "requires": {
+                "esprima": "^3.1.3",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "esprima": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+                    "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
         },
         "eslint": {
             "version": "5.16.0",
@@ -1886,6 +2567,12 @@
                 "lodash.get": "^4.4.2",
                 "lodash.zip": "^4.2.0"
             }
+        },
+        "eslint-plugin-jest": {
+            "version": "22.6.4",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.6.4.tgz",
+            "integrity": "sha512-36OqnZR/uMCDxXGmTsqU4RwllR0IiB/XF8GW3ODmhsjiITKuI0GpgultWFt193ipN3HARkaIcKowpE6HBvRHNg==",
+            "dev": true
         },
         "eslint-plugin-prettier": {
             "version": "3.1.0",
@@ -2005,6 +2692,27 @@
                 "es5-ext": "~0.10.14"
             }
         },
+        "exec-sh": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
+            "integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==",
+            "dev": true
+        },
+        "execa": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+            "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+            }
+        },
         "execall": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
@@ -2013,6 +2721,12 @@
             "requires": {
                 "clone-regexp": "^1.0.0"
             }
+        },
+        "exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "dev": true
         },
         "expand-brackets": {
             "version": "2.1.4",
@@ -2057,6 +2771,26 @@
             "requires": {
                 "homedir-polyfill": "^1.0.1"
             }
+        },
+        "expect": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-24.8.0.tgz",
+            "integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^24.8.0",
+                "ansi-styles": "^3.2.0",
+                "jest-get-type": "^24.8.0",
+                "jest-matcher-utils": "^24.8.0",
+                "jest-message-util": "^24.8.0",
+                "jest-regex-util": "^24.3.0"
+            }
+        },
+        "expect-puppeteer": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-4.1.1.tgz",
+            "integrity": "sha512-xNpu6uYJL9Qrrp4Z31MOpDWK68zAi+2qg5aMQlyOTVZNy7cAgBZiPvKCN0C1JmP3jgPZfcxhetVjZLaw/KcJOQ==",
+            "dev": true
         },
         "extend": {
             "version": "3.0.2",
@@ -2238,6 +2972,15 @@
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
         },
+        "fb-watchman": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+            "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+            "dev": true,
+            "requires": {
+                "bser": "^2.0.0"
+            }
+        },
         "fd-slicer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
@@ -2286,6 +3029,85 @@
                         "is-extendable": "^0.1.0"
                     }
                 }
+            }
+        },
+        "find-file-up": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
+            "integrity": "sha1-z2gJG8+fMApA2kEbN9pczlovvqA=",
+            "dev": true,
+            "requires": {
+                "fs-exists-sync": "^0.1.0",
+                "resolve-dir": "^0.1.0"
+            },
+            "dependencies": {
+                "expand-tilde": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+                    "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+                    "dev": true,
+                    "requires": {
+                        "os-homedir": "^1.0.1"
+                    }
+                },
+                "global-modules": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+                    "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+                    "dev": true,
+                    "requires": {
+                        "global-prefix": "^0.1.4",
+                        "is-windows": "^0.2.0"
+                    }
+                },
+                "global-prefix": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+                    "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+                    "dev": true,
+                    "requires": {
+                        "homedir-polyfill": "^1.0.0",
+                        "ini": "^1.3.4",
+                        "is-windows": "^0.2.0",
+                        "which": "^1.2.12"
+                    }
+                },
+                "is-windows": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+                    "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+                    "dev": true
+                },
+                "resolve-dir": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+                    "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+                    "dev": true,
+                    "requires": {
+                        "expand-tilde": "^1.2.2",
+                        "global-modules": "^0.2.3"
+                    }
+                }
+            }
+        },
+        "find-pkg": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
+            "integrity": "sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=",
+            "dev": true,
+            "requires": {
+                "find-file-up": "^0.1.2"
+            }
+        },
+        "find-process": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.1.tgz",
+            "integrity": "sha512-RkYWDeukxEoDKUyocqMGKAYuwhSwq77zL99gCqhX9czWon3otdlzihJ0MSZ6YWNKHyvS/MN2YR4+RGYOuIEANg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.1",
+                "commander": "^2.11.0",
+                "debug": "^2.6.8"
             }
         },
         "find-up": {
@@ -2396,6 +3218,12 @@
             "requires": {
                 "map-cache": "^0.2.2"
             }
+        },
+        "fs-exists-sync": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+            "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
+            "dev": true
         },
         "fs-mkdirp-stream": {
             "version": "1.0.0",
@@ -3125,6 +3953,27 @@
             "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
             "dev": true
         },
+        "get-stream": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+            "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+            "dev": true,
+            "requires": {
+                "pump": "^3.0.0"
+            },
+            "dependencies": {
+                "pump": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+                    "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                }
+            }
+        },
         "get-value": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -3313,6 +4162,12 @@
             "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
             "dev": true
         },
+        "growly": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+            "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+            "dev": true
+        },
         "gulp": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
@@ -3417,6 +4272,26 @@
                 "glogg": "^1.0.0"
             }
         },
+        "handlebars": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+            "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+            "dev": true,
+            "requires": {
+                "neo-async": "^2.6.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.6.1",
+                "uglify-js": "^3.1.4"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
         "har-schema": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -3431,6 +4306,15 @@
             "requires": {
                 "ajv": "^6.5.5",
                 "har-schema": "^2.0.0"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
             }
         },
         "has-ansi": {
@@ -3500,6 +4384,12 @@
                 }
             }
         },
+        "hoek": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+            "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
+            "dev": true
+        },
         "homedir-polyfill": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -3514,6 +4404,15 @@
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
             "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
             "dev": true
+        },
+        "html-encoding-sniffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+            "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+            "dev": true,
+            "requires": {
+                "whatwg-encoding": "^1.0.1"
+            }
         },
         "html-tags": {
             "version": "2.0.0",
@@ -3559,6 +4458,33 @@
                 "sshpk": "^1.7.0"
             }
         },
+        "https-proxy-agent": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+            "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+            "dev": true,
+            "requires": {
+                "agent-base": "^4.1.0",
+                "debug": "^3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
+        },
         "iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -3595,6 +4521,16 @@
             "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
             "integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==",
             "dev": true
+        },
+        "import-local": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+            "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+            "dev": true,
+            "requires": {
+                "pkg-dir": "^3.0.0",
+                "resolve-cwd": "^2.0.0"
+            }
         },
         "import-modules": {
             "version": "1.1.0",
@@ -3695,6 +4631,15 @@
             "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
             "dev": true
         },
+        "invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.0.0"
+            }
+        },
         "invert-kv": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -3780,6 +4725,21 @@
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
         },
+        "is-callable": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+            "dev": true
+        },
+        "is-ci": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+            "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+            "dev": true,
+            "requires": {
+                "ci-info": "^2.0.0"
+            }
+        },
         "is-data-descriptor": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -3799,6 +4759,12 @@
                     }
                 }
             }
+        },
+        "is-date-object": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+            "dev": true
         },
         "is-decimal": {
             "version": "1.0.3",
@@ -3856,6 +4822,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
             "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
+        },
+        "is-generator-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+            "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
             "dev": true
         },
         "is-glob": {
@@ -3950,6 +4922,15 @@
             "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
             "dev": true
         },
+        "is-regex": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+            "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.1"
+            }
+        },
         "is-regexp": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
@@ -3965,11 +4946,26 @@
                 "is-unc-path": "^1.0.0"
             }
         },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
+        },
         "is-supported-regexp-flag": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
             "integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
             "dev": true
+        },
+        "is-symbol": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+            "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.0"
+            }
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -4022,6 +5018,12 @@
             "integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A==",
             "dev": true
         },
+        "is-wsl": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+            "dev": true
+        },
         "is2": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.1.tgz",
@@ -4038,6 +5040,15 @@
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
             "dev": true
+        },
+        "isemail": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+            "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+            "dev": true,
+            "requires": {
+                "punycode": "2.x.x"
+            }
         },
         "isexe": {
             "version": "2.0.0",
@@ -4056,6 +5067,852 @@
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
             "dev": true
+        },
+        "istanbul-lib-coverage": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+            "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+            "dev": true
+        },
+        "istanbul-lib-instrument": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+            "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+            "dev": true,
+            "requires": {
+                "@babel/generator": "^7.4.0",
+                "@babel/parser": "^7.4.3",
+                "@babel/template": "^7.4.0",
+                "@babel/traverse": "^7.4.3",
+                "@babel/types": "^7.4.0",
+                "istanbul-lib-coverage": "^2.0.5",
+                "semver": "^6.0.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.1.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+                    "integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-lib-report": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+            "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+            "dev": true,
+            "requires": {
+                "istanbul-lib-coverage": "^2.0.5",
+                "make-dir": "^2.1.0",
+                "supports-color": "^6.1.0"
+            },
+            "dependencies": {
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "istanbul-lib-source-maps": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+            "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^2.0.5",
+                "make-dir": "^2.1.0",
+                "rimraf": "^2.6.3",
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-reports": {
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+            "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+            "dev": true,
+            "requires": {
+                "handlebars": "^4.1.2"
+            }
+        },
+        "jest": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-24.8.0.tgz",
+            "integrity": "sha512-o0HM90RKFRNWmAWvlyV8i5jGZ97pFwkeVoGvPW1EtLTgJc2+jcuqcbbqcSZLE/3f2S5pt0y2ZBETuhpWNl1Reg==",
+            "dev": true,
+            "requires": {
+                "import-local": "^2.0.0",
+                "jest-cli": "^24.8.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "invert-kv": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+                    "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+                    "dev": true
+                },
+                "jest-cli": {
+                    "version": "24.8.0",
+                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.8.0.tgz",
+                    "integrity": "sha512-+p6J00jSMPQ116ZLlHJJvdf8wbjNbZdeSX9ptfHX06/MSNaXmKihQzx5vQcw0q2G6JsdVkUIdWbOWtSnaYs3yA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/core": "^24.8.0",
+                        "@jest/test-result": "^24.8.0",
+                        "@jest/types": "^24.8.0",
+                        "chalk": "^2.0.1",
+                        "exit": "^0.1.2",
+                        "import-local": "^2.0.0",
+                        "is-ci": "^2.0.0",
+                        "jest-config": "^24.8.0",
+                        "jest-util": "^24.8.0",
+                        "jest-validate": "^24.8.0",
+                        "prompts": "^2.0.1",
+                        "realpath-native": "^1.1.0",
+                        "yargs": "^12.0.2"
+                    }
+                },
+                "lcid": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+                    "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "os-locale": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+                    "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+                    "dev": true,
+                    "requires": {
+                        "execa": "^1.0.0",
+                        "lcid": "^2.0.0",
+                        "mem": "^4.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "12.0.5",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+                    "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^3.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1 || ^4.0.0",
+                        "yargs-parser": "^11.1.1"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "11.1.1",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+                    "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
+        "jest-changed-files": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.8.0.tgz",
+            "integrity": "sha512-qgANC1Yrivsq+UrLXsvJefBKVoCsKB0Hv+mBb6NMjjZ90wwxCDmU3hsCXBya30cH+LnPYjwgcU65i6yJ5Nfuug==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^24.8.0",
+                "execa": "^1.0.0",
+                "throat": "^4.0.0"
+            }
+        },
+        "jest-config": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.8.0.tgz",
+            "integrity": "sha512-Czl3Nn2uEzVGsOeaewGWoDPD8GStxCpAe0zOYs2x2l0fZAgPbCr3uwUkgNKV3LwE13VXythM946cd5rdGkkBZw==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.1.0",
+                "@jest/test-sequencer": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "babel-jest": "^24.8.0",
+                "chalk": "^2.0.1",
+                "glob": "^7.1.1",
+                "jest-environment-jsdom": "^24.8.0",
+                "jest-environment-node": "^24.8.0",
+                "jest-get-type": "^24.8.0",
+                "jest-jasmine2": "^24.8.0",
+                "jest-regex-util": "^24.3.0",
+                "jest-resolve": "^24.8.0",
+                "jest-util": "^24.8.0",
+                "jest-validate": "^24.8.0",
+                "micromatch": "^3.1.10",
+                "pretty-format": "^24.8.0",
+                "realpath-native": "^1.1.0"
+            }
+        },
+        "jest-dev-server": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-4.2.0.tgz",
+            "integrity": "sha512-Hy4+Y3awthvT3OI7exmqqXmselI6pvYiAQeob2hkHLtvhpsA2rO7GDPbOwxDMjqAVGUEopQOzQm37WjfB5tWdg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.2",
+                "cwd": "^0.10.0",
+                "find-process": "^1.4.1",
+                "prompts": "^2.0.4",
+                "spawnd": "^4.0.0",
+                "tree-kill": "^1.2.1",
+                "wait-on": "^3.2.0"
+            }
+        },
+        "jest-diff": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",
+            "integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.1",
+                "diff-sequences": "^24.3.0",
+                "jest-get-type": "^24.8.0",
+                "pretty-format": "^24.8.0"
+            }
+        },
+        "jest-docblock": {
+            "version": "24.3.0",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz",
+            "integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
+            "dev": true,
+            "requires": {
+                "detect-newline": "^2.1.0"
+            }
+        },
+        "jest-each": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.8.0.tgz",
+            "integrity": "sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^24.8.0",
+                "chalk": "^2.0.1",
+                "jest-get-type": "^24.8.0",
+                "jest-util": "^24.8.0",
+                "pretty-format": "^24.8.0"
+            }
+        },
+        "jest-environment-jsdom": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz",
+            "integrity": "sha512-qbvgLmR7PpwjoFjM/sbuqHJt/NCkviuq9vus9NBn/76hhSidO+Z6Bn9tU8friecegbJL8gzZQEMZBQlFWDCwAQ==",
+            "dev": true,
+            "requires": {
+                "@jest/environment": "^24.8.0",
+                "@jest/fake-timers": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "jest-mock": "^24.8.0",
+                "jest-util": "^24.8.0",
+                "jsdom": "^11.5.1"
+            }
+        },
+        "jest-environment-node": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.8.0.tgz",
+            "integrity": "sha512-vIGUEScd1cdDgR6sqn2M08sJTRLQp6Dk/eIkCeO4PFHxZMOgy+uYLPMC4ix3PEfM5Au/x3uQ/5Tl0DpXXZsJ/Q==",
+            "dev": true,
+            "requires": {
+                "@jest/environment": "^24.8.0",
+                "@jest/fake-timers": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "jest-mock": "^24.8.0",
+                "jest-util": "^24.8.0"
+            }
+        },
+        "jest-environment-puppeteer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-4.2.0.tgz",
+            "integrity": "sha512-i3HC+BsB0l9LR79+wrnyz7ImomZdwgpu1QH/9l1DnOgAuD5tTIwvzbyQp1nX+z5aKUhAVhontDIvHaM4oHRQ0Q==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.2",
+                "cwd": "^0.10.0",
+                "jest-dev-server": "^4.2.0",
+                "merge-deep": "^3.0.2"
+            }
+        },
+        "jest-get-type": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
+            "integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
+            "dev": true
+        },
+        "jest-haste-map": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.0.tgz",
+            "integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^24.8.0",
+                "anymatch": "^2.0.0",
+                "fb-watchman": "^2.0.0",
+                "fsevents": "^1.2.7",
+                "graceful-fs": "^4.1.15",
+                "invariant": "^2.2.4",
+                "jest-serializer": "^24.4.0",
+                "jest-util": "^24.8.0",
+                "jest-worker": "^24.6.0",
+                "micromatch": "^3.1.10",
+                "sane": "^4.0.3",
+                "walker": "^1.0.7"
+            }
+        },
+        "jest-jasmine2": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz",
+            "integrity": "sha512-cEky88npEE5LKd5jPpTdDCLvKkdyklnaRycBXL6GNmpxe41F0WN44+i7lpQKa/hcbXaQ+rc9RMaM4dsebrYong==",
+            "dev": true,
+            "requires": {
+                "@babel/traverse": "^7.1.0",
+                "@jest/environment": "^24.8.0",
+                "@jest/test-result": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "chalk": "^2.0.1",
+                "co": "^4.6.0",
+                "expect": "^24.8.0",
+                "is-generator-fn": "^2.0.0",
+                "jest-each": "^24.8.0",
+                "jest-matcher-utils": "^24.8.0",
+                "jest-message-util": "^24.8.0",
+                "jest-runtime": "^24.8.0",
+                "jest-snapshot": "^24.8.0",
+                "jest-util": "^24.8.0",
+                "pretty-format": "^24.8.0",
+                "throat": "^4.0.0"
+            }
+        },
+        "jest-leak-detector": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz",
+            "integrity": "sha512-cG0yRSK8A831LN8lIHxI3AblB40uhv0z+SsQdW3GoMMVcK+sJwrIIyax5tu3eHHNJ8Fu6IMDpnLda2jhn2pD/g==",
+            "dev": true,
+            "requires": {
+                "pretty-format": "^24.8.0"
+            }
+        },
+        "jest-matcher-utils": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
+            "integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.1",
+                "jest-diff": "^24.8.0",
+                "jest-get-type": "^24.8.0",
+                "pretty-format": "^24.8.0"
+            }
+        },
+        "jest-message-util": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.8.0.tgz",
+            "integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@jest/test-result": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "@types/stack-utils": "^1.0.1",
+                "chalk": "^2.0.1",
+                "micromatch": "^3.1.10",
+                "slash": "^2.0.0",
+                "stack-utils": "^1.0.1"
+            }
+        },
+        "jest-mock": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.8.0.tgz",
+            "integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^24.8.0"
+            }
+        },
+        "jest-pnp-resolver": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+            "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
+            "dev": true
+        },
+        "jest-puppeteer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-4.2.0.tgz",
+            "integrity": "sha512-vTynE0pLia0SxbE4eRdFMWAVCm75poMTKzPhKQdQ5iS7e+mZOuMtVRNXqErsHppl4+3cRnN/r3u0g6iFSvR/sw==",
+            "dev": true,
+            "requires": {
+                "expect-puppeteer": "^4.1.1",
+                "jest-environment-puppeteer": "^4.2.0"
+            }
+        },
+        "jest-regex-util": {
+            "version": "24.3.0",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
+            "integrity": "sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==",
+            "dev": true
+        },
+        "jest-resolve": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
+            "integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^24.8.0",
+                "browser-resolve": "^1.11.3",
+                "chalk": "^2.0.1",
+                "jest-pnp-resolver": "^1.2.1",
+                "realpath-native": "^1.1.0"
+            }
+        },
+        "jest-resolve-dependencies": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.8.0.tgz",
+            "integrity": "sha512-hyK1qfIf/krV+fSNyhyJeq3elVMhK9Eijlwy+j5jqmZ9QsxwKBiP6qukQxaHtK8k6zql/KYWwCTQ+fDGTIJauw==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^24.8.0",
+                "jest-regex-util": "^24.3.0",
+                "jest-snapshot": "^24.8.0"
+            }
+        },
+        "jest-runner": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.8.0.tgz",
+            "integrity": "sha512-utFqC5BaA3JmznbissSs95X1ZF+d+4WuOWwpM9+Ak356YtMhHE/GXUondZdcyAAOTBEsRGAgH/0TwLzfI9h7ow==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^24.7.1",
+                "@jest/environment": "^24.8.0",
+                "@jest/test-result": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "chalk": "^2.4.2",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.1.15",
+                "jest-config": "^24.8.0",
+                "jest-docblock": "^24.3.0",
+                "jest-haste-map": "^24.8.0",
+                "jest-jasmine2": "^24.8.0",
+                "jest-leak-detector": "^24.8.0",
+                "jest-message-util": "^24.8.0",
+                "jest-resolve": "^24.8.0",
+                "jest-runtime": "^24.8.0",
+                "jest-util": "^24.8.0",
+                "jest-worker": "^24.6.0",
+                "source-map-support": "^0.5.6",
+                "throat": "^4.0.0"
+            }
+        },
+        "jest-runtime": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.8.0.tgz",
+            "integrity": "sha512-Mq0aIXhvO/3bX44ccT+czU1/57IgOMyy80oM0XR/nyD5zgBcesF84BPabZi39pJVA6UXw+fY2Q1N+4BiVUBWOA==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^24.7.1",
+                "@jest/environment": "^24.8.0",
+                "@jest/source-map": "^24.3.0",
+                "@jest/transform": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "@types/yargs": "^12.0.2",
+                "chalk": "^2.0.1",
+                "exit": "^0.1.2",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.1.15",
+                "jest-config": "^24.8.0",
+                "jest-haste-map": "^24.8.0",
+                "jest-message-util": "^24.8.0",
+                "jest-mock": "^24.8.0",
+                "jest-regex-util": "^24.3.0",
+                "jest-resolve": "^24.8.0",
+                "jest-snapshot": "^24.8.0",
+                "jest-util": "^24.8.0",
+                "jest-validate": "^24.8.0",
+                "realpath-native": "^1.1.0",
+                "slash": "^2.0.0",
+                "strip-bom": "^3.0.0",
+                "yargs": "^12.0.2"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "invert-kv": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+                    "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+                    "dev": true
+                },
+                "lcid": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+                    "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "os-locale": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+                    "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+                    "dev": true,
+                    "requires": {
+                        "execa": "^1.0.0",
+                        "lcid": "^2.0.0",
+                        "mem": "^4.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "dev": true
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "12.0.5",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+                    "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^3.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1 || ^4.0.0",
+                        "yargs-parser": "^11.1.1"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "11.1.1",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+                    "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
+        "jest-serializer": {
+            "version": "24.4.0",
+            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz",
+            "integrity": "sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==",
+            "dev": true
+        },
+        "jest-snapshot": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.8.0.tgz",
+            "integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0",
+                "@jest/types": "^24.8.0",
+                "chalk": "^2.0.1",
+                "expect": "^24.8.0",
+                "jest-diff": "^24.8.0",
+                "jest-matcher-utils": "^24.8.0",
+                "jest-message-util": "^24.8.0",
+                "jest-resolve": "^24.8.0",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "pretty-format": "^24.8.0",
+                "semver": "^5.5.0"
+            }
+        },
+        "jest-util": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.8.0.tgz",
+            "integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^24.7.1",
+                "@jest/fake-timers": "^24.8.0",
+                "@jest/source-map": "^24.3.0",
+                "@jest/test-result": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "callsites": "^3.0.0",
+                "chalk": "^2.0.1",
+                "graceful-fs": "^4.1.15",
+                "is-ci": "^2.0.0",
+                "mkdirp": "^0.5.1",
+                "slash": "^2.0.0",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "jest-validate": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.8.0.tgz",
+            "integrity": "sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^24.8.0",
+                "camelcase": "^5.0.0",
+                "chalk": "^2.0.1",
+                "jest-get-type": "^24.8.0",
+                "leven": "^2.1.0",
+                "pretty-format": "^24.8.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                    "dev": true
+                },
+                "leven": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+                    "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+                    "dev": true
+                }
+            }
+        },
+        "jest-watcher": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.8.0.tgz",
+            "integrity": "sha512-SBjwHt5NedQoVu54M5GEx7cl7IGEFFznvd/HNT8ier7cCAx/Qgu9ZMlaTQkvK22G1YOpcWBLQPFSImmxdn3DAw==",
+            "dev": true,
+            "requires": {
+                "@jest/test-result": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "@types/yargs": "^12.0.9",
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.1",
+                "jest-util": "^24.8.0",
+                "string-length": "^2.0.0"
+            }
+        },
+        "jest-worker": {
+            "version": "24.6.0",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
+            "integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
+            "dev": true,
+            "requires": {
+                "merge-stream": "^1.0.1",
+                "supports-color": "^6.1.0"
+            },
+            "dependencies": {
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "joi": {
+            "version": "13.7.0",
+            "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+            "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
+            "dev": true,
+            "requires": {
+                "hoek": "5.x.x",
+                "isemail": "3.x.x",
+                "topo": "3.x.x"
+            }
         },
         "jquery": {
             "version": "3.4.1",
@@ -4089,6 +5946,48 @@
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
             "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
             "dev": true
+        },
+        "jsdom": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+            "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+            "dev": true,
+            "requires": {
+                "abab": "^2.0.0",
+                "acorn": "^5.5.3",
+                "acorn-globals": "^4.1.0",
+                "array-equal": "^1.0.0",
+                "cssom": ">= 0.3.2 < 0.4.0",
+                "cssstyle": "^1.0.0",
+                "data-urls": "^1.0.0",
+                "domexception": "^1.0.1",
+                "escodegen": "^1.9.1",
+                "html-encoding-sniffer": "^1.0.2",
+                "left-pad": "^1.3.0",
+                "nwsapi": "^2.0.7",
+                "parse5": "4.0.0",
+                "pn": "^1.1.0",
+                "request": "^2.87.0",
+                "request-promise-native": "^1.0.5",
+                "sax": "^1.2.4",
+                "symbol-tree": "^3.2.2",
+                "tough-cookie": "^2.3.4",
+                "w3c-hr-time": "^1.0.1",
+                "webidl-conversions": "^4.0.2",
+                "whatwg-encoding": "^1.0.3",
+                "whatwg-mimetype": "^2.1.0",
+                "whatwg-url": "^6.4.1",
+                "ws": "^5.2.0",
+                "xml-name-validator": "^3.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.7.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+                    "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+                    "dev": true
+                }
+            }
         },
         "jsesc": {
             "version": "2.5.2",
@@ -4178,6 +6077,12 @@
             "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
             "dev": true
         },
+        "kleur": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+            "dev": true
+        },
         "known-css-properties": {
             "version": "0.13.0",
             "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.13.0.tgz",
@@ -4193,6 +6098,12 @@
                 "default-resolution": "^2.0.0",
                 "es6-weak-map": "^2.0.1"
             }
+        },
+        "lazy-cache": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+            "dev": true
         },
         "lazystream": {
             "version": "1.0.0",
@@ -4220,6 +6131,12 @@
             "requires": {
                 "flush-write-stream": "^1.0.2"
             }
+        },
+        "left-pad": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+            "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+            "dev": true
         },
         "leven": {
             "version": "3.1.0",
@@ -4343,6 +6260,12 @@
             "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=",
             "dev": true
         },
+        "lodash.sortby": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+            "dev": true
+        },
         "lodash.topairs": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.topairs/-/lodash.topairs-4.3.0.tgz",
@@ -4376,6 +6299,15 @@
             "integrity": "sha512-9lz5IVdpwsKLMzQi0MQ+oD9EA0mIGcWYP7jXMTZVXP8D42PwuAk+M/HBFYQoxt1G5OR8m7aSIgb1UymfWGBWEw==",
             "dev": true
         },
+        "loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
+            "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            }
+        },
         "loud-rejection": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -4405,6 +6337,24 @@
                 "es5-ext": "~0.10.2"
             }
         },
+        "make-dir": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+            "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+            "dev": true,
+            "requires": {
+                "pify": "^4.0.1",
+                "semver": "^5.6.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                }
+            }
+        },
         "make-iterator": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
@@ -4412,6 +6362,24 @@
             "dev": true,
             "requires": {
                 "kind-of": "^6.0.2"
+            }
+        },
+        "makeerror": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+            "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+            "dev": true,
+            "requires": {
+                "tmpl": "1.0.x"
+            }
+        },
+        "map-age-cleaner": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+            "dev": true,
+            "requires": {
+                "p-defer": "^1.0.0"
             }
         },
         "map-cache": {
@@ -4497,6 +6465,25 @@
                 "unist-util-visit": "^1.1.0"
             }
         },
+        "mem": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+            "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+            "dev": true,
+            "requires": {
+                "map-age-cleaner": "^0.1.1",
+                "mimic-fn": "^2.0.0",
+                "p-is-promise": "^2.0.0"
+            },
+            "dependencies": {
+                "mimic-fn": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+                    "dev": true
+                }
+            }
+        },
         "memoizee": {
             "version": "0.4.14",
             "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
@@ -4539,6 +6526,37 @@
                 }
             }
         },
+        "merge-deep": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
+            "integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
+            "dev": true,
+            "requires": {
+                "arr-union": "^3.1.0",
+                "clone-deep": "^0.2.4",
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "merge-stream": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.1"
+            }
+        },
         "merge2": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
@@ -4565,6 +6583,12 @@
                 "snapdragon": "^0.8.1",
                 "to-regex": "^3.0.2"
             }
+        },
+        "mime": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
+            "integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw==",
+            "dev": true
         },
         "mime-db": {
             "version": "1.38.0",
@@ -4633,6 +6657,24 @@
                 }
             }
         },
+        "mixin-object": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+            "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+            "dev": true,
+            "requires": {
+                "for-in": "^0.1.3",
+                "is-extendable": "^0.1.1"
+            },
+            "dependencies": {
+                "for-in": {
+                    "version": "0.1.8",
+                    "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+                    "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
+                    "dev": true
+                }
+            }
+        },
         "mkdirp": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -4691,6 +6733,12 @@
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
         },
+        "neo-async": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+            "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+            "dev": true
+        },
         "next-tick": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -4729,6 +6777,31 @@
                     "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
                     "dev": true
                 }
+            }
+        },
+        "node-int64": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+            "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+            "dev": true
+        },
+        "node-modules-regexp": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+            "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+            "dev": true
+        },
+        "node-notifier": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+            "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
+            "dev": true,
+            "requires": {
+                "growly": "^1.3.0",
+                "is-wsl": "^1.1.0",
+                "semver": "^5.5.0",
+                "shellwords": "^0.1.1",
+                "which": "^1.3.0"
             }
         },
         "node-releases": {
@@ -4868,6 +6941,15 @@
                 "once": "^1.3.2"
             }
         },
+        "npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "dev": true,
+            "requires": {
+                "path-key": "^2.0.0"
+            }
+        },
         "npmlog": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -4890,6 +6972,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
+        "nwsapi": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
+            "integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==",
             "dev": true
         },
         "oauth-sign": {
@@ -4974,6 +7062,16 @@
                 "isobject": "^3.0.0"
             }
         },
+        "object.getownpropertydescriptors": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+            "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.5.1"
+            }
+        },
         "object.map": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
@@ -5019,6 +7117,24 @@
             "dev": true,
             "requires": {
                 "mimic-fn": "^1.0.0"
+            }
+        },
+        "optimist": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "dev": true,
+            "requires": {
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
+            },
+            "dependencies": {
+                "wordwrap": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                    "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                    "dev": true
+                }
             }
         },
         "optionator": {
@@ -5075,6 +7191,33 @@
                 "os-tmpdir": "^1.0.0"
             }
         },
+        "p-defer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+            "dev": true
+        },
+        "p-each-series": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+            "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+            "dev": true,
+            "requires": {
+                "p-reduce": "^1.0.0"
+            }
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "dev": true
+        },
+        "p-is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+            "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+            "dev": true
+        },
         "p-limit": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
@@ -5097,6 +7240,12 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
             "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+            "dev": true
+        },
+        "p-reduce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+            "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
             "dev": true
         },
         "p-try": {
@@ -5164,6 +7313,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
             "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+            "dev": true
+        },
+        "parse5": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+            "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
             "dev": true
         },
         "pascalcase": {
@@ -5284,6 +7439,75 @@
                 "pinkie": "^2.0.0"
             }
         },
+        "pirates": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+            "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+            "dev": true,
+            "requires": {
+                "node-modules-regexp": "^1.0.0"
+            }
+        },
+        "pkg-dir": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+            "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+            "dev": true,
+            "requires": {
+                "find-up": "^3.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                }
+            }
+        },
         "plugin-error": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
@@ -5295,6 +7519,12 @@
                 "arr-union": "^3.1.0",
                 "extend-shallow": "^3.0.2"
             }
+        },
+        "pn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+            "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+            "dev": true
         },
         "popper.js": {
             "version": "1.15.0",
@@ -5468,6 +7698,26 @@
                 "fast-diff": "^1.1.2"
             }
         },
+        "pretty-format": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
+            "integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^24.8.0",
+                "ansi-regex": "^4.0.0",
+                "ansi-styles": "^3.2.0",
+                "react-is": "^16.8.4"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                }
+            }
+        },
         "pretty-hrtime": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -5484,6 +7734,22 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "dev": true
+        },
+        "prompts": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
+            "integrity": "sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==",
+            "dev": true,
+            "requires": {
+                "kleur": "^3.0.2",
+                "sisteransi": "^1.0.0"
+            }
+        },
+        "proxy-from-env": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+            "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
             "dev": true
         },
         "pseudomap": {
@@ -5524,6 +7790,48 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         },
+        "puppeteer": {
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.17.0.tgz",
+            "integrity": "sha512-3EXZSximCzxuVKpIHtyec8Wm2dWZn1fc5tQi34qWfiUgubEVYHjUvr0GOJojqf3mifI6oyKnCdrGxaOI+lWReA==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.0",
+                "extract-zip": "^1.6.6",
+                "https-proxy-agent": "^2.2.1",
+                "mime": "^2.0.3",
+                "progress": "^2.0.1",
+                "proxy-from-env": "^1.0.0",
+                "rimraf": "^2.6.1",
+                "ws": "^6.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "ws": {
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+                    "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+                    "dev": true,
+                    "requires": {
+                        "async-limiter": "~1.0.0"
+                    }
+                }
+            }
+        },
         "qs": {
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -5534,6 +7842,12 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
             "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+            "dev": true
+        },
+        "react-is": {
+            "version": "16.8.6",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+            "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
             "dev": true
         },
         "read-pkg": {
@@ -5581,6 +7895,15 @@
                 "graceful-fs": "^4.1.11",
                 "micromatch": "^3.1.10",
                 "readable-stream": "^2.0.2"
+            }
+        },
+        "realpath-native": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+            "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+            "dev": true,
+            "requires": {
+                "util.promisify": "^1.0.0"
             }
         },
         "rechoir": {
@@ -5779,6 +8102,26 @@
                 "uuid": "^3.3.2"
             }
         },
+        "request-promise-core": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+            "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.11"
+            }
+        },
+        "request-promise-native": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+            "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+            "dev": true,
+            "requires": {
+                "request-promise-core": "1.1.2",
+                "stealthy-require": "^1.1.1",
+                "tough-cookie": "^2.3.3"
+            }
+        },
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5804,6 +8147,23 @@
             "dev": true,
             "requires": {
                 "path-parse": "^1.0.6"
+            }
+        },
+        "resolve-cwd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+            "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+            "dev": true,
+            "requires": {
+                "resolve-from": "^3.0.0"
+            },
+            "dependencies": {
+                "resolve-from": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+                    "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+                    "dev": true
+                }
             }
         },
         "resolve-dir": {
@@ -5862,6 +8222,12 @@
                 "glob": "^7.1.3"
             }
         },
+        "rsvp": {
+            "version": "4.8.5",
+            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+            "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+            "dev": true
+        },
         "run-async": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -5870,6 +8236,12 @@
             "requires": {
                 "is-promise": "^2.1.0"
             }
+        },
+        "rx": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+            "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+            "dev": true
         },
         "rxjs": {
             "version": "6.4.0",
@@ -5900,6 +8272,31 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true
+        },
+        "sane": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+            "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+            "dev": true,
+            "requires": {
+                "@cnakazawa/watch": "^1.0.3",
+                "anymatch": "^2.0.0",
+                "capture-exit": "^2.0.0",
+                "exec-sh": "^0.3.2",
+                "execa": "^1.0.0",
+                "fb-watchman": "^2.0.0",
+                "micromatch": "^3.1.4",
+                "minimist": "^1.1.1",
+                "walker": "~1.0.5"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
         },
         "sass-graph": {
             "version": "2.2.4",
@@ -6002,6 +8399,35 @@
                 }
             }
         },
+        "shallow-clone": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+            "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+            "dev": true,
+            "requires": {
+                "is-extendable": "^0.1.1",
+                "kind-of": "^2.0.1",
+                "lazy-cache": "^0.2.3",
+                "mixin-object": "^2.0.1"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                    "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.0.2"
+                    }
+                },
+                "lazy-cache": {
+                    "version": "0.2.7",
+                    "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+                    "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+                    "dev": true
+                }
+            }
+        },
         "shebang-command": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -6017,10 +8443,22 @@
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true
         },
+        "shellwords": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+            "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+            "dev": true
+        },
         "signal-exit": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
+        },
+        "sisteransi": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
+            "integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==",
             "dev": true
         },
         "slash": {
@@ -6166,6 +8604,24 @@
                 "urix": "^0.1.0"
             }
         },
+        "source-map-support": {
+            "version": "0.5.12",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+            "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
         "source-map-url": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
@@ -6177,6 +8633,18 @@
             "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
             "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
             "dev": true
+        },
+        "spawnd": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-4.0.0.tgz",
+            "integrity": "sha512-ql3qhJnhAkvXpaqKBWOqou1rUTSQhFRaZkyOT+MTFB4xY3X+brgw6LTWV2wHuE9A6YPhrNe1cbg7S+jAYnbC0Q==",
+            "dev": true,
+            "requires": {
+                "exit": "^0.1.2",
+                "signal-exit": "^3.0.2",
+                "tree-kill": "^1.2.1",
+                "wait-port": "^0.2.2"
+            }
         },
         "spdx-correct": {
             "version": "3.1.0",
@@ -6254,6 +8722,12 @@
             "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
             "dev": true
         },
+        "stack-utils": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+            "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+            "dev": true
+        },
         "state-toggle": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
@@ -6290,6 +8764,12 @@
                 "readable-stream": "^2.0.1"
             }
         },
+        "stealthy-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+            "dev": true
+        },
         "stream-exhaust": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
@@ -6301,6 +8781,16 @@
             "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
             "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
             "dev": true
+        },
+        "string-length": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+            "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+            "dev": true,
+            "requires": {
+                "astral-regex": "^1.0.0",
+                "strip-ansi": "^4.0.0"
+            }
         },
         "string-width": {
             "version": "2.1.1",
@@ -6355,6 +8845,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
             "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
+            "dev": true
+        },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
             "dev": true
         },
         "strip-indent": {
@@ -6805,6 +9301,12 @@
             "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
             "dev": true
         },
+        "symbol-tree": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+            "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+            "dev": true
+        },
         "table": {
             "version": "5.2.3",
             "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
@@ -6883,10 +9385,143 @@
                 }
             }
         },
+        "test-exclude": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+            "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3",
+                "minimatch": "^3.0.4",
+                "read-pkg-up": "^4.0.0",
+                "require-main-filename": "^2.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "load-json-file": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+                    "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0",
+                        "strip-bom": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "parse-json": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                    "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
+                    }
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                },
+                "path-type": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    }
+                },
+                "read-pkg": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+                    "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "^4.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^3.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+                    "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^3.0.0",
+                        "read-pkg": "^3.0.0"
+                    }
+                },
+                "require-main-filename": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+                    "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+                    "dev": true
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "dev": true
+                }
+            }
+        },
         "text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
+        },
+        "throat": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+            "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
             "dev": true
         },
         "through": {
@@ -6939,6 +9574,12 @@
             "requires": {
                 "os-tmpdir": "~1.0.1"
             }
+        },
+        "tmpl": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+            "dev": true
         },
         "to-absolute-glob": {
             "version": "2.0.2",
@@ -7007,6 +9648,23 @@
                 "through2": "^2.0.3"
             }
         },
+        "topo": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+            "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+            "dev": true,
+            "requires": {
+                "hoek": "6.x.x"
+            },
+            "dependencies": {
+                "hoek": {
+                    "version": "6.1.3",
+                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+                    "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
+                    "dev": true
+                }
+            }
+        },
         "tough-cookie": {
             "version": "2.4.3",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -7024,6 +9682,21 @@
                     "dev": true
                 }
             }
+        },
+        "tr46": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+            "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "tree-kill": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
+            "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
+            "dev": true
         },
         "trim": {
             "version": "0.0.1",
@@ -7099,6 +9772,33 @@
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
             "dev": true
+        },
+        "uglify-js": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
+            "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "commander": "~2.20.0",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.20.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+                    "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+                    "dev": true,
+                    "optional": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
         },
         "unc-path-regex": {
             "version": "0.1.2",
@@ -7326,6 +10026,16 @@
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true
         },
+        "util.promisify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+            "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "object.getownpropertydescriptors": "^2.0.3"
+            }
+        },
         "uuid": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
@@ -7466,6 +10176,130 @@
                 "source-map": "^0.5.1"
             }
         },
+        "w3c-hr-time": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+            "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+            "dev": true,
+            "requires": {
+                "browser-process-hrtime": "^0.1.2"
+            }
+        },
+        "wait-on": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-3.2.0.tgz",
+            "integrity": "sha512-QUGNKlKLDyY6W/qHdxaRlXUAgLPe+3mLL/tRByHpRNcHs/c7dZXbu+OnJWGNux6tU1WFh/Z8aEwvbuzSAu79Zg==",
+            "dev": true,
+            "requires": {
+                "core-js": "^2.5.7",
+                "joi": "^13.0.0",
+                "minimist": "^1.2.0",
+                "request": "^2.88.0",
+                "rx": "^4.1.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
+        },
+        "wait-port": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-0.2.2.tgz",
+            "integrity": "sha1-1RpJHkhKF791qUfnEaLwErTm8uM=",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.3",
+                "commander": "^2.9.0",
+                "debug": "^2.6.6"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "walker": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+            "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+            "dev": true,
+            "requires": {
+                "makeerror": "1.0.x"
+            }
+        },
+        "webidl-conversions": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+            "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+            "dev": true
+        },
+        "whatwg-encoding": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+            "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+            "dev": true,
+            "requires": {
+                "iconv-lite": "0.4.24"
+            }
+        },
+        "whatwg-mimetype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+            "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+            "dev": true
+        },
+        "whatwg-url": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+            "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+            "dev": true,
+            "requires": {
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^1.0.1",
+                "webidl-conversions": "^4.0.2"
+            }
+        },
         "which": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -7558,10 +10392,36 @@
                 "mkdirp": "^0.5.1"
             }
         },
+        "write-file-atomic": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+            "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
+            }
+        },
+        "ws": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+            "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+            "dev": true,
+            "requires": {
+                "async-limiter": "~1.0.0"
+            }
+        },
         "x-is-string": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
             "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
+            "dev": true
+        },
+        "xml-name-validator": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+            "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
             "dev": true
         },
         "xml2js": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
     "devDependencies": {
         "axe-cli": "^3.0.0",
         "child_process": "^1.0.2",
+        "dotenv": "^8.0.0",
         "eslint": "^5.16.0",
+        "eslint-plugin-jest": "^22.6.4",
         "eslint-plugin-prettier": "^3.1.0",
         "eslint-plugin-unicorn": "^9.0.0",
         "fancy-log": "^1.3.3",
@@ -10,7 +12,11 @@
         "gulp-rename": "^1.4.0",
         "gulp-sass": "^4.0.2",
         "gulp-sourcemaps": "^2.6.5",
+        "jest": "^24.8.0",
+        "jest-puppeteer": "^4.2.0",
+        "node-notifier": "^5.4.0",
         "prettier": "^1.17.1",
+        "puppeteer": "^1.17.0",
         "stylelint": "^10.0.1",
         "stylelint-config-prettier": "^5.2.0",
         "stylelint-config-recommended": "^2.2.0"
@@ -34,5 +40,8 @@
     "bugs": {
         "url": "https://github.com/LibraryOfCongress/concordia/issues"
     },
-    "homepage": "https://github.com/LibraryOfCongress/concordia"
+    "homepage": "https://github.com/LibraryOfCongress/concordia",
+    "scripts": {
+        "test": "jest --runInBand"
+    }
 }


### PR DESCRIPTION
This is currently just enough that `npm test` or the VSCode Jest extension (`code --install-extension orta.vscode-jest`) will run and confirm that the homepage has a title.

* [ ] Cover basic activity UI functionality
* [ ] Cover the older transcription UI
* [ ] Decide what our code-coverage story should be: currently tests running under Chrome/Puppeteer do not collect coverage. Do we have Jest use `jsdom` for that rather than running in Chrome, wait for https://github.com/smooth-code/jest-puppeteer/issues/90 to resolve, split this into multiple stages, switch tools, etc.?
* [ ] Decide whether we want to pack this into a separate target so we can avoid big dependencies (e.g. Puppeteer) in the Docker containers, make sure those only use a non-dev build, etc. 
