### PR TITLE
add settings font and size add refresh btn

### DIFF
--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -296,6 +296,8 @@ AUTHENTICATION_BACKENDS = [
 CAPTCHA_CHALLENGE_FUNCT = "captcha.helpers.random_char_challenge"
 #: Anonymous sessions require captcha validation every day by default:
 ANONYMOUS_CAPTCHA_VALIDATION_INTERVAL = 86400
+CAPTCHA_IMAGE_SIZE = [150, 150]
+CAPTCHA_FONT_SIZE = 40
 
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 WHITENOISE_ROOT = os.path.join(SITE_ROOT_DIR, "static")

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -496,6 +496,9 @@
                     <input type="hidden" name="key"/>
                 </div>
                 <div class="modal-footer">
+                    <button type="submit" class='btn btn-secondary js-captcha-refresh'>
+                        Refresh Challenge
+                    </button>
                     <button type="submit" class="btn btn-primary">
                         Continue
                     </button>


### PR DESCRIPTION
This PR is in support of #1582 and implements the [Django Simple Captcha](https://django-simple-captcha.readthedocs.io/en/latest/index.html) CAPTCHA_IMAGE_SIZE and CAPTCHA_FONT_SIZE configuration settings and adds the refresh button for the user to recycle the image.