### PR TITLE
1264 filter in admin dashboard

### DIFF
--- a/concordia/admin/__init__.py
+++ b/concordia/admin/__init__.py
@@ -54,6 +54,71 @@ from .forms import (
 )
 
 
+class CampaignProjectListFilter(admin.SimpleListFilter):
+    """
+    This filter is an example of how to combine two different Filters to work together.
+    """
+
+    # Title displayed on the list filter URL
+    title = "ProjectRedux"
+    # Model field name:
+    parameter_name = "project"
+    # Custom attributes
+    related_filter_parameter = "project__campaign__id__exact"
+
+    def lookups(self, request, model_admin):
+        list_of_questions = []
+        queryset = Project.objects.order_by("campaign_id")
+        if self.related_filter_parameter in request.GET:
+            queryset = queryset.filter(
+                campaign_id=request.GET[self.related_filter_parameter]
+            )
+        for project in queryset:
+            list_of_questions.append((str(project.id), project.title))
+        return sorted(list_of_questions, key=lambda tp: tp[1])
+
+    def queryset(self, request, queryset):
+        # Compare the requested value to decide how to filter the queryset.
+        if self.value():
+            return queryset.filter(project_id=self.value())
+        return queryset
+
+
+class ItemProjectListFilter2(CampaignProjectListFilter):
+    parameter_name = "project__in"
+
+
+class ProjectItemListFilter(admin.SimpleListFilter):
+    #  modification of filter above but for asset through item
+    # Title displayed on the list filter URL
+    title = "ProjectRedux"
+    # Model field name:
+    parameter_name = "project"
+    # Custom attributes
+    related_filter_parameter = "item__project__campaign__id__exact"
+
+    def lookups(self, request, model_admin):
+        list_of_questions = []
+        queryset = Project.objects.order_by("campaign_id")
+        if self.related_filter_parameter in request.GET:
+            queryset = queryset.filter(
+                campaign_id=request.GET[self.related_filter_parameter]
+            )
+        for project in queryset:
+            list_of_questions.append((str(project.id), project.title))
+        return sorted(list_of_questions, key=lambda tp: tp[1])
+
+    def queryset(self, request, queryset):
+        # Compare the requested value to decide how to filter the queryset.
+        if self.value():
+            return queryset.filter(item__project_id=self.value())
+        return queryset
+
+
+class AssetProjectListFilter2(ProjectItemListFilter):
+    parameter_name = "item__project__in"
+
+
 class ProjectListFilter(MultipleChoiceListFilter):
     title = "Project"
 
@@ -307,7 +372,8 @@ class ItemAdmin(admin.ModelAdmin):
         "published",
         "project__topics",
         "project__campaign",
-        ItemProjectListFilter,
+        ItemProjectListFilter2,
+        # ItemProjectListFilter,
     )
 
     actions = (publish_item_action, unpublish_item_action)
@@ -394,7 +460,8 @@ class AssetAdmin(admin.ModelAdmin, CustomListDisplayFieldsMixin):
         "published",
         "item__project__topics",
         "item__project__campaign",
-        AssetProjectListFilter,
+        AssetProjectListFilter2,
+        # AssetProjectListFilter,
         "media_type",
     )
 

--- a/concordia/admin/__init__.py
+++ b/concordia/admin/__init__.py
@@ -315,7 +315,6 @@ class ItemAdmin(admin.ModelAdmin):
         "project__topics",
         "project__campaign",
         ItemProjectListFilter2,
-        # ItemProjectListFilter,
     )
 
     actions = (publish_item_action, unpublish_item_action)
@@ -403,7 +402,6 @@ class AssetAdmin(admin.ModelAdmin, CustomListDisplayFieldsMixin):
         "item__project__topics",
         "item__project__campaign",
         AssetProjectListFilter2,
-        # AssetProjectListFilter,
         "media_type",
     )
 
@@ -499,7 +497,6 @@ class TranscriptionAdmin(admin.ModelAdmin):
         AcceptedFilter,
         RejectedFilter,
         "asset__item__project__campaign",
-        # "asset__item__project",
         TranscriptionProjectListFilter,
     )
 

--- a/concordia/admin/__init__.py
+++ b/concordia/admin/__init__.py
@@ -46,77 +46,19 @@ from .actions import (
     unpublish_action,
     unpublish_item_action,
 )
-from .filters import AcceptedFilter, RejectedFilter, SubmittedFilter
+from .filters import (
+    AcceptedFilter,
+    AssetProjectListFilter2,
+    ItemProjectListFilter2,
+    RejectedFilter,
+    SubmittedFilter,
+    TranscriptionProjectListFilter,
+)
 from .forms import (
     AdminItemImportForm,
     BleachedDescriptionAdminForm,
     SimpleContentBlockAdminForm,
 )
