### PR TITLE
1593 populate existing asset storage image

### DIFF
--- a/concordia/tasks.py
+++ b/concordia/tasks.py
@@ -364,7 +364,7 @@ def populate_storage_image_values(asset_qs=None):
     # only fetch assest with no storgae image value
     asset_qs = (
         Asset.objects.filter(storage_image__isnull=True)
-        .order_by("title")
+        .order_by("id")
         .prefetch_related("item")
     )
 

--- a/concordia/tasks.py
+++ b/concordia/tasks.py
@@ -363,9 +363,9 @@ def populate_storage_image_values(asset_qs=None):
 
     # only fetch assest with no storgae image value
     asset_qs = (
-        Asset.objects.filter(storage_image__isnull=True)
-        .order_by("id")
-        .prefetch_related("item")
+        Asset.objects.filter(storage_image__isnull=True).order_by("id")
+        # .prefetch_related("item__project__campaign")[:20000]
+        .select_related("item__project__campaign")[:25000]
     )
 
     updated_count = 0
@@ -373,8 +373,7 @@ def populate_storage_image_values(asset_qs=None):
     # We'll process assets in chunks using an iterator to avoid saving objects
     # which will never be used again in memory. We will build the S3 relative key for
     # each existing asset and pass them to bulk_update() to be saved in a single query.
-    for asset_chunk in chunked(asset_qs.iterator(), 3000):
-        changed_assets = []
+    for asset_chunk in chunked(asset_qs.iterator(), 2000):
 
         for asset in asset_chunk:
             asset.storage_image = "/".join(
@@ -385,14 +384,13 @@ def populate_storage_image_values(asset_qs=None):
                     asset.media_url,
                 ]
             )
-            changed_assets.append(asset)
 
-        if changed_assets:
-            # We will only save the new storage image value both for performance
-            # and to avoid any possibility of race conditions causing stale data
-            # to be saved:
-            Asset.objects.bulk_update(changed_assets, ["storage_image"])
-            updated_count += len(changed_assets)
+        # We will only save the new storage image value both for performance
+        # and to avoid any possibility of race conditions causing stale data
+        # to be saved:
+
+        Asset.objects.bulk_update(asset_chunk, ["storage_image"])
+        updated_count += len(asset_chunk)
 
         logger.debug("Storage image updated count %s" % updated_count)
 


### PR DESCRIPTION
This PR is related to [#1593 Admin S3 Object Deletion - Build a process to populate the Storage image field value for existing assets](https://github.com/LibraryOfCongress/concordia/issues/1593)

Any suggestions on how to make this faster and use less memory? 