### PR TITLE
WIP: better account activation processes

### DIFF
--- a/concordia/forms.py
+++ b/concordia/forms.py
@@ -33,6 +33,7 @@ class ActivateAndSetPasswordForm(SetPasswordForm):
     # set is_active to True.
     def save(self, commit=True):
         if not self.user.is_active:
+            logger.info("Activated user %s due to password reset", self.user.username)
             self.user.is_active = True
             # send user_activation signal so that the user will
             # receive a welcome email

--- a/concordia/forms.py
+++ b/concordia/forms.py
@@ -70,7 +70,13 @@ class UserLoginForm(AuthenticationForm):
             view.send_activation_email(user)
 
             raise forms.ValidationError(
-                "Please check your email and click the link to activate your account.",
+                (
+                    "This account has not yet been activated. ",
+                    "An activation email has been sent to the email "
+                    "address associated with this account. ",
+                    "Please check for this message and click the link "
+                    "to finish your account registration.",
+                ),
                 code="inactive",
             )
 

--- a/concordia/forms.py
+++ b/concordia/forms.py
@@ -9,6 +9,7 @@ from django.contrib.auth.forms import (
 )
 from django_registration.backends.activation.views import RegistrationView
 from django_registration.forms import RegistrationForm
+from django_registration.signals import user_activated
 
 User = get_user_model()
 
@@ -31,7 +32,11 @@ class ActivateAndSetPasswordForm(SetPasswordForm):
     # has confirmed their email address, so
     # set is_active to True.
     def save(self, commit=True):
-        self.user.is_active = True
+        if not self.user.is_active:
+            self.user.is_active = True
+            # send user_activation signal so that the user will
+            # receive a welcome email
+            user_activated.send(sender=self.__class__, user=self.user, request=None)
         return super().save()
 
 

--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -311,13 +311,15 @@ TRANSCRIPTION_RESERVATION_SECONDS = 5 * 60
 #: Web cache policy settings
 DEFAULT_PAGE_TTL = 5 * 60
 
-# Feature flag for social share
+# Feature flags
 FLAGS = {
     "ACTIVITY_UI_ENABLED": [],
     "ADVERTISE_ACTIVITY_UI": [],
     "SIMPLE_CONTENT_BLOCKS": [],
     "CAROUSEL_CMS": [],
+    "SEND_WELCOME_EMAIL": [],
 }
