### PR TITLE
1303 Updated styling of all detail pages

### DIFF
--- a/concordia/static/scss/base.scss
+++ b/concordia/static/scss/base.scss
@@ -8,6 +8,7 @@ $orange: #fc4c02;
 $dark: #000;
 $accent: $orange;
 
+$gray-100: #f6f6f6;
 $gray-200: #efefef;
 $light: $gray-200;
 
@@ -484,32 +485,26 @@ ul.nav-secondary {
  * List-like displays for items and assets
  */
 
-.card-deck .card.concordia-object-card {
-    position: relative;
-    flex-grow: 0;
-    flex-basis: 200px;
+ .concordia-object-card-row {
+     margin: 0 -6px;
+ }
 
-    width: 200px;
-    min-height: 300px;
+ .concordia-object-card-col {
+     padding: 6px;
+     @include media-breakpoint-up(xl) {
+         flex: 0 0 20%;
+         max-width: 20%;
+     }
+ }
 
-    margin: 0.25rem;
+ .concordia-object-card {
+     background-color: $gray-100;
+     overflow: hidden;
+ }
 
-    justify-content: start;
-    align-items: center;
-
-    background-color: var(--bg-lightest-gray);
-}
-
-.card-deck .card.concordia-object-card > * {
-    /* This is only necessary for IE11 */
-    max-width: 100%;
-}
-
-@media screen and (max-width: 576px) {
-    .card-deck .card.concordia-object-card {
-        flex-basis: auto;
-    }
-}
+ .concordia-object-card-title {
+     padding: 12px 10px;
+ }
 
 .concordia-object-card .card-title,
 .concordia-object-card .card-actions {
@@ -518,8 +513,16 @@ ul.nav-secondary {
     right: 0;
 }
 
-.concordia-object-card[data-transcription-status='completed']:not(:hover) {
+.concordia-object-card[data-transcription-status='completed']:not(:hover) .card-img {
     opacity: 0.5;
+}
+
+.concordia-object-card .card-img {
+	transition: .3s ease-in-out;
+}
+.concordia-object-card:hover .card-img,
+.concordia-object-card:focus .card-img {
+	transform: scale(1.05);
 }
 
 .concordia-object-card .card-title {
@@ -533,6 +536,12 @@ ul.nav-secondary {
 
 .concordia-object-card .card-actions {
     top: 0;
+}
+
+.concordia-object-card .card-actions .btn,
+.concordia-object-card .card-img {
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
 }
 
 .concordia-object-card .card-actions .btn-default:not(:hover) {
@@ -550,6 +559,8 @@ ul.nav-secondary {
 .card.concordia-object-card .progress {
     height: 1em;
     border-radius: 0;
+    position: relative;
+    z-index: 2;
 }
 
 /*

--- a/concordia/templates/fragments/transcription-progress-row.html
+++ b/concordia/templates/fragments/transcription-progress-row.html
@@ -1,10 +1,10 @@
 {% load concordia_filtering_tags %}
 
-<div class="row mb-2 p-3 flex-column-reverse flex-xl-row justify-content-center align-items-center">
-    <div class="col-12 col-xl-6 text-center">
+<div class="row my-2 py-3 flex-column-reverse flex-xl-row justify-content-center align-items-center">
+    <div class="col-12 col-lg-auto text-center">
         {% transcription_status_filters transcription_status_counts request.GET.transcription_status %}
     </div>
-    <div class="col-12 col-xl-6">
+    <div class="col-12 col-lg">
         {% include "fragments/transcription-progress-bar.html" %}
     </div>
 </div>

--- a/concordia/templates/transcriptions/campaign_detail.html
+++ b/concordia/templates/transcriptions/campaign_detail.html
@@ -26,44 +26,53 @@
         </div>
         <div class="col-md-3">
             {% if campaign.resource_set.all|length %}
-                <div class="related-links mb-3 p-1 p-sm-2 p-lg-3">
-                    <h4>Related Links</h4>
-                    <div class="list-group">
+                <aside class="mb-3 mt-4 mt-md-0 p-3 bg-light border">
+                    <h4 class="mb-3">Related Links</h4>
+                    <ul class="list-unstyled m-0">
                         {% for resource in campaign.resource_set.all %}
                         {% if 'loc.gov' in resource.resource_url   %}
-                            <a class="list-group-item" href="{{ resource.resource_url }}" target="_blank">{{ resource.title }}</a>
+                            <li class="mb-3"><a href="{{ resource.resource_url }}" target="_blank">{{ resource.title }}</a></li>
                         {%else%}
-                            <a class="list-group-item" href="{{ resource.resource_url }}" target="_blank">{{ resource.title }} <i class="fa fa-external-link-alt"></i></a>
+                            <li class="mb-3"><a href="{{ resource.resource_url }}" target="_blank">{{ resource.title }} <i class="fa fa-external-link-alt"></i></a></li>
                         {% endif %}
                         {% endfor %}
-                    </div>
-                </div>
+                    </ul>
+                </aside>
             {% endif %}
         </div>
     </div>
     {% include "fragments/transcription-progress-row.html" %}
-    <div class="row">
-        <div class="card-deck w-100 flex-column flex-sm-row justify-content-center align-items-center align-items-sm-stretch">
-            {% for project in projects %}
-                <div class="col-12 col-md-4 col-lg-3 m-2 p-1 concordia-object-card card bg-lightest-gray shadow-regular align-items-center" data-transcription-status="{{ project.lowest_transcription_status }}">
+    <div class="row concordia-object-card-row">
+        {% for project in projects %}
+            <div class="col-6 col-md-4 col-lg-3 concordia-object-card-col">
+                <div class="h-100 concordia-object-card card border" data-transcription-status="{{ project.lowest_transcription_status }}">
                     {% url 'transcriptions:project-detail' campaign.slug project.slug as project_url %}
 
                     <a href="{{ project_url }}?{{ sublevel_querystring }}" aria-hidden="true">
                         <img class="card-img card-img-campaign" src="{{ MEDIA_URL }}{{ project.thumbnail_image }}" alt="{{ project.title }}">
                     </a>
 
-                    <div class="progress w-100 my-2">
+                    <div class="progress w-100">
                         <div title="Completed" class="progress-bar bg-completed" role="progressbar" style="width: {{ project.completed_percent }}%" aria-valuenow="{{ project.completed_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
                         <div title="Needs Review" class="progress-bar bg-submitted" role="progressbar" style="width: {{ project.submitted_percent }}%" aria-valuenow="{{ project.submitted_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
                         <div title="In Progress" class="progress-bar bg-in_progress" role="progressbar" style="width: {{ project.in_progress_percent }}%" aria-valuenow="{{ project.in_progress_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
                     </div>
 
-                    <h6 class="text-center primary-text">
+                    <h6 class="text-center primary-text m-0 concordia-object-card-title">
                         <a href="{{ project_url }}?{{ sublevel_querystring }}">{{ project.title }}</a>
                     </h6>
+
+                    {% if project.lowest_transcription_status == 'completed' %}
+                    <div class="card-actions">
+                        <a class="btn btn-sm btn-block btn-default" href="{{ project_url }}?{{ sublevel_querystring }}">
+                            <span class="fas fa-check tx-completed"></span>
+                            Complete
+                        </a>
+                    </div>
+                    {% endif %}
                 </div>
-            {% endfor %}
-        </div>
+            </div>
+        {% endfor %}
     </div>
 </div>
 {% endblock main_content %}

--- a/concordia/templates/transcriptions/item_detail.html
+++ b/concordia/templates/transcriptions/item_detail.html
@@ -31,40 +31,41 @@
             </div>
             <div class="col-md-2 align-bottom">
                 <div>
-                    <a href="{{ item.item_url }}" class="btn btn-default" title="View the original source for this item in a new tab" target="_blank">View this item on www.loc.gov<i class="fa fa-external-link-alt"></i></a>
+                    <a href="{{ item.item_url }}" class="btn btn-light" title="View the original source for this item in a new tab" target="_blank">View this item on www.loc.gov<i class="fa fa-external-link-alt"></i></a>
                 </div>
             </div>
         </div>
         {% include "fragments/transcription-progress-row.html" %}
-        <div class="card-deck justify-content-center align-items-center align-items-sm-stretch">
+        <div class="row concordia-object-card-row">
             {% for a in assets %}
                 {% url 'transcriptions:asset-detail' a.item.project.campaign.slug a.item.project.slug a.item.item_id a.slug as asset_detail_url %}
-
-                <div class="card concordia-object-card" data-transcription-status="{{ a.transcription_status }}">
-                    <a class="card-img-container" href="{{ asset_detail_url }}">
-                        <img class="card-img" alt="{{ a.slug }}" src="{% asset_media_url a %}" />
-                    </a>
-                    <a class="card-title" href="{{ asset_detail_url }}">
-                        #{{ a.sequence }}
-                    </a>
-                    <div class="card-actions">
-                        <a class="btn btn-sm btn-block btn-default" href="{{ asset_detail_url }}">
-                            {% if a.transcription_status == 'submitted' %}
-                                <span class="fas fa-list tx-submitted"></span>
-                                Review
-                            {% elif a.transcription_status == 'completed' %}
-                                <span class="fas fa-check tx-completed"></span>
-                                Complete
-                            {% else %}
-                                <span class="fas fa-edit tx-edit"></span>
-                                Transcribe
-                            {% endif %}
+                <div class="col-6 col-md-4 col-lg-3 concordia-object-card-col">
+                    <div class="h-100 card concordia-object-card border" data-transcription-status="{{ a.transcription_status }}">
+                        <a class="card-img-container" href="{{ asset_detail_url }}">
+                            <img class="card-img" alt="{{ a.slug }}" src="{% asset_media_url a %}" />
                         </a>
+                        <a class="card-title text-center" href="{{ asset_detail_url }}">
+                            #{{ a.sequence }}
+                        </a>
+                        <div class="card-actions">
+                            <a class="btn btn-sm btn-block {% if a.transcription_status != 'completed' %}btn-primary{% else %}btn-default{% endif %}" href="{{ asset_detail_url }}">
+                                {% if a.transcription_status == 'submitted' %}
+                                    <span class="fas fa-list tx-submitted"></span>
+                                    Review
+                                {% elif a.transcription_status == 'completed' %}
+                                    <span class="fas fa-check tx-completed"></span>
+                                    Complete
+                                {% else %}
+                                    <span class="fas fa-edit tx-edit"></span>
+                                    Transcribe
+                                {% endif %}
+                            </a>
+                        </div>
                     </div>
                 </div>
             {% endfor %}
         </div>
-        <div class="row">
+        <div class="row mt-4">
             {% include "fragments/standard-pagination.html" %}
         </div>
     </div>

--- a/concordia/templates/transcriptions/project_detail.html
+++ b/concordia/templates/transcriptions/project_detail.html
@@ -29,30 +29,39 @@
             </div>
         </div>
         {% include "fragments/transcription-progress-row.html" %}
-        <div class="row">
-            <div class="card-deck w-100 flex-column flex-sm-row justify-content-center align-items-center align-items-sm-stretch">
-                {% for item in items %}
-                    <div class="col-12 col-md-4 col-lg-3 m-2 p-1 concordia-object-card card bg-lightest-gray shadow-regular align-items-center" data-transcription-status="{{ item.lowest_transcription_status }}">
+        <div class="row concordia-object-card-row">
+            {% for item in items %}
+                <div class="col-6 col-md-4 col-lg-3 concordia-object-card-col">
+                    <div class="h-100 concordia-object-card card border" data-transcription-status="{{ item.lowest_transcription_status }}">
                         <a href="{% url 'transcriptions:item-detail' campaign.slug project.slug item.item_id %}?{{ sublevel_querystring }}">
                             <img class="card-img card-img-campaign" alt="{{ item.title }}" src="{{ item.thumbnail_url }}" />
                         </a>
 
-                        <div class="progress w-100 my-2">
+                        <div class="progress w-100">
                             <div title="Completed" class="progress-bar bg-completed" role="progressbar" style="width: {{ item.completed_percent }}%" aria-valuenow="{{ item.completed_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
                             <div title="Needs Review" class="progress-bar bg-submitted" role="progressbar" style="width: {{ item.submitted_percent }}%" aria-valuenow="{{ item.submitted_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
                             <div title="In Progress" class="progress-bar bg-in_progress" role="progressbar" style="width: {{ item.in_progress_percent }}%" aria-valuenow="{{ item.in_progress_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
                         </div>
 
-                        <h6 class="text-center primary-text">
+                        <h6 class="text-center primary-text m-0 concordia-object-card-title">
                             <a href="{% url 'transcriptions:item-detail' campaign.slug project.slug item.item_id %}?{{ sublevel_querystring }}" class="campaign-image-link">
                                 {{ item.title }}
                             </a>
                         </h6>
+
+                        {% if item.lowest_transcription_status == 'completed' %}
+                        <div class="card-actions">
+                            <a class="btn btn-sm btn-block btn-default" href="{% url 'transcriptions:item-detail' campaign.slug project.slug item.item_id %}?{{ sublevel_querystring }}">
+                                <span class="fas fa-check tx-completed"></span>
+                                Complete
+                            </a>
+                        </div>
+                        {% endif %}
                     </div>
-                {% endfor %}
-            </div>
+                </div>
+            {% endfor %}
         </div>
-        <div class="row">
+        <div class="row mt-4">
             {% include "fragments/standard-pagination.html" %}
         </div>
     </div>

--- a/concordia/templates/transcriptions/topic_detail.html
+++ b/concordia/templates/transcriptions/topic_detail.html
@@ -26,44 +26,53 @@
         </div>
         <div class="col-md-3">
             {% if topic.resource_set.all|length %}
-                <div class="related-links mb-3 p-1 p-sm-2 p-lg-3">
-                    <h4>Related Links</h4>
-                    <div class="list-group">
+                <aside class="mb-3 mt-4 mt-md-0 p-3 bg-light border">
+                    <h4 class="mb-3">Related Links</h4>
+                    <ul class="list-unstyled m-0">
                         {% for resource in topic.resource_set.all %}
                             {% if 'loc.gov' in resource.resource_url   %}
-                        <a class="list-group-item" href="{{ resource.resource_url }}" target="_blank">{{ resource.title }}</a>
+                        <li class="mb-3"><a href="{{ resource.resource_url }}" target="_blank">{{ resource.title }}</a></li>
                         {% else %}
-                        <a class="list-group-item" href="{{ resource.resource_url }}" target="_blank">{{ resource.title }} <i class="fa fa-external-link-alt"></i></a>
+                        <li class="mb-3"><a href="{{ resource.resource_url }}" target="_blank">{{ resource.title }} <i class="fa fa-external-link-alt"></i></a></li>
                         {% endif %}
                             {% endfor %}
-                    </div>
-                </div>
+                    </ul>
+                </aside>
             {% endif %}
         </div>
     </div>
     {% include "fragments/transcription-progress-row.html" %}
-    <div class="row">
-        <div class="card-deck w-100 flex-column flex-sm-row justify-content-center align-items-center align-items-sm-stretch">
-            {% for project in projects %}
-                <div class="col-12 col-md-4 col-lg-3 m-2 p-1 concordia-object-card card bg-lightest-gray shadow-regular align-items-center" data-transcription-status="{{ project.lowest_transcription_status }}">
-                    {% url 'transcriptions:project-detail' project.campaign.slug project.slug as project_url %}
+    <div class="row concordia-object-card-row">
+        {% for project in projects %}
+        <div class="col-6 col-md-4 col-lg-3 concordia-object-card-col">
+            <div class="h-100 concordia-object-card card border" data-transcription-status="{{ project.lowest_transcription_status }}">
+                {% url 'transcriptions:project-detail' project.campaign.slug project.slug as project_url %}
 
-                    <a href="{{ project_url }}?{{ sublevel_querystring }}" aria-hidden="true">
-                        <img class="card-img card-img-campaign" src="{{ MEDIA_URL }}{{ project.thumbnail_image }}" alt="{{ project.title }}">
-                    </a>
+                <a href="{{ project_url }}?{{ sublevel_querystring }}" aria-hidden="true">
+                    <img class="card-img card-img-campaign" src="{{ MEDIA_URL }}{{ project.thumbnail_image }}" alt="{{ project.title }}">
+                </a>
 
-                    <div class="progress w-100 my-2">
-                        <div title="Completed" class="progress-bar bg-completed" role="progressbar" style="width: {{ project.completed_percent }}%" aria-valuenow="{{ project.completed_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
-                        <div title="Needs Review" class="progress-bar bg-submitted" role="progressbar" style="width: {{ project.submitted_percent }}%" aria-valuenow="{{ project.submitted_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
-                        <div title="In Progress" class="progress-bar bg-in_progress" role="progressbar" style="width: {{ project.in_progress_percent }}%" aria-valuenow="{{ project.in_progress_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
-                    </div>
-
-                    <h6 class="text-center primary-text">
-                        <a href="{{ project_url }}?{{ sublevel_querystring }}">{{ project.campaign.title }} - {{ project.title }}</a>
-                    </h6>
+                <div class="progress w-100">
+                    <div title="Completed" class="progress-bar bg-completed" role="progressbar" style="width: {{ project.completed_percent }}%" aria-valuenow="{{ project.completed_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
+                    <div title="Needs Review" class="progress-bar bg-submitted" role="progressbar" style="width: {{ project.submitted_percent }}%" aria-valuenow="{{ project.submitted_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
+                    <div title="In Progress" class="progress-bar bg-in_progress" role="progressbar" style="width: {{ project.in_progress_percent }}%" aria-valuenow="{{ project.in_progress_percent }}" aria-valuemin="0" aria-valuemax="100"></div>
                 </div>
-            {% endfor %}
+
+                <h6 class="text-center primary-text m-0 concordia-object-card-title">
+                    <a href="{{ project_url }}?{{ sublevel_querystring }}">{{ project.campaign.title }} - {{ project.title }}</a>
+                </h6>
+
+                {% if project.lowest_transcription_status == 'completed' %}
+                <div class="card-actions">
+                    <a class="btn btn-sm btn-block btn-default" href="{{ project_url }}?{{ sublevel_querystring }}">
+                        <span class="fas fa-check tx-completed"></span>
+                        Complete
+                    </a>
+                </div>
+                {% endif %}
+            </div>
         </div>
+        {% endfor %}
     </div>
 </div>
 {% endblock main_content %}


### PR DESCRIPTION
- Updated all detail pages as described in the ticket
- Removed drop-shadow from cards to make it consistent with item-detail cards and in line with P1 styling
- Updated styling of 'Related links' box and 'View this item on www.loc.gov' button to meet contrast compliance
- Fixed overall spacings of the page, so that all elements/layouts on the page take advantage of the available width 
- Improved responsive design of the gallery
- Added 'zoom in' hover effect (thought it was strange for only 'completed' ones have a hover effect)
- Added spacing between gallery and pagination