### PR TITLE
Admin warning banner

### DIFF
--- a/concordia/admin_site.py
+++ b/concordia/admin_site.py
@@ -5,6 +5,7 @@ from django.urls import path
 class ConcordiaAdminSite(admin.AdminSite):
     site_header = "Concordia Admin"
     site_title = "Concordia"
+    login_template = "admin/auth/admin_login.html"
 
     def get_urls(self):
         from concordia.admin.views import admin_bulk_import_view, admin_site_report_view

--- a/concordia/templates/admin/auth/admin_login.html
+++ b/concordia/templates/admin/auth/admin_login.html
@@ -1,0 +1,13 @@
+{% extends "admin/login.html" %}
+
+{% block content %}
+        <p>This computer system is the property and/or operated on behalf of the Library of Congress
+        and may be accessed only by authorized users. Users may access and use the Library's computer
+        system only for official business and in accordance with Library regulations. Any usage of the
+        Library's computer system is subject to monitoring by the Library and inappropriate usage may
+        subject the user to loss or limitation of system access rights, adverse administrative action,
+        and criminal prosecution. By accessing and using the Library's computer system, users are
+        consenting to monitoring of their activities and communications on the system.</p>
+
+    {{ block.super }}
+{% endblock %}

--- a/concordia/templates/admin/index.html
+++ b/concordia/templates/admin/index.html
@@ -41,13 +41,6 @@
     <div class="module" id="version-module">
         <h2>Application Version</h2>
         <p><small>{{ APPLICATION_VERSION }}</small></p>
-        <p>This computer system is the property and/or operated on behalf of the Library of Congress
-        and may be accessed only by authorized users. Users may access and use the Library's computer
-        system only for official business and in accordance with Library regulations. Any usage of the
-        Library's computer system is subject to monitoring by the Library and inappropriate usage may
-        subject the user to loss or limitation of system access rights, adverse administrative action,
-        and criminal prosecution. By accessing and using the Library's computer system, users are
-        consenting to monitoring of their activities and communications on the system.</p>
     </div>
 </div>
 {% endblock sidebar%}

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -277,7 +277,7 @@ class ConcordiaLoginView(RatelimitMixin, LoginView):
 
         if user.is_staff:
             logger.info("Staff tried to log in using the regular form, redirecting")
-            return redirect("/admin/login")
+            return redirect(reverse("admin:login"))
         else:
             return super().form_valid(form)
 

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -272,7 +272,14 @@ class ConcordiaLoginView(RatelimitMixin, LoginView):
 
     def form_valid(self, form):
         self.request.session["captcha_validation_time"] = time()
-        return super().form_valid(form)
+
+        user = form.get_user()
+
+        if user.is_staff:
+            logger.info("Staff tried to log in using the regular form, redirecting")
+            return redirect("/admin/login")
+        else:
+            return super().form_valid(form)
 
 
 def ratelimit_view(request, exception=None):


### PR DESCRIPTION
- [x] Move warning banner from admin site dashbaord to admin login template
- [x] Only allow admin access through the admin login form, and not through the regular login form

Closes #1156 