### PR TITLE
adds feature flag to disable item description display

### DIFF
--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -351,6 +351,7 @@ FLAGS = {
     "SIMPLE_CONTENT_BLOCKS": [],
     "CAROUSEL_CMS": [],
     "SEND_WELCOME_EMAIL": [],
+    "DISPLAY_ITEM_DESCRIPTION": [],
 }
 
 ASGI_APPLICATION = "concordia.routing.application"

--- a/concordia/templates/transcriptions/item_detail.html
+++ b/concordia/templates/transcriptions/item_detail.html
@@ -3,6 +3,7 @@
 {% load humanize %}
 {% load staticfiles %}
 {% load concordia_media_tags %}
+{% load feature_flags %}
 
 {% block title %}
 {{ item.title }} ({{ campaign.title }}: {{ project.title }})
@@ -20,11 +21,15 @@
 {% endblock breadcrumbs%}
 
 {% block main_content %}
+{% flag_enabled 'DISPLAY_ITEM_DESCRIPTION' as DISPLAY_ITEM_DESCRIPTION %}
+
 <div class="container py-3">
     <div class="row">
         <div class="col-md-10">
             <h1 class="m-3">{{ item.title }}</h1>
-            <div class="m-3 hero-text">{{ item.description|safe }}</div>
+            {% if DISPLAY_ITEM_DESCRIPTION %}
+                <div class="m-3 hero-text">{{ item.description|safe }}</div>
+            {% endif %}
         </div>
         <div class="col-md-2 align-bottom">
             <div class="m-3">


### PR DESCRIPTION
Refs #1180 

I confirmed that we have no non-whitespace, non-empty descriptions in our current production database. This change introduces a new feature flag that, when enabled, will cause the item detail page not to display the description text. It applies globally, which should be fine since we currently only have blank descriptions in the database. If we decide later on that we have a campaign with item descriptions that we want to display, we'll have to make another change (if Spanish legal documents are still published) or disable the feature flag (if Spanish legal documents are done).

 