### PR TITLE
test time_out on task populate es idices

### DIFF
--- a/concordia/tasks.py
+++ b/concordia/tasks.py
@@ -391,7 +391,7 @@ def create_elasticsearch_indices():
     call_command("search_index", action="create")
 
 
-@celery_app.task
+@celery_app.task(time_limt=20)
 def populate_elasticsearch_indices():
     call_command("search_index", action="populate")
 


### PR DESCRIPTION
Change to test possible solution to read timeout in importer log during nightly es indices population task. Found during testing for #1412 but seems related to differences in database performance post upgrade from postgresql 9.6 to 12 (#1328).