### PR TITLE
1593 populate existing asset storage image

### DIFF
--- a/concordia/tasks.py
+++ b/concordia/tasks.py
@@ -363,7 +363,6 @@ def populate_storage_image_values(asset_qs=None):
 
     # only fetch assest with no storgae image value
     asset_qs = (
-        1593-populate-existing-asset-storage-image
         Asset.objects.filter(storage_image__isnull=True)
         .order_by("id")
         .prefetch_related("item__project__campaign")[:20000]


### PR DESCRIPTION
#1593 Switched from select related to prefetch related.
Error log for the RDS the following error statement 3xs:
2022-02-23 13:04:01 UTC:10.192.21.163(44588):concordia@concordia:[30446]:log: could not receive data from client: Connection reset by peer. The process was killed at some point despite being in a periodic celery task. I did npt experience this behavior in a local dev. env with app and importer running locally in pipenv and postgresql, redis and celerybeat in docker containers.
