### PR TITLE
Cleanup logging config

### DIFF
--- a/concordia/settings_dev.py
+++ b/concordia/settings_dev.py
@@ -5,11 +5,10 @@ from .settings_template import INSTALLED_APPS, LOGGING, MIDDLEWARE
 
 LOGGING["handlers"]["stream"]["level"] = "DEBUG"
 LOGGING["handlers"]["file"]["level"] = "DEBUG"
-LOGGING["handlers"]["file"]["filename"] = "./logs/concordia-web.log"
 LOGGING["handlers"]["celery"]["level"] = "DEBUG"
-LOGGING["handlers"]["celery"]["filename"] = "./logs/concordia-celery.log"
 LOGGING["loggers"]["django"]["level"] = "DEBUG"
 LOGGING["loggers"]["celery"]["level"] = "DEBUG"
+LOGGING["loggers"]["concordia"]["level"] = "DEBUG"
 LOGGING["loggers"]["django.utils.autoreload"] = {"level": "INFO"}
 LOGGING["loggers"]["django.template"] = {"level": "INFO"}
 

--- a/concordia/settings_dev.py
+++ b/concordia/settings_dev.py
@@ -6,11 +6,13 @@ from .settings_template import INSTALLED_APPS, LOGGING, MIDDLEWARE
 LOGGING["handlers"]["stream"]["level"] = "DEBUG"
 LOGGING["handlers"]["file"]["level"] = "DEBUG"
 LOGGING["handlers"]["celery"]["level"] = "DEBUG"
-LOGGING["loggers"]["django"]["level"] = "DEBUG"
-LOGGING["loggers"]["celery"]["level"] = "DEBUG"
-LOGGING["loggers"]["concordia"]["level"] = "DEBUG"
-LOGGING["loggers"]["django.utils.autoreload"] = {"level": "INFO"}
-LOGGING["loggers"]["django.template"] = {"level": "INFO"}
+LOGGING["loggers"] = {
+    "django": {"handlers": ["file", "stream"], "level": "DEBUG"},
+    "celery": {"handlers": ["celery", "stream"], "level": "DEBUG"},
+    "concordia": {"handlers": ["file", "stream"], "level": "DEBUG"},
+    "django.utils.autoreload": {"level": "INFO"},
+    "django.template": {"level": "INFO"},
+}
 
 DEBUG = True
 

--- a/concordia/settings_docker.py
+++ b/concordia/settings_docker.py
@@ -3,15 +3,7 @@ import os
 from django.core.management.utils import get_random_secret_key
 
 from .settings_template import *  # NOQA ignore=F405
-from .settings_template import INSTALLED_APPS, LOGGING
-
-LOGGING["handlers"]["stream"]["level"] = "INFO"
-LOGGING["handlers"]["file"]["level"] = "INFO"
-LOGGING["handlers"]["file"]["filename"] = "./logs/concordia-web.log"
-LOGGING["handlers"]["celery"]["level"] = "INFO"
-LOGGING["handlers"]["celery"]["filename"] = "./logs/concordia-celery.log"
-LOGGING["loggers"]["django"]["level"] = "INFO"
-LOGGING["loggers"]["celery"]["level"] = "INFO"
+from .settings_template import INSTALLED_APPS
 
 DEBUG = os.getenv("DEBUG", "").lower() == "true"
 

--- a/concordia/settings_ecs.py
+++ b/concordia/settings_ecs.py
@@ -5,15 +5,7 @@ from django.core.management.utils import get_random_secret_key
 
 from .secrets import get_secret
 from .settings_template import *  # NOQA ignore=F405
-from .settings_template import CONCORDIA_ENVIRONMENT, DATABASES, INSTALLED_APPS, LOGGING
-
-LOGGING["handlers"]["stream"]["level"] = "INFO"
-LOGGING["handlers"]["file"]["level"] = "INFO"
-LOGGING["handlers"]["file"]["filename"] = "./logs/concordia-web.log"
-LOGGING["handlers"]["celery"]["level"] = "INFO"
-LOGGING["handlers"]["celery"]["filename"] = "./logs/concordia-celery.log"
-LOGGING["loggers"]["django"]["level"] = "INFO"
-LOGGING["loggers"]["celery"]["level"] = "INFO"
+from .settings_template import CONCORDIA_ENVIRONMENT, DATABASES, INSTALLED_APPS
 
 if os.getenv("AWS"):
     ENV_NAME = os.getenv("ENV_NAME")

--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -196,10 +196,10 @@ LOGGING = {
             "level": "INFO",
             "formatter": "long",
         },
-        "null": {"level": "DEBUG", "class": "logging.NullHandler"},
+        "null": {"level": "INFO", "class": "logging.NullHandler"},
         "file": {
             "class": "logging.handlers.TimedRotatingFileHandler",
-            "level": "DEBUG",
+            "level": "INFO",
             "formatter": "long",
             "filename": "{}/logs/concordia.log".format(SITE_ROOT_DIR),
             "when": "H",
@@ -207,7 +207,7 @@ LOGGING = {
             "backupCount": 16,
         },
         "celery": {
-            "level": "DEBUG",
+            "level": "INFO",
             "class": "logging.handlers.RotatingFileHandler",
             "filename": "{}/logs/celery.log".format(SITE_ROOT_DIR),
             "formatter": "long",
@@ -215,13 +215,9 @@ LOGGING = {
         },
     },
     "loggers": {
-        "django": {"handlers": ["file", "stream"], "level": "DEBUG", "propagate": True},
-        "celery": {"handlers": ["celery", "stream"], "level": "DEBUG"},
-        "concordia": {
-            "handlers": ["file", "stream"],
-            "level": "INFO",
-            "propagate": True,
-        },
+        "django": {"handlers": ["file", "stream"], "level": "INFO", "propagate": True},
+        "celery": {"handlers": ["celery", "stream"], "level": "INFO"},
+        "concordia": {"handlers": ["file", "stream"], "level": "INFO"},
     },
 }
 

