### PR TITLE
add celery workaround back in

### DIFF
--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -94,7 +94,9 @@ DATABASES = {
         "PASSWORD": os.getenv("POSTGRESQL_PW"),
         "HOST": os.getenv("POSTGRESQL_HOST", "localhost"),
         "PORT": os.getenv("POSTGRESQL_PORT", "5432"),
-        "CONN_MAX_AGE": 900,  # 15 minutes
+        # Change this back to 15 minutes (15*60) once celery regression
+        # is fixed  see https://github.com/celery/celery/issues/4878
+        "CONN_MAX_AGE": 0,  # 15 minutes
     }
 }
 


### PR DESCRIPTION
Trying to get past an issue with the period populate storage image task that wasn't an issue prior to upgrade. During the upgrade the workaround was removed.  