### PR TITLE
Added completed campaign page

### DIFF
--- a/concordia/static/scss/base.scss
+++ b/concordia/static/scss/base.scss
@@ -512,6 +512,19 @@ $card-progress-height: 12px;
     vertical-align: baseline;
 }
 
+// Campaign small blocks
+
+.small-campaign-title {
+    min-height: 6ex;
+}
+
+.small-campaign-description {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+}
+
 /*
  * Homepage customizations
  */

--- a/concordia/templates/transcriptions/campaign_list_small_blocks.html
+++ b/concordia/templates/transcriptions/campaign_list_small_blocks.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% load staticfiles %}
+
+{% block title %}Completed Campaigns{% endblock title %}
+
+{% block head_content %}
+    <link rel="canonical" href="https://{{ request.get_host }}{{ request.path }}">
+{% endblock head_content %}
+
+{% block breadcrumbs %}
+    <li class="breadcrumb-item active" aria-current="page">Completed Campaigns</li>
+{% endblock breadcrumbs %}
+
+{% block main_content %}
+    <div class="container py-3">
+        <h1>Completed Campaigns</h1>
+        <ul class="list-unstyled row">
+            {% with show_description=True %}
+                {% for campaign in campaigns %}
+                    {% include "transcriptions/campaign_small_block.html" %}
+                {% endfor %}
+            {% endwith %}
+        </ul>
+    </div>
+{% endblock main_content %}

--- a/concordia/templates/transcriptions/campaign_small_block.html
+++ b/concordia/templates/transcriptions/campaign_small_block.html
@@ -1,0 +1,15 @@
+{% load truncation %}
+
+<li class="col-sm-4 mb-4">
+    <a href="{% url 'transcriptions:campaign-detail' campaign.slug %}">
+        <div class="aspect-ratio-box">
+            <div class="aspect-ratio-box-inner-wrapper">
+                <img src="{{ MEDIA_URL }}{{ campaign.thumbnail_image }}" class="img-fluid" alt="" loading="lazy">
+            </div>
+        </div>
+        <span class="d-block h4 mt-2 small-campaign-title">{{ campaign.title }}</span>
+    </a>
+    {% if show_description %}
+        <p class="small-campaign-description">{{ campaign.short_description|striptags|truncatechars_on_word_break:160 }}</p>
+    {% endif %}
+</li>

--- a/concordia/templatetags/truncation.py
+++ b/concordia/templatetags/truncation.py
@@ -1,0 +1,67 @@
+import unicodedata
+
+from django import template
+from django.template.defaultfilters import stringfilter
+from django.utils.text import Truncator
+
+register = template.Library()
+
+
+class WordBreakTruncator(Truncator):
+    def word_break(self, num, truncate=None):
+        """
+        Return the text truncated to be no longer than the specified number
+        of characters, but truncated on the most recent word break.
+        `truncate` specifies what should be used to notify that the string has
+        been truncated, defaulting to a translatable string of an ellipsis.
+        """
+        self._setup()
+        length = int(num)
+        text = unicodedata.normalize("NFC", self._wrapped)
+
+        # Calculate the length to truncate to (max length - end_text length)
+        truncate_len = length
+        for char in self.add_truncation_text("", truncate):
+            if not unicodedata.combining(char):
+                truncate_len -= 1
+                if truncate_len == 0:
+                    break
+        return self._text_word_break(length, truncate, text, truncate_len)
+
+    def _text_word_break(self, length, truncate, text, truncate_len):
+        """
+        Truncate a string after a certain number of chars on the most recent
+        word break
+        """
+        s_len = 0
+        end_index = None
+        for i, char in enumerate(text):
+            if unicodedata.combining(char):
+                # Don't consider combining characters
+                # as adding to the string length
+                continue
+            s_len += 1
+            if end_index is None and s_len > truncate_len:
+                end_index = i
+            if s_len > length:
+                # Return the truncated string
+                return self.add_truncation_text(
+                    " ".join(text[: end_index or 0].split()[:-1]), truncate
+                )
+
+        # Return the original string since no truncation was necessary
+        return text
+
+
+@register.filter(is_safe=True)
+@stringfilter
+def truncatechars_on_word_break(value, arg):
+    """
+    Truncate a string after `arg` number of characters, truncating
+    on the most recent word break.
+    """
+    try:
+        length = int(arg)
+    except ValueError:  # Invalid literal for int().
+        return value  # Fail silently.
+    return WordBreakTruncator(value).word_break(length, "[…]")

--- a/concordia/urls.py
+++ b/concordia/urls.py
@@ -17,6 +17,11 @@ tx_urlpatterns = (
     [
         path("", views.CampaignListView.as_view(), name="campaign-list"),
         path(
+            "completed/",
+            views.CompletedCampaignListView.as_view(),
+            name="completed-campaign-list",
+        ),
+        path(
             "<uslug:slug>/", views.CampaignDetailView.as_view(), name="campaign-detail"
         ),
         path(

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -694,6 +694,19 @@ class CampaignListView(APIListView):
         return data
 
 
+@method_decorator(default_cache_control, name="dispatch")
+class CompletedCampaignListView(APIListView):
+    template_name = "transcriptions/campaign_list_small_blocks.html"
+
+    queryset = (
+        Campaign.objects.published()
+        .listed()
+        .filter(status__in=[Campaign.Status.COMPLETED, Campaign.Status.RETIRED])
+        .order_by("ordering", "title")
+    )
+    context_object_name = "campaigns"
+
+
 def calculate_asset_stats(asset_qs, ctx):
     asset_count = asset_qs.count()
 


### PR DESCRIPTION
Adds a template for the smaller/simpler campaign display block and a page for displaying all completed/retired campaigns.

Also added a combined character length and word break truncator to support the truncation required for the page so truncation never happens in the middle of a word. The truncator uses the as much of the built-in Django code as possible and otherwise follows the same logic and convention.

https://staff.loc.gov/tasks/browse/CONCD-162