### PR TITLE
Turn down django.template and django.utils.autoreload debug logging

### DIFF
--- a/concordia/settings_dev.py
+++ b/concordia/settings_dev.py
@@ -10,6 +10,8 @@ LOGGING["handlers"]["celery"]["level"] = "DEBUG"
 LOGGING["handlers"]["celery"]["filename"] = "./logs/concordia-celery.log"
 LOGGING["loggers"]["django"]["level"] = "DEBUG"
 LOGGING["loggers"]["celery"]["level"] = "DEBUG"
+LOGGING["loggers"]["django.utils.autoreload"] = {"level": "INFO"}
+LOGGING["loggers"]["django.template"] = {"level": "INFO"}
 
 DEBUG = True
 


### PR DESCRIPTION
In dev environments, the default django debug loggers generate too much output. This PR shows how to turn them down in `settings_dev.py.`