### PR TITLE
add test trigger on pull request for branches prefixed with feature-

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     push:
         branches: [main, release, 'feature-*']
     pull_request:
-        branches: [main]
+        branches: [main, 'feature-*']
 
 env:
     PIPENV_IGNORE_VIRTUALENVS: 1


### PR DESCRIPTION
CONCD-265 added a trigger on pull request for branches with a prefix of 'feature-'. 
The feature-retire-campaign was set up to work with an isolated AWS environment setup mostly via the Cloudformation featurebranch.yml. The decision was made to enforce Pull Requests and code reviews instead allow pushes directly to feature-retire-campaign branch/AWS environment. This change adds invoking test on pull request.