### PR TITLE
CONCD-159 revert change (rounding)

### DIFF
--- a/concordia/models.py
+++ b/concordia/models.py
@@ -7,7 +7,6 @@ from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db import models
 from django.db.models import Count, F, JSONField, Q
-from django.db.models.functions import Round
 from django.urls import reverse
 from django_prometheus_metrics.models import MetricsModelMixin
 
@@ -105,12 +104,8 @@ class UnlistedPublicationQuerySet(PublicationQuerySet):
             )
             .annotate(needs_review_count=F("in_progress_count") + F("submitted_count"))
             .annotate(
-                completed_percent=Round(
-                    100.0 * F("completed_count") / F("asset_count")
-                ),
-                submitted_percent=Round(
-                    100.0 * F("needs_review_count") / F("asset_count")
-                ),
+                completed_percent=100 * F("completed_count") / F("asset_count"),
+                submitted_percent=100 * F("needs_review_count") / F("asset_count"),
             )
         )
 

--- a/concordia/templates/transcriptions/campaign_topic_list.html
+++ b/concordia/templates/transcriptions/campaign_topic_list.html
@@ -56,11 +56,11 @@
                             </div>
                             <div class="progress-bar-label">
                                 {% if campaign.completed_percent %}
-                                    <span>{{ campaign.completed_percent|floatformat:"0" }}% Completed</span>
+                                    <span>{{ campaign.completed_percent }}% Completed</span>
                                     {% if campaign.submitted_percent %} | {%endif %}
                                 {% endif %}
                                 {% if campaign.submitted_percent %}
-                                    <span>{{ campaign.submitted_percent|floatformat:"0" }}% Needs Review</span>
+                                    <span>{{ campaign.submitted_percent }}% Needs Review</span>
                                 {% endif %}
                             </div>
                         </div>


### PR DESCRIPTION
rounding was causing some campaigns to appear as 100%, when they should not (such as Blackwells)