### PR TITLE
CONCD-188 Profile page mod: contributions table

### DIFF
--- a/concordia/static/scss/base.scss
+++ b/concordia/static/scss/base.scss
@@ -978,6 +978,16 @@ div.related-links {
     display: block;
 }
 
+/* Profile page */
+.contribution-table a {
+    text-decoration: underline;
+}
+
+.contribution-table thead th {
+    border-bottom: 1px solid #000;
+    border-top: 1px solid #000;
+}
+
 /* print */
 @media print {
     @page {

--- a/concordia/templates/account/profile.html
+++ b/concordia/templates/account/profile.html
@@ -74,35 +74,35 @@
                 <div class="col-12 col-md-10">
                     <h2>My Contributions</h2>
                     <div>Click on a campaign title to see only those actions. Click "All Campaigns" to view all.</div>
-                    <table id="tblTranscription" class="table table-striped table-sm table-responsive-sm">
+                    <table id="tblTranscription" class="table table-striped table-sm table-responsive-sm contribution-table">
                         <thead>
                             <tr>
                                 <th></th>
                                 <th>Campaign</th>
-                                <th><abbr title="Total number of times you saved, submitted a transcription">Saves & Submits</abbr></th>
-                                <th><abbr title="Total number of times you reviewed a transcription">Reviews</abbr></th>
-                                <th><abbr title="Total number of times you saved, submitted, or reviewed a transcription">Total Actions</abbr></th>
+                                <th><abbr title="Total number of times you saved, submitted a transcription" class="text-decoration-none">Saves & Submits</abbr></th>
+                                <th><abbr title="Total number of times you reviewed a transcription" class="text-decoration-none">Reviews</abbr></th>
+                                <th><abbr title="Total number of times you saved, submitted, or reviewed a transcription" class="text-decoration-none">Total Actions</abbr></th>
                             </tr>
                         </thead>
                         <tbody>
+                            <tr>
+                                <td></td>
+                                <td class="campaign" id="-1"><b>  <a href="{% url 'campaign-topic-list' %}">All Campaigns</a></b></td>
+                                <td><b>{{ totalTranscriptions|intcomma }}</b></td>
+                                <td><b>{{ totalReviews|intcomma }}</b></td>
+                                <td><b>{{ totalCount|intcomma }}</b></td>
+                            </tr>
                             {% for campaign in contributed_campaigns %}
                                 <tr>
                                     <td></td>
                                     <td>
-                                        <a class="campaign" id={{campaign.id}} href="?campaign_slug={{ campaign.id }}">{{ campaign.title }}</a>
+                                        <a class="campaign" id={{campaign.id}} href="{% url 'transcriptions:campaign-detail' campaign.slug %}">{{ campaign.title }}</a>
                                     </td>
                                     <td>{{ campaign.transcribe_count|intcomma }}</td>
                                     <td>{{ campaign.review_count|intcomma }}</td>
                                     <td>{{ campaign.action_count|intcomma }}</td>
                                 </tr>
                             {% endfor %}
-                            <tr>
-                                <td></td>
-                                <td class="campaign" id="-1"><b>  <a style="color:#000000;" href="/account/profile">All Campaigns</a></b></td>
-                                <td><b>{{ totalTranscriptions|intcomma }}</b></td>
-                                <td><b>{{ totalReviews|intcomma }}</b></td>
-                                <td><b>{{ totalCount|intcomma }}</b></td>
-                            </tr>
                         </tbody>
                     </table>
                     <h3>Pages worked on</h3>


### PR DESCRIPTION
- The total of contributions across campaigns is listed at the top of the table (not the bottom)
- Each of the campaign titles links to that campaign's title page.
- Campaign titles no longer act as data filters
- All Campaigns hyperlink takes me to the campaigns-topics page.