### PR TITLE
Added 'Completed Campaigns' section to active campaigns page

### DIFF
--- a/concordia/static/scss/base.scss
+++ b/concordia/static/scss/base.scss
@@ -358,6 +358,12 @@ $card-progress-height: 12px;
     overflow: hidden;
 }
 
+.section-link {
+    text-decoration: underline;
+    padding-top: 1em;
+    padding-bottom: 0.25em;
+}
+
 /*
  * List-like displays for items and assets
  */

--- a/concordia/templates/transcriptions/campaign_list.html
+++ b/concordia/templates/transcriptions/campaign_list.html
@@ -2,19 +2,19 @@
 
 {% load staticfiles %}
 
-{% block title %}Campaigns{% endblock title %}
+{% block title %}Active Campaigns{% endblock title %}
 
 {% block head_content %}
     <link rel="canonical" href="https://{{ request.get_host }}{{ request.path }}">
 {% endblock head_content %}
 
 {% block breadcrumbs %}
-    <li class="breadcrumb-item active" aria-current="page">Campaigns</li>
+    <li class="breadcrumb-item active" aria-current="page">Active Campaigns</li>
 {% endblock breadcrumbs %}
 
 {% block main_content %}
     <div class="container py-3">
-        <h1 class="sr-only">Campaigns</h1>
+        <h1>Active Campaigns</h1>
         {% if topics %}
             <h3><a href="{% url 'topic-list' %}">Explore by topic</a></h3>
             <ul class="topic-list">
@@ -43,8 +43,6 @@
                 </li>
             {% endfor %}
         </ul>
-        <div class="row">
-            {% include "fragments/standard-pagination.html" %}
-        </div>
+        {% include "transcriptions/completed_campaigns_section.html" %}
     </div>
 {% endblock main_content %}

--- a/concordia/templates/transcriptions/campaign_topic_list.html
+++ b/concordia/templates/transcriptions/campaign_topic_list.html
@@ -2,19 +2,19 @@
 
 {% load staticfiles %}
 
-{% block title %}Campaigns{% endblock title %}
+{% block title %}Active Campaigns{% endblock title %}
 
 {% block head_content %}
     <link rel="canonical" href="https://{{ request.get_host }}{{ request.path }}">
 {% endblock head_content %}
 
 {% block breadcrumbs %}
-    <li class="breadcrumb-item active" aria-current="page">Campaigns</li>
+    <li class="breadcrumb-item active" aria-current="page">Active Campaigns</li>
 {% endblock breadcrumbs %}
 
 {% block main_content %}
     <div class="container py-3">
-        <h1 class="sr-only">Campaigns</h1>
+        <h1>Active Campaigns</h1>
         <ul class="list-unstyled">
             {% for campaign in campaigns_topics %}
                 <li class="p-4 mb-1 bg-light">
@@ -31,8 +31,6 @@
                 </li>
             {% endfor %}
         </ul>
-        <div class="row">
-            {% include "fragments/standard-pagination.html" %}
-        </div>
+        {% include "transcriptions/completed_campaigns_section.html" %}
     </div>
 {% endblock main_content %}

--- a/concordia/templates/transcriptions/completed_campaigns_section.html
+++ b/concordia/templates/transcriptions/completed_campaigns_section.html
@@ -1,0 +1,7 @@
+<h2>Completed Campaigns</h2>
+<h4 class="section-link"><a href="{% url 'transcriptions:completed-campaign-list' %}">See All Completed Campaigns &raquo;</a></h4>
+<ul class="list-unstyled row">
+    {% for campaign in completed_campaigns|slice:6 %}
+        {% include "transcriptions/campaign_small_block.html" %}
+    {% endfor %}
+</ul>

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -644,15 +644,25 @@ class HomeView(ListView):
 @method_decorator(default_cache_control, name="dispatch")
 class CampaignListView(APIListView):
     template_name = "transcriptions/campaign_list.html"
-    paginate_by = 10
 
-    queryset = Campaign.objects.published().listed().order_by("ordering", "title")
+    queryset = (
+        Campaign.objects.published()
+        .listed()
+        .filter(status=Campaign.Status.ACTIVE)
+        .order_by("ordering", "title")
+    )
     context_object_name = "campaigns"
 
     def get_context_data(self, **kwargs):
         data = super().get_context_data(**kwargs)
         data["topics"] = (
             Topic.objects.published().listed().order_by("ordering", "title")
+        )
+        data["completed_campaigns"] = (
+            Campaign.objects.published()
+            .listed()
+            .filter(status__in=[Campaign.Status.COMPLETED, Campaign.Status.RETIRED])
+            .order_by("ordering", "title")
         )
         return data
 
@@ -817,13 +827,22 @@ class CampaignTopicListView(TemplateView):
     def get(self, context):
         data = {}
         data["campaigns"] = (
-            Campaign.objects.published().listed().order_by("ordering", "title")
+            Campaign.objects.published()
+            .listed()
+            .filter(status=Campaign.Status.ACTIVE)
+            .order_by("ordering", "title")
         )
         data["topics"] = (
             Topic.objects.published().listed().order_by("ordering", "title")
         )
         data["campaigns_topics"] = sorted(
             [*data["campaigns"], *data["topics"]], key=attrgetter("ordering", "title")
+        )
+        data["completed_campaigns"] = (
+            Campaign.objects.published()
+            .listed()
+            .filter(status__in=[Campaign.Status.COMPLETED, Campaign.Status.RETIRED])
+            .order_by("ordering", "title")
         )
 
         return render(self.request, self.template_name, data)


### PR DESCRIPTION
Adds the 'Completed Campaigns' section to the active campaigns page and changed titles on the active campaigns page to be 'Active Campaigns' instead of just 'Campaigns'.

There are actually two active campaign list views/templates, 'campaigns' and 'campaign-topics'. At the moment, 'campaign-topics' is the one in use, but due to changes being made (primarily, topics being displayed separately from campaigns), I believe 'campaigns' should be used instead. However, I want to confirm with the rest of the team first. In the meantime, I  made the above changes to both views/templates.

https://staff.loc.gov/tasks/browse/CONCD-163