### PR TITLE
Cleanup unused or incorrect CSS

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -1,5 +1,10 @@
 extends:
     - stylelint-config-recommended
     - stylelint-config-prettier
+
+plugins:
+    - stylelint-value-no-unknown-custom-properties
+
 rules:
     no-descending-specificity: null
+    csstools/value-no-unknown-custom-properties: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,6 @@ script:
     - git fetch --unshallow
     - git diff --name-only $TRAVIS_COMMIT_RANGE | xargs pipenv run pre-commit run --files
     - pipenv run safety check
+    - npx --quiet csstree-validator static/css/
 after_success:
     - 'if [[ $TRAVIS_PYTHON_VERSION == "3.7" ]]; then git fetch --unshallow --tags; pipenv run coverage xml; sonar-scanner -Dsonar.projectVersion="$(pipenv run python setup.py --version)"; coveralls; fi'

--- a/concordia/static/scss/action-app.scss
+++ b/concordia/static/scss/action-app.scss
@@ -80,7 +80,6 @@ main {
 .concordia-app-input-group-text {
     font-weight: bold;
     border: none;
-    background-color: none;
 }
 
 .concordia-app-range-min {

--- a/concordia/static/scss/base.scss
+++ b/concordia/static/scss/base.scss
@@ -869,7 +869,7 @@ body.view-transcriptions--asset-detail main {
 
     background-color: rgba(250, 250, 250, 0.8);
     border-top: 1pt solid var(--bg-darkest-gray);
-    transition: height 1s linear 0;
+    transition: height 1s linear 0s;
 }
 
 #instruction-window.collapse {

--- a/concordia/static/scss/base.scss
+++ b/concordia/static/scss/base.scss
@@ -345,13 +345,6 @@ ul.nav-secondary {
     opacity: 0.3 !important;
 }
 
-.btn-secondary.disabled,
-.btn-secondary:disabled {
-    background-color: var(--secondary-color) !important;
-    border-color: var(--secondary-color) !important;
-    color: var(--text-color-offwhite) !important;
-}
-
 .btn-default {
     background-color: rgba(158, 158, 158, 1);
     border-color: rgba(158, 158, 158, 1);

--- a/concordia/static/scss/base.scss
+++ b/concordia/static/scss/base.scss
@@ -1,6 +1,7 @@
 :root {
     --primary-color: #f05129;
     --primary-color-hover: rgba(188, 57, 1, 1); /* #BC3901 */
+    --secondary-color: rgba(0, 167, 228, 1); /* #00A7E4 */
     --color-success: rgba(22, 201, 74, 1); /* #16C94A */
     --color-danger: rgba(254, 12, 11, 1); /* #FE0C0B */
     --color-warning: rgba(254, 153, 11, 1); /* #FE990B */
@@ -134,10 +135,6 @@ h6 {
     color: var(--primary-color);
 }
 
-.secondary-text {
-    color: var(--secondary-color);
-}
-
 .gray-text {
     color: var(--text-color-primary);
 }
@@ -153,16 +150,6 @@ a.primary-text {
 
 a.primary-text:hover {
     color: var(--primary-color-hover);
-    text-decoration: underline;
-}
-
-a.secondary-text {
-    color: var(--secondary-color);
-    text-decoration: none;
-}
-
-a.secondary-text:hover {
-    color: var(--secondary-color-hover);
     text-decoration: underline;
 }
 
@@ -356,18 +343,6 @@ ul.nav-secondary {
 .btn.disabled,
 .btn:disabled {
     opacity: 0.3 !important;
-}
-
-.btn-minimal-secondary {
-    background-color: transparent;
-    border-color: transparent;
-    color: var(--secondary-color);
-}
-
-.btn-minimal-secondary:hover {
-    background-color: var(--secondary-color);
-    border-color: transparent;
-    color: var(--text-color-offwhite);
 }
 
 .btn-secondary.disabled,

--- a/concordia/static/scss/base.scss
+++ b/concordia/static/scss/base.scss
@@ -180,7 +180,7 @@ a.nav-secondary {
 }
 
 a.nav-secondary:hover {
-    opacity: 70%;
+    opacity: 0.7;
     text-decoration: none;
 }
 

--- a/concordia/static/scss/base.scss
+++ b/concordia/static/scss/base.scss
@@ -952,37 +952,37 @@ div.related-links {
 
 .alert.alert-primary {
     background-color: var(--primary-color);
-    border-color: none;
+    border-color: var(--primary-color);
     color: var(--text-color-offwhite);
 }
 
 .alert.alert-secondary {
     background-color: var(--secondary-color);
-    border-color: none;
+    border-color: var(--secondary-color);
     color: var(--text-color-primary);
 }
 
 .alert.alert-success {
     background-color: var(--color-success);
-    border-color: none;
+    border-color: var(--color-success);
     color: var(--text-color-offwhite);
 }
 
 .alert.alert-danger {
     background-color: var(--color-danger);
-    border-color: none;
+    border-color: var(--color-danger);
     color: var(--text-color-offwhite);
 }
 
 .alert.alert-warning {
     background-color: var(--color-warning);
-    border-color: none;
+    border-color: var(--color-warning);
     color: var(--text-color-primary);
 }
 
 .alert.alert-info {
     background-color: var(--color-info);
-    border-color: none;
+    border-color: var(--color-info);
     color: var(--text-color-primary);
 }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -45,9 +45,9 @@
                     }
                 },
                 "ms": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "dev": true
                 }
             }
@@ -160,9 +160,9 @@
                     }
                 },
                 "ms": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "dev": true
                 }
             }
