### PR TITLE
Rename Navbar Help to How-To

### DIFF
--- a/concordia/templates/base.html
+++ b/concordia/templates/base.html
@@ -63,7 +63,7 @@
                             <a class="nav-link" href="https://historyhub.history.gov/community/crowd-loc">Discuss</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link {% if PATH_LEVEL_1 == 'help-center' %}active{% endif %}" href="{% url 'help-center' %}">Help</a>
+                            <a class="nav-link {% if PATH_LEVEL_1 == 'help-center' %}active{% endif %}" href="{% url 'help-center' %}">How-To</a>
                         </li>
                         <li id="topnav-account-dropdown" class="nav-item dropdown nav-dropdown authenticated-only" hidden>
                             <a id="topnav-account-dropdown-toggle" class="nav-link dropdown-toggle {% if PATH_LEVEL_1 == 'account'%}active{% endif %}" href="{% url 'user-profile' %}" rel="nofollow" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Account</a>


### PR DESCRIPTION
#1341 Rename Navbar Help to How-To

![image](https://user-images.githubusercontent.com/72825410/109867113-1fe24c00-7c34-11eb-9d99-60045188f307.png)
