### PR TITLE
Tune channels config

### DIFF
--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -365,6 +365,10 @@ ASGI_APPLICATION = "concordia.routing.application"
 CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
-        "CONFIG": {"hosts": [(REDIS_ADDRESS, REDIS_PORT)]},
+        "CONFIG": {
+            "hosts": [(REDIS_ADDRESS, REDIS_PORT)],
+            "capacity": 1500,
+            "expiry": 10,
+        },
     }
 }


### PR DESCRIPTION
Configure channels with greater capacity than the default and shorter expiry than the default, so channels don't fill up