### PR TITLE
Avoid direct use of Object.prototype hasOwnProperty

### DIFF
--- a/concordia/static/js/action-app/index.js
+++ b/concordia/static/js/action-app/index.js
@@ -67,7 +67,7 @@ export class ActionApp {
     reportError(category, header, body) {
         let alert;
 
-        if (!this.alerts.hasOwnProperty(category)) {
+        if (!Object.prototype.hasOwnProperty.call(this.alerts, category)) {
             alert = new Alert();
             this.alerts[category] = alert;
             mount(document.body, alert);
@@ -84,7 +84,7 @@ export class ActionApp {
     }
 
     clearError(category) {
-        if (this.alerts.hasOwnProperty(category)) {
+        if (Object.prototype.hasOwnProperty.call(this.alerts, category)) {
             jQuery(this.alerts[category].el).alert('close');
         }
     }


### PR DESCRIPTION
See https://eslint.org/docs/rules/no-prototype-builtins — I'm not sure whether the answer is to do this or convert it to a `Map` which has the exact semantics we want and less legacy baggage.