### PR TITLE
1624 importer periodic process sigkill

### DIFF
--- a/concordia/tasks.py
+++ b/concordia/tasks.py
@@ -359,14 +359,26 @@ def populate_storage_image_values(asset_qs=None):
     For Assets that existed prior to implementing the storage_image ImageField, build
     the relative S3 storage key for the asset and update the storage_image value
     """
-
-    # only fetch assest with no storgae image value
+    # As a reference point - how many records have a null storage image field?
+    asset_storage_qs = Asset.objects.filter(storage_image__isnull=True)
+    storage_image_null_count = asset_storage_qs.count()
     asset_qs = (
         Asset.objects.filter(storage_image__isnull=True)
         .order_by("id")
-        .select_related("item__project__campaign")[:20000]
+        .select_related("item__project__campaign")
+        .only(
+            "id",
+            "storage_image",
+            "media_url",
+            "item",
+            "item__item_id",
+            "item__project",
+            "item__project__slug",
+            "item__project__campaign",
+            "item__project__campaign__slug",
+        )[:20000]
     )
-
+    logger.debug("Total Storage image null count %s" % storage_image_null_count)
     logger.debug("Start storage image chunking")
 
     updated_count = 0
@@ -395,7 +407,7 @@ def populate_storage_image_values(asset_qs=None):
 
         logger.debug("Storage image updated count %s" % updated_count)
 
-    return updated_count
+    return updated_count, storage_image_null_count
 
 
 @celery_app.task
@@ -428,7 +440,7 @@ def populate_asset_years():
             Asset.objects.bulk_update(changed_assets, ["year"])
             updated_count += len(changed_assets)
 
-    return updated_count
+    return (updated_count,)
 
 
 @celery_app.task

--- a/concordia/tasks.py
+++ b/concordia/tasks.py
@@ -440,7 +440,7 @@ def populate_asset_years():
             Asset.objects.bulk_update(changed_assets, ["year"])
             updated_count += len(changed_assets)
 
-    return (updated_count,)
+    return updated_count
 
 
 @celery_app.task

--- a/importer/entrypoint.sh
+++ b/importer/entrypoint.sh
@@ -6,4 +6,4 @@ mkdir -p /app/logs
 touch /app/logs/concordia.log
 
 echo "Running celery worker"
-celery -A concordia worker -l info -c 10
+celery -A concordia worker -l info -c 1


### PR DESCRIPTION
reduced queryset memory requirement - reduced it down mostly to just the fields needed across the parent/upstream related objects, added a null count to assist troubleshooting via celery response/task return in log.
Concurrency is still at 1