### PR TITLE
Add basic load testing

### DIFF
--- a/load_test.sh
+++ b/load_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+locust  --no-web -c 1000 -r 100 --run-time 1h30m --host https://crowd-dev.loc.gov

--- a/locustfile.py
+++ b/locustfile.py
@@ -1,0 +1,42 @@
+from locust import TaskSet, between
+from locust.contrib.fasthttp import FastHttpLocust
+
+
+def campaigns_topics(l):
+    l.client.get("/campaigns-topics")
+
+
+def about(l):
+    l.client.get("/about")
+
+
+def index(l):
+    l.client.get("/")
+
+
+def resources(l):
+    l.client.get("/resources")
+
+
+def herencia(l):
+    l.client.get("/campaigns/herencia-centuries-of-spanish-legal-documents/")
+
+
+def suffrage_next_asset(l):
+    l.client.get("/topics/suffrage-women-fight-for-the-vote/next-transcribable-asset/")
+
+
+class UserBehavior(TaskSet):
+    tasks = {
+        index: 2,
+        about: 1,
+        resources: 1,
+        campaigns_topics: 3,
+        herencia: 4,
+        suffrage_next_asset: 4,
+    }
+
+
+class WebsiteUser(FastHttpLocust):
+    task_set = UserBehavior
+    wait_time = between(5.0, 9.0)

--- a/locustfile.py
+++ b/locustfile.py
@@ -2,28 +2,30 @@ from locust import TaskSet, between
 from locust.contrib.fasthttp import FastHttpLocust
 
 
-def campaigns_topics(l):
-    l.client.get("/campaigns-topics")
+def campaigns_topics(user):
+    user.client.get("/campaigns-topics/")
 
 
-def about(l):
-    l.client.get("/about")
+def about(user):
+    user.client.get("/about/")
 
 
-def index(l):
-    l.client.get("/")
+def index(user):
+    user.client.get("/")
 
 
-def resources(l):
-    l.client.get("/resources")
+def resources(user):
+    user.client.get("/resources/")
 
 
-def herencia(l):
-    l.client.get("/campaigns/herencia-centuries-of-spanish-legal-documents/")
+def herencia(user):
+    user.client.get("/campaigns/herencia-centuries-of-spanish-legal-documents/")
 
 
-def suffrage_next_asset(l):
-    l.client.get("/topics/suffrage-women-fight-for-the-vote/next-transcribable-asset/")
+def suffrage_next_asset(user):
+    user.client.get(
+        "/topics/suffrage-women-fight-for-the-vote/next-transcribable-asset/"
+    )
 
 
 class UserBehavior(TaskSet):


### PR DESCRIPTION
These current tests look appropriate. I made some changes to avoid redirects and correct spacing.

Once these are merged, we can schedule a time to run the tests against the development environment.

Supports CONCD-46