### PR TITLE
1556 profile pages worked on

### DIFF
--- a/concordia/templates/account/profile.html
+++ b/concordia/templates/account/profile.html
@@ -128,7 +128,9 @@
                     </tbody>
                 </table>
 
-                <div>{% include "fragments/standard-pagination.html" %}</div>
+                <div class="row">
+                    {% include "fragments/standard-pagination.html" %}
+                </div>
             </div>
         </div>
     {% endif %}

--- a/concordia/templates/account/profile.html
+++ b/concordia/templates/account/profile.html
@@ -85,7 +85,7 @@
                             <tr>
                                 <td></td>
                                 <td>
-                                    <a class="campaign" id={{campaign.id}} href="{{ campaign.get_absolute_url }}">{{ campaign.title }}</a>
+                                    <a class="campaign" id={{campaign.id}} href="?campaign_slug={{ campaign.id }}">{{ campaign.title }}</a>
                                 </td>
                                 <td>{{ campaign.transcribe_count|intcomma }}</td>
                                 <td>{{ campaign.review_count|intcomma }}</td>


### PR DESCRIPTION
PR for #1556 
Update: Seems there is a bug when order_by is just a datetime field when using pagination. https://stackoverflow.com/questions/5044464/django-pagination-is-repeating-results. I applied this workaround at least for now and it solves the pagination (rows repeating after 15 records - initially sequentially and then in small groups of rows disbursed with new rows of data.

I also change to one date column for aggregating the user_id and reviewed_by_id records - because the nulls and the various current sorts seemed to not be playing well together.