### PR TITLE
Exposing Campaign editor description field labels

### DIFF
--- a/concordia/static/admin/editor-preview.js
+++ b/concordia/static/admin/editor-preview.js
@@ -20,7 +20,7 @@
             .parents('.form-row')
             .first();
         $formRow.addClass('codemirror-with-preview');
-        $formRow.find('label').remove();
+        //$formRow.find('label').remove();
 
         var preview = $('<iframe>')
             // Firefox and, reportedly, Safari have a quirk where the <iframe> body

--- a/concordia/templates/fragments/codemirror.html
+++ b/concordia/templates/fragments/codemirror.html
@@ -20,14 +20,23 @@
     .form-row.codemirror-with-preview > div {
         display: flex;
         width: 100%;
+        flex-wrap: wrap;
     }
 
     .form-row.codemirror-with-preview > div > * {
         flex-basis: 50%;
         overflow-y: auto;
-
+        box-sizing: border-box;
         min-height: 500px;
     }
+
+    .form-row.codemirror-with-preview > div > label {
+        flex-basis: 100%;
+        min-height: 0;
+        font-weight: bold;
+        color: #333;
+    }
+
 </style>
 
 <template id="preview-head">{% spaceless %}


### PR DESCRIPTION
This request is for ticket #1266 