@@ -255,9 +255,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "12.0.4",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.4.tgz",
-            "integrity": "sha512-j8YL2C0fXq7IONwl/Ud5Kt0PeXw22zGERt+HSSnwbKOJVsAGkEz3sFCYwaF9IOuoG1HOtE0vKCj6sXF7Q0+Vaw==",
+            "version": "12.0.8",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.8.tgz",
+            "integrity": "sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg==",
             "dev": true
         },
         "@types/unist": {
@@ -642,16 +642,17 @@
             "dev": true
         },
         "autoprefixer": {
-            "version": "9.5.1",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.5.1.tgz",
-            "integrity": "sha512-KJSzkStUl3wP0D5sdMlP82Q52JLy5+atf2MHAre48+ckWkXgixmfHyWmA77wFDy6jTHU6mIgXv6hAQ2mf1PjJQ==",
+            "version": "9.6.0",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.0.tgz",
+            "integrity": "sha512-kuip9YilBqhirhHEGHaBTZKXL//xxGnzvsD0FtBQa6z+A69qZD6s/BAX9VzDF1i9VKDquTJDQaPLSEhOnL6FvQ==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.5.4",
-                "caniuse-lite": "^1.0.30000957",
+                "browserslist": "^4.6.1",
+                "caniuse-lite": "^1.0.30000971",
+                "chalk": "^2.4.2",
                 "normalize-range": "^0.1.2",
                 "num2fraction": "^1.2.2",
-                "postcss": "^7.0.14",
+                "postcss": "^7.0.16",
                 "postcss-value-parser": "^3.3.1"
             }
         },
@@ -861,14 +862,14 @@
             }
         },
         "browserslist": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.1.tgz",
