### PR TITLE
Log successful and unsuccessful login attempts

### DIFF
--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -217,6 +217,11 @@ LOGGING = {
     "loggers": {
         "django": {"handlers": ["file", "stream"], "level": "DEBUG", "propagate": True},
         "celery": {"handlers": ["celery", "stream"], "level": "DEBUG"},
+        "concordia": {
+            "handlers": ["file", "stream"],
+            "level": "DEBUG",
+            "propagate": True,
+        },
     },
 }
 

--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -219,7 +219,7 @@ LOGGING = {
         "celery": {"handlers": ["celery", "stream"], "level": "DEBUG"},
         "concordia": {
             "handlers": ["file", "stream"],
-            "level": "DEBUG",
+            "level": "INFO",
             "propagate": True,
         },
     },

--- a/concordia/signals/handlers.py
+++ b/concordia/signals/handlers.py
@@ -1,4 +1,4 @@
-from logging import getLogger
+import logging
 from time import time
 
 from asgiref.sync import AsyncToSync
@@ -16,7 +16,7 @@ from .signals import reservation_obtained, reservation_released
 
 ASSET_CHANNEL_LAYER = get_channel_layer()
 
-logger = getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @receiver(user_logged_in)
@@ -26,13 +26,11 @@ def clear_reservation_token(sender, user, request, **kwargs):
     except KeyError:
         pass
 
-    # TODO: WHy doesn't this work?
     logger.info("User logged in")
 
 
 @receiver(user_login_failed)
 def handle_user_login_failed(sender, credentials, request, **kwargs):
-    # TODO: WHy doesn't this work?
     logger.warning("User login failed")
 
 

--- a/concordia/signals/handlers.py
+++ b/concordia/signals/handlers.py
@@ -1,10 +1,11 @@
+from logging import getLogger
 from time import time
 
 from asgiref.sync import AsyncToSync
 from channels.layers import get_channel_layer
 from django.conf import settings
 from django.contrib.auth.models import Group
-from django.contrib.auth.signals import user_logged_in
+from django.contrib.auth.signals import user_logged_in, user_login_failed
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django_registration.signals import user_registered
@@ -15,6 +16,8 @@ from .signals import reservation_obtained, reservation_released
 
 ASSET_CHANNEL_LAYER = get_channel_layer()
 
+logger = getLogger(__name__)
+
 
 @receiver(user_logged_in)
 def clear_reservation_token(sender, user, request, **kwargs):
@@ -22,6 +25,15 @@ def clear_reservation_token(sender, user, request, **kwargs):
         del request.session["reservation_token"]
     except KeyError:
         pass
+
+    # TODO: WHy doesn't this work?
+    logger.info("User logged in")
+
+
+@receiver(user_login_failed)
+def handle_user_login_failed(sender, credentials, request, **kwargs):
+    # TODO: WHy doesn't this work?
+    logger.warning("User login failed")
 
 
 @receiver(user_registered)

--- a/concordia/signals/handlers.py
+++ b/concordia/signals/handlers.py
@@ -25,13 +25,12 @@ def clear_reservation_token(sender, user, request, **kwargs):
         del request.session["reservation_token"]
     except KeyError:
         pass
-
-    logger.info("User logged in")
+    logger.info("Successful user login with username %s", user)
 
 
 @receiver(user_login_failed)
 def handle_user_login_failed(sender, credentials, request, **kwargs):
-    logger.warning("User login failed")
+    logger.warning("Failed user login with username %s", credentials["username"])
 
 
 @receiver(user_registered)


### PR DESCRIPTION
Fixes #1102 

Once this is merged, we'll have data in our regular ECS application logs from which we can create a metric filter and an alarm for excessive failed login attempts. See comment below with link to tutorial on how to do that.