--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -215,9 +215,9 @@ LOGGING = {
         },
     },
     "loggers": {
-        "django": {"handlers": ["file", "stream"], "level": "INFO", "propagate": True},
-        "celery": {"handlers": ["celery", "stream"], "level": "INFO"},
-        "concordia": {"handlers": ["file", "stream"], "level": "INFO"},
+        "django": {"handlers": ["file"], "level": "INFO"},
+        "celery": {"handlers": ["celery"], "level": "INFO"},
+        "concordia": {"handlers": ["file"], "level": "INFO"},
     },
 }
 

--- a/concordia/settings_test.py
+++ b/concordia/settings_test.py
@@ -1,13 +1,5 @@
 from .settings_template import *  # NOQA ignore=F405
-from .settings_template import DATABASES, LOGGING
-
-LOGGING["handlers"]["stream"]["level"] = "INFO"
-LOGGING["handlers"]["file"]["level"] = "INFO"
-LOGGING["handlers"]["file"]["filename"] = "./logs/concordia-web.log"
-LOGGING["handlers"]["celery"]["level"] = "INFO"
-LOGGING["handlers"]["celery"]["filename"] = "./logs/concordia-celery.log"
-LOGGING["loggers"]["django"]["level"] = "INFO"
-LOGGING["loggers"]["celery"]["level"] = "INFO"
+from .settings_template import DATABASES
 
 DEBUG = False
 


### PR DESCRIPTION
I'm trying to get to the bottom of why logging works fine with `pipenv run ./manage.py runserver` but when run with daphne the warning level messages are all duplicated. See below for example. In doing testing, I cleaned up some of the logging related settings to make comparing the various environments simpler. Turns out, the problem doesn't have anything to do with our logging configuration, but anyway this is cleaner than it was.

```
~/concordia ± pipenv run daphne -b 0.0.0.0 -p 80 concordia.asgi:application
Loading .env environment variables…
2019-10-10 13:48:28,265 INFO     Starting server at tcp:port=80:interface=0.0.0.0
2019-10-10 13:48:28,266 INFO     HTTP/2 support not enabled (install the http2 and tls Twisted extras)
2019-10-10 13:48:28,266 INFO     Configuring endpoint tcp:port=80:interface=0.0.0.0
2019-10-10 13:48:28,268 INFO     Listening on TCP address 0.0.0.0:80
[2019-10-10T13:48:37 WARNING concordia.signals.handlers:33] Failed user login with username asdf
2019-10-10 13:48:37,967 WARNING  Failed user login with username asdf
127.0.0.1:52434 - - [10/Oct/2019:13:48:38] "POST /account/login/" 200 12287
127.0.0.1:52434 - - [10/Oct/2019:13:48:38] "GET /account/ajax-messages/" 302 -
127.0.0.1:52435 - - [10/Oct/2019:13:48:38] "GET /account/ajax-status/" 200 2
127.0.0.1:52434 - - [10/Oct/2019:13:48:38] "GET /account/login/?next=/account/ajax-messages/" 200 11972
[2019-10-10T13:48:43 WARNING django.request:228] Not Found: /media/campaign-thumbnails/SusanBAnthonyCampaign.jpg
2019-10-10 13:48:43,086 WARNING  Not Found: /media/campaign-thumbnails/SusanBAnthonyCampaign.jpg
[2019-10-10T13:48:43 WARNING django.request:228] Not Found: /media/campaign-thumbnails/MaryChurchTerrellCampOrig.jpg
2019-10-10 13:48:43,089 WARNING  Not Found: /media/campaign-thumbnails/MaryChurchTerrellCampOrig.jpg
127.0.0.1:52435 - - [10/Oct/2019:13:48:43] "GET /media/campaign-thumbnails/MaryChurchTerrellCampOrig.jpg" 404 2739
127.0.0.1:52434 - - [10/Oct/2019:13:48:43] "GET /media/campaign-thumbnails/SusanBAnthonyCampaign.jpg" 404 2739
[2019-10-10T13:48:43 WARNING django.request:228] Not Found: /media/campaign-thumbnails/WhitmanCampaignEdit.jpg
2019-10-10 13:48:43,136 WARNING  Not Found: /media/campaign-thumbnails/WhitmanCampaignEdit.jpg
127.0.0.1:52434 - - [10/Oct/2019:13:48:43] "GET /media/campaign-thumbnails/WhitmanCampaignEdit.jpg" 404 2739
127.0.0.1:52434 - - [10/Oct/2019:13:48:43] "GET /account/ajax-status/" 200 2
127.0.0.1:52435 - - [10/Oct/2019:13:48:43] "GET /account/ajax-messages/" 302 -
127.0.0.1:52435 - - [10/Oct/2019:13:48:43] "GET /account/login/?next=/account/ajax-messages/" 200 11972
```