-            "integrity": "sha512-1MC18ooMPRG2UuVFJTHFIAkk6mpByJfxCrnUyvSlu/hyQSFHMrlhM02SzNuCV+quTP4CKmqtOMAIjrifrpBJXQ==",
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.3.tgz",
+            "integrity": "sha512-CNBqTCq22RKM8wKJNowcqihHJ4SkI8CGeK7KOR9tPboXUuS5Zk5lQgzzTbs4oxD8x+6HUshZUa2OyNI9lR93bQ==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30000971",
-                "electron-to-chromium": "^1.3.137",
-                "node-releases": "^1.1.21"
+                "caniuse-lite": "^1.0.30000975",
+                "electron-to-chromium": "^1.3.164",
+                "node-releases": "^1.1.23"
             }
         },
         "buffer-equal": {
@@ -963,9 +964,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30000971",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000971.tgz",
-            "integrity": "sha512-TQFYFhRS0O5rdsmSbF1Wn+16latXYsQJat66f7S7lizXW1PVpWJeZw9wqqVLIjuxDRz7s7xRUj13QCfd8hKn6g==",
+            "version": "1.0.30000976",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000976.tgz",
+            "integrity": "sha512-tleNB1IwPRqZiod6nUNum63xQCMN96BUO2JTeiwuRM7p9d616EHsMBjBWJMudX39qCaPuWY8KEWzMZq7A9XQMQ==",
             "dev": true
         },
         "caseless": {
@@ -1176,13 +1177,12 @@
             "dev": true
         },
         "clone-regexp": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
-            "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
+            "integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
             "dev": true,
             "requires": {
-                "is-regexp": "^1.0.0",
-                "is-supported-regexp-flag": "^1.0.0"
+                "is-regexp": "^2.0.0"
             }
         },
         "clone-stats": {
@@ -1731,9 +1731,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.141",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.141.tgz",
-            "integrity": "sha512-DdQaeP8yQNYFdivOrp37UNAZMvyZP//+SWYMVJD31A/3gbI1J6olQs8tuRaHL2ij7dubhCDXhlE4F97mrT8KGQ==",
+            "version": "1.3.167",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.167.tgz",
+            "integrity": "sha512-84IjpeRudjP43Q0+K7tlS7ESoHOl0W6CIdzs5reS9p+sAjCQEDiaAyiXN2v1qLUdL+Of6ZSaH4Cq6bl+sfzy8A==",
             "dev": true
         },
         "emoji-regex": {
@@ -2006,12 +2006,12 @@
             }
         },
         "execall": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
-            "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
+            "integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
             "dev": true,
             "requires": {
-                "clone-regexp": "^1.0.0"
+                "clone-regexp": "^2.1.0"
             }
         },
         "expand-brackets": {
@@ -2344,6 +2344,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
             "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+            "dev": true
+        },
+        "flatten": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+            "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
             "dev": true
         },
         "flush-write-stream": {
@@ -3516,9 +3522,9 @@
             "dev": true
         },
         "html-tags": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
-            "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.0.0.tgz",
+            "integrity": "sha512-xiXEBjihaNI+VZ2mKEoI5ZPxqUsevTKM+aeeJ/W4KAg2deGE35minmCJMn51BvwJZmiHaeAxrb2LAS0yZJxuuA==",
             "dev": true
         },
         "htmlparser2": {
@@ -3591,9 +3597,9 @@
             }
         },
         "import-lazy": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
-            "integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+            "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
             "dev": true
         },
         "import-modules": {
@@ -3951,9 +3957,9 @@
             "dev": true
         },
         "is-regexp": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-            "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
+            "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
             "dev": true
         },
         "is-relative": {
@@ -3964,12 +3970,6 @@
             "requires": {
                 "is-unc-path": "^1.0.0"
             }
-        },
-        "is-supported-regexp-flag": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
-            "integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
-            "dev": true
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -4179,9 +4179,9 @@
             "dev": true
         },
         "known-css-properties": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.13.0.tgz",
-            "integrity": "sha512-6VWDxNr7cQXPDtMdCWLZMK3E8hdLrpyPPRdx6RbyvqklqgM6/XNFsVopv8QOZ+hRB6iHG/urEDwzlWbmMCv/kw==",
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.14.0.tgz",
+            "integrity": "sha512-P+0a/gBzLgVlCnK8I7VcD0yuYJscmWn66wH9tlKsQnmVdg689tLEmziwB9PuazZYLkcm07fvWOKCJJqI55sD5Q==",
             "dev": true
         },
         "last-run": {
@@ -4362,12 +4362,12 @@
             "dev": true
         },
         "log-symbols": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-            "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+            "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.1"
