### PR TITLE
Restore CSS background for legacy mode fullscreen display

### DIFF
--- a/concordia/static/scss/base.scss
+++ b/concordia/static/scss/base.scss
@@ -48,7 +48,9 @@
     --top-tags-input: calc(50vh - 0.75rem);
 }
 
-html {
+html,
+body.view-transcriptions--asset-detail main,
+#contribute-main-content {
     /* This avoids browser inconsistencies when using the fullscreen API */
     color: var(--text-color-primary);
     background-color: var(--bg-offwhite);


### PR DESCRIPTION
This needs to be present as long as we offer full-screen mode on the legacy transcription interface. Alternatively, we might want to remove that since it's less useful due to popping out on every page transition.

Closes #1073 