### PR TITLE
COND-214 temporarily pin npm to continue builds with node <= 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN pip3 install pipenv
 WORKDIR /app
 COPY . /app
 
-RUN npm install --silent --global npm@latest && /usr/local/bin/npm install --silent && npx gulp build
+RUN npm install --silent --global npm@8.19.3 && /usr/local/bin/npm install --silent && npx gulp build
 
 RUN pipenv install --system --dev --deploy && rm -rf ~/.cache/
 


### PR DESCRIPTION
Beginning today - Builds began failing in Jenkins as a result of an upgrade to npm (latest v9.1.1 - via Docker file) which is incompatible with version 12 of Node.js.

Last successful build used npm 8.19.3 on Nov 9, 2022

We will need upgrade Node - which is currently @ 18 for LTS