### PR TITLE
Transcription form exit confirmation

### DIFF
--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -585,4 +585,21 @@
                 "review");
         {% endif %}
     </script>
+
+    <script>
+        let transcriptionForm = document.getElementById("transcription-editor");
+        let formChanged = false;
+        transcriptionForm.addEventListener('change', function(){
+            formChanged = true;
+        });
+        transcriptionForm.addEventListener('submit', function(){
+            formChanged = false;
+        });
+        window.addEventListener('beforeunload', function(event){
+            if(formChanged){
+                // Some browsers ignore this value and always display a built-in message instead
+                return event.returnValue = "The transcription you've started has not been saved.";
+            }
+        });
+    </script>
 {% endblock body_scripts %}


### PR DESCRIPTION
Added check to transcription form to warn users if their work hasn't been saved when they try to leave the page.

Resolves CONCD-40.