### PR TITLE
update ami to Amazon Linux 2.0 AMI (2.0.20220719.0)

### DIFF
--- a/cloudformation/infrastructure/bastion-hosts.yaml
+++ b/cloudformation/infrastructure/bastion-hosts.yaml
@@ -17,7 +17,7 @@ Parameters:
 Mappings:
     AWSRegionToAMI:
         us-east-1:
-            AMI: ami-0b898040803850657
+            AMI: ami-0cabc39acf991f4f1
 
     EnvironmentMapping:
         IamInstanceProfileName:

--- a/cloudformation/infrastructure/data-load.yaml
+++ b/cloudformation/infrastructure/data-load.yaml
@@ -24,7 +24,7 @@ Parameters:
 Mappings:
     AWSRegionToAMI:
         us-east-1:
-            AMI: ami-0b898040803850657
+            AMI: ami-0cabc39acf991f4f1
 
     EnvironmentMapping:
         IamInstanceProfileName:
@@ -56,7 +56,7 @@ Resources:
                     - AWSRegionToAMI
                     - Ref: 'AWS::Region'
                     - 'AMI'
-            InstanceType: 't1.micro'
+            InstanceType: 't2.medium'
             IamInstanceProfile:
                 Fn::FindInMap:
                     - EnvironmentMapping


### PR DESCRIPTION
CONCD-139 update AMI to Amazon Linux 2.0 AMI (2.0.20220719.0) in bastion-hosts and data-load.