+                "chalk": "^2.4.2"
             }
         },
         "longest-streak": {
@@ -4732,9 +4732,9 @@
             }
         },
         "node-releases": {
-            "version": "1.1.22",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.22.tgz",
-            "integrity": "sha512-O6XpteBuntW1j86mw6LlovBIwTe+sO2+7vi9avQffNeIW4upgnaCVm6xrBWH+KATz7mNNRNNeEpuWB7dT6Cr3w==",
+            "version": "1.1.23",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.23.tgz",
+            "integrity": "sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==",
             "dev": true,
             "requires": {
                 "semver": "^5.3.0"
@@ -5308,9 +5308,9 @@
             "dev": true
         },
         "postcss": {
-            "version": "7.0.16",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
-            "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+            "version": "7.0.17",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
+            "integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
             "dev": true,
             "requires": {
                 "chalk": "^2.4.2",
@@ -5345,12 +5345,12 @@
             }
         },
         "postcss-jsx": {
-            "version": "0.36.0",
-            "resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.0.tgz",
-            "integrity": "sha512-/lWOSXSX5jlITCKFkuYU2WLFdrncZmjSVyNpHAunEgirZXLwI8RjU556e3Uz4mv0WVHnJA9d3JWb36lK9Yx99g==",
+            "version": "0.36.1",
+            "resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.1.tgz",
+            "integrity": "sha512-xaZpy01YR7ijsFUtu5rViYCFHurFIPHir+faiOQp8g/NfTfWqZCKDhKrydQZ4d8WlSAmVdXGwLjpFbsNUI26Sw==",
             "dev": true,
             "requires": {
-                "@babel/core": ">=7.1.0"
+                "@babel/core": ">=7.2.2"
             }
         },
         "postcss-less": {
@@ -5388,6 +5388,17 @@
                 "lodash": "^4.17.11",
                 "log-symbols": "^2.2.0",
                 "postcss": "^7.0.7"
+            },
+            "dependencies": {
+                "log-symbols": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+                    "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.0.1"
+                    }
+                }
             }
         },
         "postcss-resolve-nested-selector": {
@@ -5446,6 +5457,17 @@
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
             "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
             "dev": true
+        },
+        "postcss-values-parser": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
+            "integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
+            "dev": true,
+            "requires": {
+                "flatten": "^1.0.2",
+                "indexes-of": "^1.0.1",
+                "uniq": "^1.0.1"
+            }
         },
         "prelude-ls": {
             "version": "1.1.2",
@@ -6024,9 +6046,9 @@
             "dev": true
         },
         "slash": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true
         },
         "slice-ansi": {
@@ -6379,9 +6401,9 @@
             "dev": true
         },
         "stylelint": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-10.0.1.tgz",
