### PR TITLE
removed pagination due to bug temporarily so we get core functionalit…

### DIFF
--- a/concordia/views.py
+++ b/concordia/views.py
@@ -483,7 +483,7 @@ class AccountProfileView(LoginRequiredMixin, FormView, ListView):
     # presented in the template as a standard paginated list of Asset
     # instances with annotations
     allow_empty = True
-    paginate_by = 30
+    # paginate_by = 30
 
     def post(self, *args, **kwargs):
         self.object_list = self.get_queryset()


### PR DESCRIPTION
#1556 - this PR removes pagination (due to a bug) temporarily so we get core functionality out of the "Pages worked on" list.

A workaround for the bug is mentioned here https://stackoverflow.com/questions/5044464/django-pagination-is-repeating-results - but sorting is a bit tricky and while we figure that out, this request will remove some frustration for the Community Managers.