### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Concordia is a platform developed by the Library of Congress (LOC) for crowdsour
 
 LOC launched the first iteration of Concordia as [By the People at crowd.loc.gov](https://crowd.loc.gov/) in October 2018.
 
-The application invites volunteers to transcribe and tag digitized images of manuscripts and typed materials from the Library’s collections. All transcriptions are made by volunteers and reviewed by volunteers. It takes at least one volunteer to transcribe a page and at least one other volunteer to review and mark it complete. Some complex documents may pass through both transcription and review many times before they are accepted as complete. 
+The application invites volunteers to transcribe and tag digitized images of manuscript and typed materials from the Library’s collections. All transcriptions are made by volunteers and reviewed by volunteers. It takes at least one volunteer to transcribe a page and at least one other volunteer to review and mark it complete. Some complex documents may pass through both transcription and review many times before they are accepted as complete. 
 
 Concordia leverages the [LOC’s API](https://libraryofcongress.github.io/data-exploration/) to pull materials from the Library's catalog. Completed transcriptions can be exported out of the application in a single CSV or individual TXT files in a BagIt bag. 
 
-The Library of Congress publishes Concordia-created transcriptions on [loc.gov](https://www.loc.gov/) to improve search, readability, and access to handwritten and typed documents. Individual transcriptions are published alongside the transcribed images in digital collections and transcriptions are also published in bulk as [datasets](https://www.loc.gov/search/?fa=contributor:by+the+people+%28program%29).
+The Library of Congress publishes volunteer-created transcriptions on [loc.gov](https://www.loc.gov/) to improve search, readability, and access to handwritten and typed documents. Individual transcriptions are published alongside the transcribed images in digital collections and transcriptions are also published in bulk as [datasets](https://www.loc.gov/search/?fa=contributor:by+the+people+%28program%29).
 
 Concordia code and the By the People transcriptions are released into the public domain. Anyone is free to use or reuse the data. [More info on our licensing page](https://github.com/LibraryOfCongress/concordia/blob/main/LICENSE.md).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The application invites volunteers to transcribe and tag digitized images of man
 
 Concordia leverages the [LOC’s API](https://libraryofcongress.github.io/data-exploration/) to pull materials from the Library's catalog. Completed transcriptions can be exported out of the application in a single CSV or individual TXT files in a BagIt bag. 
 
-The Library of Congress publishes volunteer-created transcriptions on [loc.gov](https://www.loc.gov/) to improve search, readability, and access to handwritten and typed documents. Individual transcriptions are published alongside the transcribed images in digital collections and transcriptions are also published in bulk as [datasets](https://www.loc.gov/search/?fa=contributor:by+the+people+%28program%29).
+The Library of Congress publishes transcriptions created by volunteers through Concordia on [loc.gov](https://www.loc.gov/) to improve search, readability, and access to handwritten and typed documents. Individual transcriptions are published alongside the transcribed images in digital collections and transcriptions are also published in bulk as [datasets](https://www.loc.gov/search/?fa=contributor:by+the+people+%28program%29).
 
 Concordia code and the By the People transcriptions are released into the public domain. Anyone is free to use or reuse the data. [More info on our licensing page](https://github.com/LibraryOfCongress/concordia/blob/main/LICENSE.md).
 


### PR DESCRIPTION
Changed "manuscripts" to "manuscript" to convert to adjective
Changed "Concordia-created transcriptions" to "volunteer-created transcriptions" since it seems to make more sense to give the agency to the human creators? 