-            "integrity": "sha512-NbpD9BvQRmPe7QfaLB2OqhhDr5g6SAn43AAH2XLyqtQ9ZcioQECgadkIbormfhzxLhccAQWBZbVNiZz1oqEf8g==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-10.1.0.tgz",
+            "integrity": "sha512-OmlUXrgzEMLQYj1JPTpyZPR9G4bl0StidfHnGJEMpdiQ0JyTq0MPg1xkHk1/xVJ2rTPESyJCDWjG8Kbpoo7Kuw==",
             "dev": true,
             "requires": {
                 "autoprefixer": "^9.5.1",
@@ -6389,20 +6411,20 @@
                 "chalk": "^2.4.2",
                 "cosmiconfig": "^5.2.0",
                 "debug": "^4.1.1",
-                "execall": "^1.0.0",
+                "execall": "^2.0.0",
                 "file-entry-cache": "^5.0.1",
                 "get-stdin": "^7.0.0",
                 "global-modules": "^2.0.0",
                 "globby": "^9.2.0",
                 "globjoin": "^0.1.4",
-                "html-tags": "^2.0.0",
+                "html-tags": "^3.0.0",
                 "ignore": "^5.0.6",
-                "import-lazy": "^3.1.0",
+                "import-lazy": "^4.0.0",
                 "imurmurhash": "^0.1.4",
-                "known-css-properties": "^0.13.0",
+                "known-css-properties": "^0.14.0",
                 "leven": "^3.1.0",
                 "lodash": "^4.17.11",
-                "log-symbols": "^2.2.0",
+                "log-symbols": "^3.0.0",
                 "mathml-tag-names": "^2.1.0",
                 "meow": "^5.0.0",
                 "micromatch": "^4.0.0",
@@ -6410,7 +6432,7 @@
                 "pify": "^4.0.1",
                 "postcss": "^7.0.14",
                 "postcss-html": "^0.36.0",
-                "postcss-jsx": "^0.36.0",
+                "postcss-jsx": "^0.36.1",
                 "postcss-less": "^3.1.4",
                 "postcss-markdown": "^0.36.0",
                 "postcss-media-query-parser": "^0.2.3",
@@ -6424,9 +6446,10 @@
                 "postcss-value-parser": "^3.3.1",
                 "resolve-from": "^5.0.0",
                 "signal-exit": "^3.0.2",
-                "slash": "^2.0.0",
+                "slash": "^3.0.0",
                 "specificity": "^0.4.1",
                 "string-width": "^4.1.0",
+                "strip-ansi": "^5.2.0",
                 "style-search": "^0.1.0",
                 "sugarss": "^2.0.0",
                 "svg-tags": "^1.0.0",
@@ -6545,6 +6568,12 @@
                             "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
                             "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
                             "dev": true
+                        },
+                        "slash": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+                            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+                            "dev": true
                         }
                     }
                 },
@@ -6626,9 +6655,9 @@
                     }
                 },
                 "ms": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "dev": true
                 },
                 "parse-json": {
@@ -6770,6 +6799,15 @@
             "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-2.2.0.tgz",
             "integrity": "sha512-bZ+d4RiNEfmoR74KZtCKmsABdBJr4iXRiCso+6LtMJPw5rd/KnxUWTxht7TbafrTJK1YRjNgnN0iVZaJfc3xJA==",
             "dev": true
+        },
+        "stylelint-value-no-unknown-custom-properties": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/stylelint-value-no-unknown-custom-properties/-/stylelint-value-no-unknown-custom-properties-2.0.0.tgz",
+            "integrity": "sha512-iA7pLNBRCrRi35rUpF3bS4zpPWQtk1YxqKC0MhgOvhI1XDciE/FaAQoFgn65vGMEyQ0Q3PPGfWawn7sVd/thXQ==",
+            "dev": true,
+            "requires": {
+                "postcss-values-parser": "^2.0.0"
+            }
         },
         "sugarss": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
         "gulp-sass": "^4.0.2",
         "gulp-sourcemaps": "^2.6.5",
         "prettier": "^1.18.1",
-        "stylelint": "^10.0.1",
+        "stylelint": "^10.1.0",
         "stylelint-config-prettier": "^5.2.0",
-        "stylelint-config-recommended": "^2.2.0"
+        "stylelint-config-recommended": "^2.2.0",
+        "stylelint-value-no-unknown-custom-properties": "^2.0.0"
     },
     "dependencies": {
         "array-sort-by": "^1.2.1",


### PR DESCRIPTION
* I noticed some undefined variable errors while testing #1064. It looks like 338ba54384dfd6c67af913e851174293895b56f6 removed `--secondary-color` but not the rules which referenced it. Some of these are easily remediated since we have no references to `secondary-text`, etc. but we have some `.btn-secondary` rules which do reference it.
* We had several cases where a CSS property such as `opacity`, `transition` or `background-color` was specified with an invalid value
* We now have a CSS validation step in our CI configuration which runs ` npx --quiet csstree-validator static/css/` on the Gulp output