### PR TITLE
contact us link add 'optional'

### DIFF
--- a/concordia/forms.py
+++ b/concordia/forms.py
@@ -109,7 +109,7 @@ class ContactUsForm(forms.Form):
     subject = forms.CharField(label="Subject:", required=True)
 
     link = forms.URLField(
-        label="Have a specific page you need help with? Add the link below:",
+        label="Have a specific page you need help with? Add the link below (optional):",
         required=False,
     )
 


### PR DESCRIPTION
On Contact Us form - added  text '(optional)' to optional field "Have a specific page you need help with? Add the link below:".  This was an attempt to address confusion about which fields are required. 

Currently, required fields default on the form as bold text.