### PR TITLE
add title to open help question mark button

### DIFF
--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -124,7 +124,7 @@
                         </div>
 
                         <div class="d-flex btn-group m-1">
-                            <button type="button" class="btn btn-dark" data-toggle="modal" data-target="#keyboard-help-modal">
+                            <button type="button" class="btn btn-dark" title="Open Help" data-toggle="modal" data-target="#keyboard-help-modal">
                                 <span class="fas fa-question-circle" aria-label="Open Help"></span>
                             </button>
                         </div>


### PR DESCRIPTION
This PR resolves CONCD-144. Adds title to circle question mark button to resolve WAVE "Empty Button" error.