### PR TITLE
Minor tweaks related to account activation processes

### DIFF
--- a/concordia/forms.py
+++ b/concordia/forms.py
@@ -61,6 +61,14 @@ class UserRegistrationForm(RegistrationForm):
 
 class UserLoginForm(AuthenticationForm):
     def confirm_login_allowed(self, user):
+        inactive_message = (
+            "This account has not yet been activated. "
+            "An activation email has been sent to the email "
+            "address associated with this account. "
+            "Please check for this message and click the link "
+            "to finish your account registration."
+        )
+
         # If the user provided a correct username and password combination,
         # but has not yet confirmed their email,
         # resend the email activation request and display a custom message.
@@ -69,16 +77,7 @@ class UserLoginForm(AuthenticationForm):
             view = RegistrationView(request=self.request)
             view.send_activation_email(user)
 
-            raise forms.ValidationError(
-                (
-                    "This account has not yet been activated. ",
-                    "An activation email has been sent to the email "
-                    "address associated with this account. ",
-                    "Please check for this message and click the link "
-                    "to finish your account registration.",
-                ),
-                code="inactive",
-            )
+            raise forms.ValidationError(inactive_message, code="inactive")
 
 
 class UserProfileForm(forms.Form):

--- a/concordia/templates/django_registration/activation_email_body.txt
+++ b/concordia/templates/django_registration/activation_email_body.txt
@@ -3,7 +3,7 @@ Hi {{ user }},
 
 Thank you for becoming a Library of Congress virtual volunteer with By the People!
 
-To complete your activation, please verify your email address in the next {{ expiration_days |multiply:24 }} hours by clicking the link below:
+To complete your activation, please verify your email address in the next {{ expiration_days }} days by clicking the link below:
 
 https://{{ site }}{% url "django_registration_activate" activation_key %}
 


### PR DESCRIPTION
- Correct formatting of inactive account message on login with inactive valid credentials 
- Account confirmation / activation email uses days instead of hours as the unit