### PR TITLE
1406 Fixed a css validation error

### DIFF
--- a/concordia/static/scss/base.scss
+++ b/concordia/static/scss/base.scss
@@ -254,7 +254,7 @@ ul.nav-secondary {
 }
 
 .border-login-register {
-    border-left: solid 0.0675 $dark;
+    border-left: solid 0.0675rem $dark;
 }
 
 .border-left-home-contribute {


### PR DESCRIPTION
@acdha: Border width value error is fixed. However I'm not sure if this, "At-rule `@page` should contain a prelude", is an error. And also "-webkit-match-parent" value error is newly added by Bootstrap to "Fix alignment for Safari", and probably not harmful. Do we just ignore both errors? or is there a way for csstree-validator to ignore these?