### PR TITLE
Refactor error templates to extend base.html

### DIFF
--- a/concordia/templates/404.html
+++ b/concordia/templates/404.html
@@ -1,48 +1,50 @@
-{% spaceless %}
-    {% load staticfiles %}
-{% endspaceless %}<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <title>{% block title %}404 Error{% endblock title %}</title>
-        <link rel="shortcut icon" href="{% static 'favicon.ico' %}">
-        {% include "fragments/common-stylesheets.html" %}
-        <style>
-            body {
-                height: 100vh;
-                width: 100vw;
-                margin: 0;
-                padding: 0;
-            }
+{% extends "base.html" %}
+{% load staticfiles %}
 
-            #error-message {
-                max-width: 30em;
-            }
-        </style>
-    </head>
-    <body class="d-flex justify-content-center align-items-center text-center">
-        <div id="error-message">
-            <h1>HTTP 404 Error</h1>
+{% block full_title %}404 Error{% endblock full_title %}
 
-            <p>
-                The requested page was not found.
-            </p>
+{% block head_content %}
+    <style>
+        body {
+            height: 100vh;
+            width: 100vw;
+            margin: 0;
+            padding: 0;
+        }
 
-            <nav>
-                <ul class="nav justify-content-center">
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ request.META.HTTP_REFERER }}">
-                            &laquo; Go Back
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/">Go Home &raquo;</a>
-                    </li>
-                </ul>
-            </nav>
-        </div>
+        #error-message {
+            max-width: 30em;
+        }
+    </style>
+{% endblock head_content %}
 
-        {% include "fragments/common-scripts.html" %}
-    </body>
-</html>
+{% block body_classes %}d-flex justify-content-center align-items-center text-center{% endblock body_classes %}
+
+{% block site-header %}{% endblock site-header %}
+
+{% block breadcrumbs-container %}{% endblock breadcrumbs-container %}
+
+{% block site-main %}
+    <div id="error-message">
+        <h1>HTTP 404 Error</h1>
+
+        <p>
+            The requested page was not found.
+        </p>
+
+        <nav>
+            <ul class="nav justify-content-center">
+                <li class="nav-item">
+                    <a class="nav-link" href="{{ request.META.HTTP_REFERER }}">
+                        &laquo; Go Back
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/">Go Home &raquo;</a>
+                </li>
+            </ul>
+        </nav>
+    </div>
+{% endblock site-main %}
+
+{% block site-footer %} {% endblock site-footer %}

--- a/concordia/templates/404.html
+++ b/concordia/templates/404.html
@@ -1,50 +1,24 @@
-{% extends "base.html" %}
-{% load staticfiles %}
+{% extends "error.html" %}
 
 {% block full_title %}404 Error{% endblock full_title %}
 
-{% block head_content %}
-    <style>
-        body {
-            height: 100vh;
-            width: 100vw;
-            margin: 0;
-            padding: 0;
-        }
+{% block error_message %}
+    <h1>HTTP 404 Error</h1>
 
-        #error-message {
-            max-width: 30em;
-        }
-    </style>
-{% endblock head_content %}
+    <p>
+        The requested page was not found.
+    </p>
 
-{% block body_classes %}d-flex justify-content-center align-items-center text-center{% endblock body_classes %}
-
-{% block site-header %}{% endblock site-header %}
-
-{% block breadcrumbs-container %}{% endblock breadcrumbs-container %}
-
-{% block site-main %}
-    <div id="error-message">
-        <h1>HTTP 404 Error</h1>
-
-        <p>
-            The requested page was not found.
-        </p>
-
-        <nav>
-            <ul class="nav justify-content-center">
-                <li class="nav-item">
-                    <a class="nav-link" href="{{ request.META.HTTP_REFERER }}">
-                        &laquo; Go Back
-                    </a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="/">Go Home &raquo;</a>
-                </li>
-            </ul>
-        </nav>
-    </div>
-{% endblock site-main %}
-
-{% block site-footer %} {% endblock site-footer %}
+    <nav>
+        <ul class="nav justify-content-center">
+            <li class="nav-item">
+                <a class="nav-link" href="{{ request.META.HTTP_REFERER }}">
+                    &laquo; Go Back
+                </a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="/">Go Home &raquo;</a>
+            </li>
+        </ul>
+    </nav>
+{% endblock error_message %}

--- a/concordia/templates/429.html
+++ b/concordia/templates/429.html
@@ -1,44 +1,19 @@
-{% spaceless %}
-    {% load staticfiles %}
-{% endspaceless %}<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <title>{% block title %}429 Error{% endblock title %}</title>
-        <link rel="shortcut icon" href="{% static 'favicon.ico' %}">
-        {% include "fragments/common-stylesheets.html" %}
-        <style>
-            body {
-                height: 100vh;
-                width: 100vw;
-                margin: 0;
-                padding: 0;
-            }
+{% extends "error.html" %}
 
-            #error-message {
-                max-width: 30em;
-            }
-        </style>
-    </head>
-    <body class="d-flex justify-content-center align-items-center text-center">
-        <div id="error-message">
-            <h1>HTTP 429: Too Many Requests</h1>
+{% block full_title %}429 Error{% endblock full_title %}
 
-            <p>
-                {% if exception %}
-                    {{ exception }}
-                {% else %}
-                    {{ error|default:'Please wait a bit, then try again.' }}
-                {% endif %}
+{% block error_message %}
+    <h1>HTTP 429: Too Many Requests</h1>
 
