### PR TITLE
CONCD-195 Profile page mod: Recent page filter - by activity

### DIFF
--- a/concordia/templates/account/profile.html
+++ b/concordia/templates/account/profile.html
@@ -3,6 +3,7 @@
 {% load staticfiles %}
 {% load humanize %}
 {% load bootstrap4 %}
+{% load bittersweet_querystring %}
 
 {% block title %}User Profile{% endblock title %}
 
@@ -157,7 +158,13 @@
                                         <th>Date</th>
                                         <th>Item</th>
                                         <th>Page</th>
-                                        <th>Your Contribution</th>
+                                        <th>
+                                            <div class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Your Contribution</div>
+                                            <div class="dropdown-menu">
+                                                <a class="dropdown-item" href="?{% qs_alter request.GET activity='reviewed' %}">Reviewed</a>
+                                                <a class="dropdown-item" href="?{% qs_alter request.GET activity='transcribed' %}">Transcribed</a>
+                                            </div>
+                                        </th>
                                         <th>Current Status</th>
                                     </tr>
                                 </thead>

--- a/concordia/templates/account/profile.html
+++ b/concordia/templates/account/profile.html
@@ -160,8 +160,8 @@
                                         <th>Page</th>
                                         <th>
                                             <div class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Your Contribution</div>
-                                            <div class="dropdown-menu">
-                                                <a class="dropdown-item" href="?{% qs_alter request.GET activity='reviewed' %}">Reviewed</a>
+                                            <div class="dropdown-menu border border-primary">
+                                                <a class="dropdown-item border-bottom border-primary" href="?{% qs_alter request.GET activity='reviewed' %}">Reviewed</a>
                                                 <a class="dropdown-item" href="?{% qs_alter request.GET activity='transcribed' %}">Transcribed</a>
                                             </div>
                                         </th>

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -493,9 +493,14 @@ class AccountProfileView(LoginRequiredMixin, FormView, ListView):
 
     def get_queryset(self):
         user = self.request.user
-        transcriptions = Transcription.objects.filter(
-            Q(user=user) | Q(reviewed_by=user)
-        )
+        activity = self.request.GET.get("activity", None)
+        if activity == "transcribed":
+            q = Q(user=user)
+        elif activity == "reviewed":
+            q = Q(reviewed_by=user)
+        else:
+            q = Q(user=user) | Q(reviewed_by=user)
+        transcriptions = Transcription.objects.filter(q)
 
         qId = self.request.GET.get("campaign_slug", None)
 
@@ -538,11 +543,12 @@ class AccountProfileView(LoginRequiredMixin, FormView, ListView):
         obj_list = ctx.pop("object_list")
         ctx["object_list"] = object_list = []
 
-        ctx["active_tab"] = (
-            "pages"
-            if self.request.GET.get("page", None) is not None
-            else self.request.GET.get("tab", "contributions")
-        )
+        page = self.request.GET.get("page", None)
+        activity = self.request.GET.get("activity", None)
+        if page is not None and activity is not None:
+            ctx["active_tab"] = "pages"
+        else:
+            ctx["active_tab"] = self.request.GET.get("tab", "contributions")
         qId = self.request.GET.get("campaign_slug", None)
 
         if qId:

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -545,7 +545,7 @@ class AccountProfileView(LoginRequiredMixin, FormView, ListView):
 
         page = self.request.GET.get("page", None)
         activity = self.request.GET.get("activity", None)
-        if page is not None and activity is not None:
+        if page is not None or activity is not None:
             ctx["active_tab"] = "pages"
         else:
             ctx["active_tab"] = self.request.GET.get("tab", "contributions")


### PR DESCRIPTION
Add filtering to activity column in recent pages table as shown in mocks:
- At the top of the activity column an arrow will show/hide the filter.
- I can select to either see pages I have reviewed or pages I have transcribed
- I expect to be able to deactivate each filter, so that I can again see all data.