### PR TITLE
Fixed test_password_reset_will_activate_user test 

### DIFF
--- a/concordia/tests/test_views.py
+++ b/concordia/tests/test_views.py
@@ -1025,7 +1025,7 @@ class TransactionalViewTests(CreateTestUsers, JSONAssertMixin, TransactionTestCa
         second_user = self.create_test_user(
             username="second_tester", email="second_tester@example.com"
         )
-        self.client.login(username=second_user.username, password=second_user.password)
+        self.client.login(username=second_user.username, password=second_user._password)
 
         resp = self.client.post(
             reverse("submit-tags", kwargs={"asset_pk": asset.pk}),

--- a/concordia/tests/utils.py
+++ b/concordia/tests/utils.py
@@ -184,7 +184,7 @@ class CreateTestUsers(object):
         if not hasattr(self, "user"):
             self.user = self.create_test_user("tester")
 
-        self.client.login(username=self.user.username, password=self.user.password)
+        self.client.login(username=self.user.username, password=self.user._password)
 
     def create_user(self, username, is_active=True, **kwargs):
         if "email" not in kwargs:
@@ -196,7 +196,7 @@ class CreateTestUsers(object):
         user.set_password(fake_pw)
         user.save()
 
-        user.password = fake_pw
+        user._password = fake_pw
 
         return user
 


### PR DESCRIPTION
Fixed test_password_reset_will_activate_user test and fixed other tests broken by the fix for that test.

The issue at the bottom of the problem was that the code that created users for tests was overwriting the 'password' attribute for users with the plaintext password so that it could be used to log the user in for some tests. This broken the reset test because the reset token was generated using that plaintext password, but then checked against the salted/hashed password from the database, which caused the tokens to not match.

Fixing that issue (by storing the plaintext password in _password, which is how Django handles it when setting a password normally) broken two other tests that manually logged in the user. Those tests were fixed by having them use _password instead.

Also some code compliance changes for touched files.