### PR TITLE
1478 update dump restore containers

### DIFF
--- a/cloudformation/infrastructure/bastion-hosts.yaml
+++ b/cloudformation/infrastructure/bastion-hosts.yaml
@@ -89,7 +89,7 @@ Resources:
                     yum -y update
                     yum -y install git
                     aws s3 cp s3://crowd-deployment/database-dumps/concordia.latest.dmp concordia.dmp
-                    amazon-linux-extras install -y postgresql9.6
+                    amazon-linux-extras install -y postgresql12
 
             Tags:
                 - Key: Name
@@ -133,7 +133,7 @@ Resources:
                     yum -y update
                     yum -y install git
                     aws s3 cp s3://crowd-deployment/database-dumps/concordia.latest.dmp concordia.dmp
-                    amazon-linux-extras install -y postgresql9.6
+                    amazon-linux-extras install -y postgresql12
 
             Tags:
                 - Key: Name

--- a/cloudformation/infrastructure/data-load.yaml
+++ b/cloudformation/infrastructure/data-load.yaml
@@ -83,7 +83,7 @@ Resources:
                     echo "export ENV_NAME=${EnvironmentName}" >> /home/ec2-user/.bash_profile
                     source /home/ec2-user/.bash_profile
                     yum -y update
-                    amazon-linux-extras install -y postgresql9.6
+                    amazon-linux-extras install -y postgresql12
                     aws s3 cp s3://crowd-deployment/database-dumps/concordia.latest.dmp concordia.dmp
                     echo "${PostgresqlHost}:5432:*:concordia:${PostgresqlPassword}" >> /root/.pgpass
                     chmod 0600 /root/.pgpass

--- a/cloudformation/infrastructure/elasticsearch.yaml
+++ b/cloudformation/infrastructure/elasticsearch.yaml
@@ -28,7 +28,7 @@ Resources:
                 InstanceCount: 1
                 ZoneAwarenessEnabled: false
                 InstanceType: 'm4.xlarge.elasticsearch'
-            ElasticsearchVersion: '6.7'
+            ElasticsearchVersion: '6.8'
             EBSOptions:
                 EBSEnabled: true
                 Iops: 0

--- a/cloudformation/infrastructure/jenkins-server.yaml
+++ b/cloudformation/infrastructure/jenkins-server.yaml
@@ -43,7 +43,7 @@ Resources:
                       openjdk-8-jdk jenkins \
                       nginx awscli
                     usermod -aG docker jenkins
-                    snap install postgresql96
+                    snap install postgresql12
                     pip3 install awscli --upgrade
             Tags:
                 - Key: Name

--- a/cloudformation/infrastructure/rds.yaml
+++ b/cloudformation/infrastructure/rds.yaml
@@ -49,7 +49,7 @@ Resources:
             PreferredMaintenanceWindow: sun:07:14-sun:07:44
             DBName: concordia
             Engine: postgres
-            EngineVersion: 9.6.6
+            EngineVersion: '12.5'
             LicenseModel: postgresql-license
             DBSubnetGroupName:
                 Ref: PostgresSubnetGroup

--- a/db_scripts/dump/Dockerfile
+++ b/db_scripts/dump/Dockerfile
@@ -1,14 +1,5 @@
 FROM git.loc.gov:4567/devops/docker-hub-mirror/amazonlinux:2
-SHELL ["bin/bash", "-c"]
-RUN echo $' \n\
-[pgdg12] \n\
-name=PostgreSQL 12 for RHEL/CentOS 7 - x86_64 \n\
-baseurl=https://download.postgresql.org/pub/repos/yum/12/redhat/rhel-7-x86_64 \n\
-enabled=1 \n\
-gpgcheck=0' >> /etc/yum.repos.d/pgdg.repo
-
-RUN yum makecache && yum -y install postgresql12 \
-    && yum update -y \
+RUN yum update -y && amazon-linux-extras install -y postgresql12 \
     && yum -y install unzip \
     && curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
     && unzip awscliv2.zip \

--- a/db_scripts/dump/push-container.sh
+++ b/db_scripts/dump/push-container.sh
@@ -2,6 +2,6 @@
 
 export AWS_PROFILE=AWSCrowdlocgov
 aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 619333082511.dkr.ecr.us-east-1.amazonaws.com
-docker build --no-cache -t crowd-db-dump .
+docker build --no-cache --pull -t crowd-db-dump .
 docker tag crowd-db-dump:latest 619333082511.dkr.ecr.us-east-1.amazonaws.com/crowd-db-dump:latest
 docker push 619333082511.dkr.ecr.us-east-1.amazonaws.com/crowd-db-dump:latest

--- a/db_scripts/restore/Dockerfile
+++ b/db_scripts/restore/Dockerfile
@@ -1,5 +1,5 @@
 FROM git.loc.gov:4567/devops/docker-hub-mirror/amazonlinux:2
-RUN yum update -y && amazon-linux-extras install -y postgres12 \
+RUN yum update -y && amazon-linux-extras install -y postgresql12 \
     && yum -y install unzip \
     && curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
     && unzip awscliv2.zip \

--- a/db_scripts/restore/Dockerfile
+++ b/db_scripts/restore/Dockerfile
@@ -1,14 +1,5 @@
 FROM git.loc.gov:4567/devops/docker-hub-mirror/amazonlinux:2
-SHELL ["bin/bash", "-c"]
-RUN echo $' \n\
-[pgdg12] \n\
-name=PostgreSQL 12 for RHEL/CentOS 7 - x86_64 \n\
-baseurl=https://download.postgresql.org/pub/repos/yum/12/redhat/rhel-7-x86_64 \n\
-enabled=1 \n\
-gpgcheck=0' >> /etc/yum.repos.d/pgdg.repo
-
-RUN yum makecache && yum -y install postgresql12 \
-    && yum update -y \
+RUN yum update -y && amazon-linux-extras install -y postgres12 \
     && yum -y install unzip \
     && curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
     && unzip awscliv2.zip \

--- a/db_scripts/restore/push-container.sh
+++ b/db_scripts/restore/push-container.sh
@@ -2,6 +2,6 @@
 
 export AWS_PROFILE=AWSCrowdlocgov
 aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 619333082511.dkr.ecr.us-east-1.amazonaws.com
-docker build --no-cache -t crowd-db-restore .
+docker build --no-cache --pull -t crowd-db-restore .
 docker tag crowd-db-restore:latest 619333082511.dkr.ecr.us-east-1.amazonaws.com/crowd-db-restore:latest
 docker push 619333082511.dkr.ecr.us-east-1.amazonaws.com/crowd-db-restore:latest


### PR DESCRIPTION
This PR is related to issue #1478.  In addition to the Dockerfiles and push container scripts I updated the cloudformation/infrastructure yaml files impacted by the recent version upgrades of postgresql 9.6 to 12 (12.5) and elastic search 6.7 to 6.8.

One of the linters insisted that the rds.yaml database engine value be a string - '12.5' vs 12.5.
I'm hoping it's correct and I don't have a local linter configuration change to manage. But wanted to call it out just in case.