### PR TITLE
Upgrade CSS variables polyfill

### DIFF
--- a/concordia/static/js/base.js
+++ b/concordia/static/js/base.js
@@ -129,12 +129,12 @@ $(function() {
         }
 
         loadLegacyPolyfill(
-            'https://cdn.jsdelivr.net/npm/css-vars-ponyfill@1.12.0/dist/css-vars-ponyfill.min.js',
+            'https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2.0.2/dist/css-vars-ponyfill.min.js',
             function() {
                 /* global cssVars */
                 cssVars({
                     legacyOnly: true,
-                    onlyVars: true,
+                    preserveStatic: true,
                     include: 'link[rel="stylesheet"][href^="/static/"]'
                 });
             }

--- a/concordia/static/js/base.js
+++ b/concordia/static/js/base.js
@@ -84,7 +84,11 @@ function displayMessage(level, message, uniqueId) {
 }
 
 function isOutdatedBrowser() {
-    /* See https://caniuse.com/#feat=css-supports-api */
+    /*
+        See https://caniuse.com/#feat=css-supports-api for the full matrix but
+        by now this is effectively the same as testing for IE11 vs. all of the
+        evergreen browsers:
+    */
     return typeof CSS == 'undefined' || !CSS.supports;
 }
 
@@ -128,6 +132,10 @@ $(function() {
             );
         }
 
+        /*
+            CSS variables are supported by everything except IE11:
+            https://caniuse.com/#feat=css-variables
+        */
         loadLegacyPolyfill(
             'https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2.0.2/dist/css-vars-ponyfill.min.js',
             function() {


### PR DESCRIPTION
Since we still support IE11 we'll stay current on this polyfill. I also added a couple of comments to make sure we don't retain it when we drop IE11 after Microsoft formally stops supporting it (planned to be January 31, 2020).