### PR TITLE
Revert "removed pagination due to bug temporarily so we get core functionalit…"

### DIFF
--- a/concordia/views.py
+++ b/concordia/views.py
@@ -483,7 +483,7 @@ class AccountProfileView(LoginRequiredMixin, FormView, ListView):
     # presented in the template as a standard paginated list of Asset
     # instances with annotations
     allow_empty = True
-    # paginate_by = 30
+    paginate_by = 30
 
     def post(self, *args, **kwargs):
         self.object_list = self.get_queryset()


### PR DESCRIPTION
Reverts LibraryOfCongress/concordia#1655

In the AWS environment - this was causing users with 2000 plus actions to receive 504, 503 and 502 in DEV. 
Which may need to be scaled up soon anyway..?