### PR TITLE
CONCD-167 pipenv=2022.9.4 and later are failing

### DIFF
--- a/build_containers.sh
+++ b/build_containers.sh
@@ -17,7 +17,7 @@ source "${VENV}/bin/activate"
 # Update pip
 pip3 install -U pip
 pip3 install -U setuptools
-pip3 install -U pipenv
+pip3 install -U pipenv==2022.8.30
 
 pipenv install --dev --deploy
 


### PR DESCRIPTION
CONCD-167
Issue starts with v2022.8.31. Pin 2022.8.30 for now. When resolution exists on https://github.com/pypa/pipenv/issues/5340, unpin pipenv.