### PR TITLE
CONCD-16 bug when deleting tags

### DIFF
--- a/concordia/tests/test_views.py
+++ b/concordia/tests/test_views.py
@@ -1094,7 +1094,7 @@ class TransactionalViewTests(CreateTestUsers, JSONAssertMixin, TransactionTestCa
         self.login_user()
 
         initial_tags = ["foo", "bar"]
-        resp = self.client.post(
+        self.client.post(
             reverse("submit-tags", kwargs={"asset_pk": asset.pk}),
             data={"tags": initial_tags},
         )

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -1408,12 +1408,13 @@ def submit_tags(request, *, asset_pk):
         if tag not in existing_user_tags:
             user_tags.tags.add(tag)
 
-    for tag in existing_user_tags:
+    all_tags_qs = Tag.objects.filter(userassettagcollection__asset__pk=asset_pk)
+
+    for tag in all_tags_qs:
         if tag not in all_submitted_tags:
             for collection in asset.userassettagcollection_set.all():
                 collection.tags.remove(tag)
 
-    all_tags_qs = Tag.objects.filter(userassettagcollection__asset__pk=asset_pk)
     all_tags = all_tags_qs.order_by("value")
 
     final_user_tags = user_tags.tags.order_by("value").values_list("value", flat=True)


### PR DESCRIPTION
fixed an issue where, if the user is editing tags for the first time on a specific asset and attempts to delete one of those tags, then the tag was not actually deleted.