### PR TITLE
Allow failures for travis CI syntax change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
     - '3.8'
     - '3.8-dev'
     - 'nightly'
-matrix:
+jobs:
     allow_failures:
         - python:
               - 3.8-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,11 @@ python:
     - 'nightly'
 jobs:
     allow_failures:
-        - python:
-              - 3.8-dev
-              - nightly
+        - language: python
+          python: 3.8-dev
+        - language: python
+          python: nightly
+
 services:
     - postgresql
     - redis-server


### PR DESCRIPTION
Travis CI changed its syntax on how to specify which jobs are allowed to fail.