### PR TITLE
CONCD-14 fix help page link contrast post robo format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,6 @@ repos:
       rev: 'v1.5.1'
       hooks:
           - id: djhtml
-          - id: djcss
-          - id: djjs
     - repo: https://github.com/ambv/black
       rev: 22.3.0
       hooks:

--- a/concordia/static/scss/base.scss
+++ b/concordia/static/scss/base.scss
@@ -1,18 +1,18 @@
 // colors
-$gray-100:  #F6F6F6;
-$gray-200:  #EFEFEF;
-$gray-300:  $gray-200;
-$gray-400:  #BFBFBF;
-$gray-500:  $gray-400;
-$gray-600:  #808080;
-$gray-700:  #545454;
-$gray-800:  #242424;
-$gray-900:  $gray-800;
+$gray-100: #f6f6f6;
+$gray-200: #efefef;
+$gray-300: $gray-200;
+$gray-400: #bfbfbf;
+$gray-500: $gray-400;
+$gray-600: #808080;
+$gray-700: #545454;
+$gray-800: #242424;
+$gray-900: $gray-800;
 
-$blue: #0076AD;
-$orange: #F05129;
+$blue: #0076ad;
+$orange: #f05129;
 $green: #218739;
-$red: #D1332E;
+$red: #d1332e;
 $navy: #002347;
 
 $dark: $gray-900;
@@ -25,10 +25,10 @@ $theme-colors: (
     'accent': $orange,
     'error': $red,
     'info': $blue,
-    'warning': $secondary
+    'warning': $secondary,
 );
 
-$mark-bg: #CAEEA4;
+$mark-bg: #caeea4;
 
 // additional sizes
 $sizes: (
@@ -37,7 +37,7 @@ $sizes: (
     35: 35%,
     40: 40%,
     60: 60%,
-    65: 65%
+    65: 65%,
 );
 
 // typography
@@ -362,29 +362,31 @@ $card-progress-height: 12px;
  * List-like displays for items and assets
  */
 
- .concordia-object-card-row {
-     margin: 0 -6px;
- }
+.concordia-object-card-row {
+    margin: 0 -6px;
+}
 
- .concordia-object-card-col {
-     padding: 6px;
-     @include media-breakpoint-up(xl) {
-         flex: 0 0 20%;
-         max-width: 20%;
-     }
- }
+.concordia-object-card-col {
+    padding: 6px;
 
- .concordia-object-card {
-     background-color: $gray-100;
-     overflow: hidden;
-     .view-transcriptions--item-detail & {
-         padding-top: 31px;
-     }
- }
+    @include media-breakpoint-up(xl) {
+        flex: 0 0 20%;
+        max-width: 20%;
+    }
+}
 
- .concordia-object-card-title {
-     padding: 12px 10px;
- }
+.concordia-object-card {
+    background-color: $gray-100;
+    overflow: hidden;
+
+    .view-transcriptions--item-detail & {
+        padding-top: 31px;
+    }
+}
+
+.concordia-object-card-title {
+    padding: 12px 10px;
+}
 
 .concordia-object-card .card-title,
 .concordia-object-card .card-actions {
@@ -393,16 +395,20 @@ $card-progress-height: 12px;
     right: 0;
 }
 
-.concordia-object-card[data-transcription-status='completed']:not(:hover) .card-img {
+.concordia-object-card[data-transcription-status='completed']:not(:hover)
+    .card-img {
     opacity: 0.4;
 }
 
 .concordia-object-card .card-img {
-	transition: .3s ease-in-out;
+    transition: 0.3s ease-in-out;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
 }
+
 .concordia-object-card:hover .card-img,
 .concordia-object-card:focus .card-img {
-	transform: scale(1.05);
+    transform: scale(1.05);
 }
 
 .concordia-object-card .card-title {
@@ -415,7 +421,9 @@ $card-progress-height: 12px;
 }
 
 .concordia-object-card .card-actions {
-    top: calc(#{$card-img-height} - #{$card-btn-height - $card-progress-height});
+    top: calc(
+        #{$card-img-height} - #{$card-btn-height - $card-progress-height}
+    );
     z-index: 3;
     .view-transcriptions--item-detail & {
         top: 0;
@@ -428,11 +436,6 @@ $card-progress-height: 12px;
     .view-transcriptions--item-detail & {
         border-radius: 0.2rem 0.2rem 0 0;
     }
-}
-
-.concordia-object-card .card-img {
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
 }
 
 .concordia-object-card .card-actions .btn-default:not(:hover) {
@@ -456,9 +459,9 @@ $card-progress-height: 12px;
 
 .progress {
     background-color: #f6f6f6;
-    background-color: #E5F7FF;
+    background-color: #e5f7ff;
     &::after {
-        content: "";
+        content: '';
         background-color: #fff;
         box-shadow: inset 0 0 1px 1px $primary;
         flex: 1 1 0%;
@@ -590,7 +593,7 @@ $card-progress-height: 12px;
 #homepage-next-transcribable-links {
     position: relative;
     &::before {
-        content: "";
+        content: '';
         width: calc(100% - 2rem);
         position: absolute;
         border-top: 1px solid #000;
@@ -598,7 +601,7 @@ $card-progress-height: 12px;
             width: 725px;
             left: 50%;
             -webkit-transform: translateX(-50%);
-            transform: translateX(-50%)
+            transform: translateX(-50%);
         }
     }
 }
@@ -718,12 +721,12 @@ $card-progress-height: 12px;
 }
 
 .help-center a.nav-link {
-    color: #333;
+    color: #0076ad;
     font-weight: bold;
 }
 
 .help-center a.nav-link.active {
-    color: $accent;
+    color: #242424;
 }
 
 /* End of help center stuff */
@@ -758,12 +761,12 @@ $card-progress-height: 12px;
  * Tag input on the asset detail page
  */
 #tag-label {
-    [data-toggle="collapse"][aria-expanded="true"] .fas:before {
-        content: "\f146";
+    [data-toggle='collapse'][aria-expanded='true'] .fas:before {
+        content: '\f146';
     }
 
-    [data-toggle="collapse"].collapsed .fas:before {
-        content: "\f0fe";
+    [data-toggle='collapse'].collapsed .fas:before {
+        content: '\f0fe';
     }
 }
 


### PR DESCRIPTION
CONCD-14
Note: lots of robo formatting changes by DjCSS. 
Made one change for Prettier and combined elements of a duplicated selector.
pre-commit seemed to get stuck after those changes were git added when going to commit. 
Went with --no-verify after three attemtps to commit but the build locally (npx gulp build) looked good for the change and the robo reformatting didn't seem to break anything.

```
stylelint................................................................Failed
- hook id: stylelint
- exit code: 2
concordia/static/scss/base.scss
 436:1  :heavy_multiplication_x:  Unexpected duplicate selector                 no-duplicate-selectors
           ".concordia-object-card .card-img", first
           used at line 401
```