### PR TITLE
Change page title on account activation failed template

### DIFF
--- a/concordia/templates/django_registration/activation_failed.html
+++ b/concordia/templates/django_registration/activation_failed.html
@@ -4,7 +4,7 @@
     <div class="container">
         <div class="row">
             <div class="col-md-8 mx-auto p-3">
-                <h2>Registration Failed</h2>
+                <h2>Account Activation</h2>
                 <p class="activation-error-{{ activation_error.code }}">
                     {{ activation_error.message }}
                 </p>


### PR DESCRIPTION
Closes #704 

In some cases, the reason for the "failure" is that the account is already activated. In which case, if the user is in the same browser session, the user may already be logged in.

This change makes the account activation failure template a little friendlier by not displaying "Registration Failed" at the top.