-            </p>
-            <p>
-                Seeing this page a lot? <a href="{% url 'contact' %}">Contact Us</a>
-            </p>
+    <p>
+        {% if exception %}
+            {{ exception }}
+        {% else %}
+            {{ error|default:'Please wait a bit, then try again.' }}
+        {% endif %}
 
-        </div>
-
-        {% include "fragments/common-scripts.html" %}
-    </body>
-</html>
+    </p>
+    <p>
+        Seeing this page a lot? <a href="{% url 'contact' %}">Contact Us</a>
+    </p>
+{% endblock error_message %}

--- a/concordia/templates/500.html
+++ b/concordia/templates/500.html
@@ -1,56 +1,31 @@
-{% spaceless %} {% load staticfiles %} {% endspaceless %}<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8" />
-        <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1, shrink-to-fit=no"
-        />
-        <title>{% block title %}500 Error{% endblock title %}</title>
-        <link rel="shortcut icon" href="{% static 'favicon.ico' %}" />
-        {% include "fragments/common-stylesheets.html" %}
-        <style>
-            body {
-                height: 100vh;
-                width: 100vw;
-                margin: 0;
-                padding: 0;
-            }
+{% extends "error.html" %}
 
-            #error-message {
-                max-width: 30em;
-            }
-        </style>
-    </head>
-    <body class="d-flex justify-content-center align-items-center text-center">
-        <div id="error-message">
-            <h1>HTTP 500 Error</h1>
+{% block full_title %}500 Error{% endblock full_title %}
 
-            <p>
-                The server encountered an unexpected condition which prevented
-                it from fulfilling the request. Our staff have been notified
-                about the failure.
-            </p>
+{% block error_message %}
+    <h1>HTTP 500 Error</h1>
 
-            <nav>
-                <ul class="nav justify-content-center">
-                    {% if request %}
-                        <li class="nav-item">
-                            <a
-                                class="nav-link"
-                                href="{{ request.META.HTTP_REFERER }}"
-                            >
-                                &laquo; Go Back
-                            </a>
-                        </li>
-                    {% endif %}
-                    <li class="nav-item">
-                        <a class="nav-link" href="/">Go Home &raquo;</a>
-                    </li>
-                </ul>
-            </nav>
-        </div>
+    <p>
+        The server encountered an unexpected condition which prevented
+        it from fulfilling the request. Our staff have been notified
+        about the failure.
+    </p>
 
-        {% include "fragments/common-scripts.html" %}
-    </body>
-</html>
+    <nav>
+        <ul class="nav justify-content-center">
+            {% if request %}
+                <li class="nav-item">
+                    <a
+                        class="nav-link"
+                        href="{{ request.META.HTTP_REFERER }}"
+                    >
+                        &laquo; Go Back
+                    </a>
+                </li>
+            {% endif %}
+            <li class="nav-item">
+                <a class="nav-link" href="/">Go Home &raquo;</a>
+            </li>
+        </ul>
+    </nav>
+{% endblock error_message %}

--- a/concordia/templates/base.html
+++ b/concordia/templates/base.html
@@ -6,7 +6,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <title>By the People {% block title %}{% if title %}{{ title }}{% else %}Untitled{% endif %}{% endblock title %}</title>
+        <title>{% block full_title %}By the People {% block title %}{% if title %}{{ title }}{% else %}Untitled{% endif %}{% endblock title %}{% endblock full_title %}</title>
         <meta name="description" content="Crowdsourcing project By the People invites anyone to become a Library of Congress virtual volunteer. Explore, transcribe, review, and tag digital collections to improve search and readability and open new avenues of research.">
         <link rel="shortcut icon" href="{% static 'favicon.ico' %}">
         {% include "fragments/common-stylesheets.html" %}
@@ -29,7 +29,7 @@
         {% endif %}
     </head>
 
-    <body id="body" class="view-{{ VIEW_NAME_FOR_CSS }} section-{{ PATH_LEVEL_1|default:'homepage' }} environment-{{ CONCORDIA_ENVIRONMENT }} {% block extra_body_classes %}{% endblock %} d-print-block">
+    <body id="body" class="{% block body_classes %}view-{{ VIEW_NAME_FOR_CSS }} section-{{ PATH_LEVEL_1|default:'homepage' }} environment-{{ CONCORDIA_ENVIRONMENT }} {% block extra_body_classes %}{% endblock %} d-print-block {% endblock body_classes %}">
         {% block site-header %}
             <header class="border-bottom" role="banner" aria-label="site navigation">
                 <nav class="container navbar navbar-light navbar-expand-lg align-items-lg-end py-3 d-print-block">

--- a/concordia/templates/error.html
+++ b/concordia/templates/error.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% load staticfiles %}
+
+{% block head_content %}
+    <style>
+        body {
+            height: 100vh;
+            width: 100vw;
+            margin: 0;
+            padding: 0;
+        }
+
+        #error-message {
+            max-width: 30em;
+        }
+    </style>
+{% endblock head_content %}
+
+{% block body_classes %}d-flex justify-content-center align-items-center text-center{% endblock body_classes %}
+
+{% block site-header %}{% endblock site-header %}
+
+{% block breadcrumbs-container %}{% endblock breadcrumbs-container %}
+
+{% block site-main %}
+    <div id="error-message">
+        {% block error_message %}{% endblock error_message %}
+    </div>
+{% endblock site-main %}
+
+{% block site-footer %} {% endblock site-footer %}


### PR DESCRIPTION
Related to CONCD-58

The three error templates used mostly common code, so I factored that code out to a re-usable error.html template, which extends base.html. The error templates now extend error.html and are very simplified.