### PR TITLE
Concd 203 jkue gh action lint

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -8,4 +8,6 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: actions/setup-python@v4
+              with:
+                  python-version: '3.10'
             - uses: psf/black@stable

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -6,6 +6,6 @@ jobs:
     lint:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-python@v2
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
             - uses: psf/black@stable


### PR DESCRIPTION
CONCD-203 - update GitHub action versions - addresses Node 12 depreciation warnings.