+
 ASGI_APPLICATION = "concordia.routing.application"
 
 CHANNEL_LAYERS = {

--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -267,8 +267,8 @@ ANONYMOUS_CAPTCHA_VALIDATION_INTERVAL = 86400
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 WHITENOISE_ROOT = os.path.join(SITE_ROOT_DIR, "static")
 
-PASSWORD_RESET_TIMEOUT_DAYS = 2
-ACCOUNT_ACTIVATION_DAYS = 2
+PASSWORD_RESET_TIMEOUT_DAYS = 7
+ACCOUNT_ACTIVATION_DAYS = 7
 REGISTRATION_OPEN = True  # set to false to temporarily disable registrations
 
 MESSAGE_STORAGE = "django.contrib.messages.storage.session.SessionStorage"

--- a/concordia/templates/django_registration/activation_complete.html
+++ b/concordia/templates/django_registration/activation_complete.html
@@ -6,7 +6,7 @@
         <div class="col-md-8 mx-auto p-3">
             <h2>Account Activation Complete</h2>
             <p>
-                Welcome back! Your registration is now complete. Go ahead and <a href="{% url 'login' %}">Login</a>.
+                Welcome back! Your registration is now complete and you are logged in.
             </p>
         </div>
     </div>

--- a/concordia/templates/django_registration/activation_complete.html
+++ b/concordia/templates/django_registration/activation_complete.html
@@ -6,7 +6,11 @@
         <div class="col-md-8 mx-auto p-3">
             <h2>Account Activation Complete</h2>
             <p>
-                Welcome back! Your registration is now complete and you are logged in.
+            Welcome back! Your registration is now complete and you are logged in.
+            </p>
+            <p>
+            Visit the <a href="{% url 'welcome-guide' %}">By the People Welcome Guide</a> for instructions and help getting started.
+            Or, <a href="{% url 'redirect-to-next-transcribable-topic-asset' 'suffrage-women-fight-for-the-vote' %}">jump right in</a> to a page that needs your help!
             </p>
         </div>
     </div>

--- a/concordia/templates/emails/welcome_email_body.html
+++ b/concordia/templates/emails/welcome_email_body.html
@@ -1,0 +1,16 @@
+<p>
+Thank you for becoming a By the People virtual volunteer for the Library of Congress!
+</p>
+<p>
+To help you get started, we recommend reading the <a href="{% url 'welcome-guide' %}">Welcome Guide</a>. It includes instructions on transcribing, tagging, and reviewing transcriptions by other volunteers. Reviewing is an area where we especially need your help in completing transcriptions and moving them over the finish line!
+</p>
+<p>
+Once you have a handle on the transcription guidelines, explore the different collections available under <a href="{% url 'campaigns-topics' %}">“Campaigns”</a> using the top navigation on any page.
+</p>
+<p>
+Let us know what you find once you dig in! Share your experience or questions with the community managers and other volunteers on our <a href="https://historyhub.history.gov/community/crowd-loc">discussion space on History Hub</a>.
+</p>
+<p>
+Happy transcribing!<br/>
+The By the People team
+</p>

--- a/concordia/templates/emails/welcome_email_body.txt
+++ b/concordia/templates/emails/welcome_email_body.txt
@@ -1,1 +1,10 @@
-Thanks for activating your account.
+Thank you for becoming a By the People virtual volunteer for the Library of Congress!
+
+To help you get started, we recommend reading the Welcome Guide <https://crowd.loc.gov/help-center/welcome-guide/>. It includes instructions on transcribing, tagging, and reviewing transcriptions by other volunteers. Reviewing is an area where we especially need your help in completing transcriptions and moving them over the finish line!
+
+Once you have a handle on the transcription guidelines, explore the different collections available under “Campaigns” <https://crowd.loc.gov/campaigns-topics/> using the top navigation on any page.
+
+Let us know what you find once you dig in! Share your experience or questions with the community managers and other volunteers on our discussion space on History Hub <https://historyhub.history.gov/community/crowd-loc>.
+
+Happy transcribing!
+The By the People team

--- a/concordia/templates/emails/welcome_email_body.txt
+++ b/concordia/templates/emails/welcome_email_body.txt
@@ -1,0 +1,1 @@
+Thanks for activating your account.

--- a/concordia/templates/emails/welcome_email_subject.txt
+++ b/concordia/templates/emails/welcome_email_subject.txt
@@ -1,0 +1,1 @@
+Welcome to By The People at crowd.loc.gov

--- a/concordia/templates/emails/welcome_email_subject.txt
+++ b/concordia/templates/emails/welcome_email_subject.txt
@@ -1,1 +1,1 @@
-Welcome to By The People at crowd.loc.gov
+Welcome to By The People

--- a/concordia/templates/registration/password_reset_complete.html
+++ b/concordia/templates/registration/password_reset_complete.html
@@ -8,7 +8,13 @@
 <div class="container p-3">
     <div class="row">
         <div class="col-md-6 mx-auto">
-            <p>{% trans "Your password has been reset and you have been logged in. If your account was inactive, it has been activated." %}</p>
+            <p>
+            Your password has been reset and you are now logged in. If your account was inactive, it has been activated.
+            </p>
+            <p>
+            New here? Visit the <a href="{% url 'welcome-guide' %}">By the People Welcome Guide</a> for instructions and help getting started.
+            Or, <a href="{% url 'redirect-to-next-transcribable-topic-asset' 'suffrage-women-fight-for-the-vote' %}">jump right in</a> to a page that needs your help!
+            </p>
         </div>
     </div>
 </div>

--- a/concordia/templates/registration/password_reset_complete.html
+++ b/concordia/templates/registration/password_reset_complete.html
@@ -8,11 +8,7 @@
 <div class="container p-3">
     <div class="row">
         <div class="col-md-6 mx-auto">
-            <p>{% trans "Your password has been set.  You may go ahead and log in now." %}</p>
-
-            <p class="text-center">
-                <a class="btn btn-primary" href="{% url 'login' %}">{% trans 'Log in' %}</a>
-            </p>
+            <p>{% trans "Your password has been reset and you have been logged in. If your account was inactive, it has been activated." %}</p>
         </div>
     </div>
 </div>

--- a/concordia/tests/test_registration_views.py
+++ b/concordia/tests/test_registration_views.py
@@ -1,0 +1,27 @@
+"""
+Tests for user registration-related views
+"""
+from django.core import mail
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from .utils import CacheControlAssertions, CreateTestUsers, JSONAssertMixin
+
+
+@override_settings(RATELIMIT_ENABLE=False)
+class ConcordiaViewTests(
+    JSONAssertMixin, CacheControlAssertions, TestCase, CreateTestUsers
+):
+    def test_inactiveUserCanPasswordReset(self):
+        """
+        Test the ability to activate a user account based on password reset
+        """
+        self.user = self.create_inactive_user("tester")
+
+        self.client.post(reverse("password_reset"), {"email": self.user.email})
+
+        self.assertEqual(len(mail.outbox), 1)
+
+
+#    def test_userActivationViaEmailConfirmation(self):
+#        self.user = self.create_inactive_user("tester")

--- a/concordia/tests/test_registration_views.py
+++ b/concordia/tests/test_registration_views.py
@@ -37,10 +37,7 @@ class ConcordiaViewTests(
             {"username": self.user.username, "password": self.user.password},
         )
 
-        self.assertContains(
-            response,
-            "Please check your email and click the link to activate your account.",
-        )
+        self.assertContains(response, "This account has not yet been activated.")
 
         self.assertEqual(len(mail.outbox), 1)
 

--- a/concordia/tests/test_registration_views.py
+++ b/concordia/tests/test_registration_views.py
@@ -1,27 +1,82 @@
 """
 Tests for user registration-related views
 """
+import unittest
+from logging import getLogger
+from secrets import token_hex
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.tokens import default_token_generator
 from django.core import mail
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
 
 from .utils import CacheControlAssertions, CreateTestUsers, JSONAssertMixin
+
+User = get_user_model()
+
+
+logger = getLogger(__name__)
+
+
+INTERNAL_RESET_URL_TOKEN = "set-password"
+INTERNAL_RESET_SESSION_TOKEN = "_password_reset_token"
 
 
 @override_settings(RATELIMIT_ENABLE=False)
 class ConcordiaViewTests(
     JSONAssertMixin, CacheControlAssertions, TestCase, CreateTestUsers
 ):
-    def test_inactiveUserCanPasswordReset(self):
-        """
-        Test the ability to activate a user account based on password reset
-        """
+    def test_send_activation_email_on_inactive_login(self):
+        self.user = self.create_inactive_user("tester")
+
+        response = self.client.post(
+            reverse("registration_login"),
+            {"username": self.user.username, "password": self.user.password},
+        )
+
+        self.assertContains(
+            response,
+            "Please check your email and click the link to activate your account.",
+        )
+
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_inactive_user_can_password_reset(self):
         self.user = self.create_inactive_user("tester")
 
         self.client.post(reverse("password_reset"), {"email": self.user.email})
 
         self.assertEqual(len(mail.outbox), 1)
 
+    @unittest.skip
+    def test_password_reset_will_activate_user(self):
+        self.user = self.create_inactive_user("tester2")
+        fake_pw = token_hex(24)
+        new_password_data = {"new_password1": fake_pw, "new_password2": fake_pw}
+        password_reset_token = default_token_generator.make_token(self.user)
+        uidb64 = urlsafe_base64_encode(force_bytes(self.user.pk))
 
-#    def test_userActivationViaEmailConfirmation(self):
-#        self.user = self.create_inactive_user("tester")
+        session = self.client.session
+        session[INTERNAL_RESET_SESSION_TOKEN] = password_reset_token
+        session.save()
+
+        confirm_response = self.client.post(
+            reverse(
+                "password_reset_confirm",
+                kwargs={"uidb64": uidb64, "token": INTERNAL_RESET_URL_TOKEN},
+            ),
+            new_password_data,
+        )
+
+        self.assertEqual(confirm_response.status_code, 200)
+        self.assertTemplateUsed(
+            confirm_response, template_name="registration/password_reset_complete.html"
+        )
+        self.assertUncacheable(confirm_response)
+
+        # Verify the User was correctly activated
+        updated_user = User.objects.get(pk=self.user.pk)
+        self.assertEqual(updated_user.is_active, True)

--- a/concordia/tests/utils.py
+++ b/concordia/tests/utils.py
@@ -174,22 +174,31 @@ class CreateTestUsers(object):
 
         self.client.login(username=self.user.username, password=self.user.password)
 
-    def create_test_user(self, username, **kwargs):
-        """
-        Creates a test User account
-        """
-
+    def create_user(self, username, is_active=True, **kwargs):
         if "email" not in kwargs:
             kwargs["email"] = f"{username}@example.com"
 
         user = User.objects.create_user(username=username, **kwargs)
         fake_pw = token_hex(24)
+        user.is_active = is_active
         user.set_password(fake_pw)
         user.save()
 
         user.password = fake_pw
 
         return user
+
+    def create_test_user(self, username, **kwargs):
+        """
+        Creates an activated test User account
+        """
+        return self.create_user(username, is_active=True, **kwargs)
+
+    def create_inactive_user(self, username, **kwargs):
+        """
+        Creates an inactive test User account
+        """
+        return self.create_user(username, is_active=False, **kwargs)
 
 
 class CacheControlAssertions(object):

--- a/concordia/urls.py
+++ b/concordia/urls.py
@@ -150,6 +150,16 @@ urlpatterns = [
         "account/login/", views.ConcordiaLoginView.as_view(), name="registration_login"
     ),
     path("account/profile/", views.AccountProfileView.as_view(), name="user-profile"),
+    path(
+        "account/password_reset/",
+        views.ConcordiaPasswordResetRequestView.as_view(),
+        name="password_reset",
+    ),
+    path(
+        "account/reset/<uidb64>/<token>/",
+        views.ConcordiaPasswordResetConfirmView.as_view(),
+        name="password_reset_confirm",
+    ),
     path("account/", include("django_registration.backends.activation.urls")),
     path("account/", include("django.contrib.auth.urls")),
     path(

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -53,6 +53,7 @@ from concordia.forms import (
     ActivateAndSetPasswordForm,
     AllowInactivePasswordResetForm,
     ContactUsForm,
+    UserLoginForm,
     UserProfileForm,
     UserRegistrationForm,
 )
@@ -245,6 +246,7 @@ class ConcordiaLoginView(RatelimitMixin, LoginView):
     ratelimit_rate = "3/15m"
     ratelimit_method = "POST"
     ratelimit_block = False
+    form_class = UserLoginForm
 
     def post(self, request, *args, **kwargs):
         form = self.get_form()

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -18,7 +18,11 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.models import User
-from django.contrib.auth.views import LoginView
+from django.contrib.auth.views import (
+    LoginView,
+    PasswordResetConfirmView,
+    PasswordResetView,
+)
 from django.contrib.messages import get_messages
 from django.core.exceptions import ValidationError
 from django.core.mail import EmailMultiAlternatives, send_mail
@@ -45,7 +49,13 @@ from ratelimit.mixins import RatelimitMixin
 from ratelimit.utils import is_ratelimited
 
 from concordia.api_views import APIDetailView, APIListView
-from concordia.forms import ContactUsForm, UserProfileForm, UserRegistrationForm
+from concordia.forms import (
+    ActivateAndSetPasswordForm,
+    AllowInactivePasswordResetForm,
+    ContactUsForm,
+    UserProfileForm,
+    UserRegistrationForm,
+)
 from concordia.models import (
     Asset,
     AssetTranscriptionReservation,
@@ -196,6 +206,18 @@ def ajax_messages(request):
             ]
         }
     )
+
+
+class ConcordiaPasswordResetConfirmView(PasswordResetConfirmView):
+    # Automatically log a user in following a successful password reset
+    post_reset_login = True
+    form_class = ActivateAndSetPasswordForm
+
+
+class ConcordiaPasswordResetRequestView(PasswordResetView):
+    # Allow inactive users to reset their password and activate their account
+    # in one step
+    form_class = AllowInactivePasswordResetForm
 
 
 def registration_rate(self, group, request):


### PR DESCRIPTION
Will fix #662 and #607 when complete

- [x] Reset password function will activate account
- [ ] ~~If you register you automatically get another email after 48 hours if still inactive~~ decided to extend the period to 1 week instead of resend after 48 hours
- [x] After login with correct username and password and it is not activated - a message shows to say check email to activate
- [x] After successful password reset, user is automatically logged in
- [x] After successful account activation, user is automatically logged in
- [x] Send welcome email after successful user activation