-
-
-class CampaignProjectListFilter(admin.SimpleListFilter):
-    """
-    This filter is an example of how to combine two different Filters to work together.
-    """
-
-    # Title displayed on the list filter URL
-    title = "ProjectRedux"
-    # Model field name:
-    parameter_name = "project"
-    # Custom attributes
-    related_filter_parameter = "project__campaign__id__exact"
-
-    def lookups(self, request, model_admin):
-        list_of_questions = []
-        queryset = Project.objects.order_by("campaign_id")
-        if self.related_filter_parameter in request.GET:
-            queryset = queryset.filter(
-                campaign_id=request.GET[self.related_filter_parameter]
-            )
-        for project in queryset:
-            list_of_questions.append((str(project.id), project.title))
-        return sorted(list_of_questions, key=lambda tp: tp[1])
-
-    def queryset(self, request, queryset):
-        # Compare the requested value to decide how to filter the queryset.
-        if self.value():
-            return queryset.filter(project_id=self.value())
-        return queryset
-
-
-class ItemProjectListFilter2(CampaignProjectListFilter):
-    parameter_name = "project__in"
-
-
-class ProjectItemListFilter(admin.SimpleListFilter):
-    #  modification of filter above but for asset through item
-    # Title displayed on the list filter URL
-    title = "ProjectRedux"
-    # Model field name:
-    parameter_name = "project"
-    # Custom attributes
-    related_filter_parameter = "item__project__campaign__id__exact"
-
-    def lookups(self, request, model_admin):
-        list_of_questions = []
-        queryset = Project.objects.order_by("campaign_id")
-        if self.related_filter_parameter in request.GET:
-            queryset = queryset.filter(
-                campaign_id=request.GET[self.related_filter_parameter]
-            )
-        for project in queryset:
-            list_of_questions.append((str(project.id), project.title))
-        return sorted(list_of_questions, key=lambda tp: tp[1])
-
-    def queryset(self, request, queryset):
-        # Compare the requested value to decide how to filter the queryset.
-        if self.value():
-            return queryset.filter(item__project_id=self.value())
-        return queryset
-
-
-class AssetProjectListFilter2(ProjectItemListFilter):
-    parameter_name = "item__project__in"
 
 
 class ProjectListFilter(MultipleChoiceListFilter):
@@ -557,7 +499,8 @@ class TranscriptionAdmin(admin.ModelAdmin):
         AcceptedFilter,
         RejectedFilter,
         "asset__item__project__campaign",
-        "asset__item__project",
+        # "asset__item__project",
+        TranscriptionProjectListFilter,
     )
 
     search_fields = ["text", "user__username", "user__email"]

--- a/concordia/admin/filters.py
+++ b/concordia/admin/filters.py
@@ -72,11 +72,11 @@ class CampaignProjectListFilter(admin.SimpleListFilter):
         return sorted(list_of_questions, key=lambda tp: tp[1])
 
     def queryset(self, request, queryset):
-        # fkey_field = self.project_ref
+        fkey_field = self.project_ref
         if self.value():
             # return queryset.filter(project_id=self.value())
-            return queryset.filter(project_ref=self.value())
-            # return queryset.filter(fkey_field=self.value())
+            # return queryset.filter(project_ref=self.value())
+            return queryset.filter(**{fkey_field: self.value()})
         return queryset
 
 

--- a/concordia/admin/filters.py
+++ b/concordia/admin/filters.py
@@ -74,8 +74,6 @@ class CampaignProjectListFilter(admin.SimpleListFilter):
     def queryset(self, request, queryset):
         fkey_field = self.project_ref
         if self.value():
-            # return queryset.filter(project_id=self.value())
-            # return queryset.filter(project_ref=self.value())
             return queryset.filter(**{fkey_field: self.value()})
         return queryset
 


### PR DESCRIPTION
as mentioned in slack:
Good morning Chris - I'm stuck on change to Concordia I have 3 working admin customized SimpleListFilter classes that reduce the number of projects based on chosen champaign and project for item, asset, and transcription.  I'm trying to create a base class and just pass values to it based on the object (item, asset, or transcription).  The sticking point specifically is getting the base class queryset.filter to interpret the passed in foreign key field. I could not get **kwargs to work.  So the filter breaks when filtering on project (vs. campaign)
I'm working in the admin/filters.py for the base class -- had the 3 individuals filters working set up originally in  ..init...py
here's the base class - as it currently is
