### PR TITLE
Releases with cleanly tagged versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ mss*
 config-optional-override.json
 env/
 concordia/settings_dev_*.py
+version.txt
 static-files


### PR DESCRIPTION
This change should allow jenkins to build releases that have a clean tagged version number instead of a dev0 version number.

e.g. a stage / prod release should report its own version as 0.5.13 rather than 0.5.14.dev0+g27086449.d20191113

The jenkins workspace is currently doing a setup.py build step which generates the correct version.txt file (with contents 0.5.13) but since that file is not tracked by git it dirties the workspace. So the django app reports itself as the next version up +dev0.

Ignoring the version.txt file in git should solve the problem.