### PR TITLE
CONCD-270 add build GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,9 @@ name: 'Build'
 on:
     workflow_dispatch:
     push:
-        branches: [main, release]
+        branches: [main, release, 'feature-*']
     pull_request:
-        branches: [main]
+        branches: [main, 'feature-*']
 
 jobs:
     build:
@@ -15,7 +15,13 @@ jobs:
         steps:
             - name: Install system packages
               run: |
-                  sudo apt-get install -qy libmemcached-dev libz-dev libfreetype6-dev libtiff-dev libjpeg-dev libopenjp2-7-dev libwebp-dev zlib1g-dev libpq-dev
+                  sudo apt-get install -qy libmemcached-dev libz-dev libfreetype6-dev libtiff-dev \
+                    libjpeg-dev libopenjp2-7-dev libwebp-dev zlib1g-dev libpq-dev
+
+            - name: Install node and npm
+              uses: actions/setup-node@v3
+              with:
+                  node-version: '12'
 
             - name: Checkout repository
               uses: actions/checkout@v3
@@ -31,11 +37,19 @@ jobs:
             - name: Display Python version
               run: python -c "import sys; print(sys.version)"
 
-            - name: Install Dependencies
+            - name: Initialize venv install Dependencies
               run: |
+                  python3 -n venv venv-1
+                  source venv-1//bin/activate
                   python3 -m pip install --upgrade pip
                   pip3 install -U packaging
                   pip3 install -U setuptools
                   pip3 install -U pipenv
                   pipenv install --dev --system --deploy
                   python3 setup.py build
+
+            - name: build containers
+              run: |
+                  docker build -t concordia .
+                  docker build -t concordia/importer --file importer/Dockerfile .
+                  docker build -t concordia/celerybeat --file celerybeat/Dockerfile .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: 'Build'
+
+on:
+    workflow_dispatch:
+    push:
+        branches: [main, release]
+    pull_request:
+        branches: [main]
+
+jobs:
+    build:
+        name: Build
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Install system packages
+              run: |
+                  sudo apt-get install -qy libmemcached-dev libz-dev libfreetype6-dev libtiff-dev libjpeg-dev libopenjp2-7-dev libwebp-dev zlib1g-dev libpq-dev
+
+            - name: Checkout repository
+              uses: actions/checkout@v3
+
+            - name: Set up Python 3.10
+              uses: actions/setup-python@v4
+              with:
+                  # Semantic version range syntax or exact version of a Python version
+                  python-version: '3.10'
+                  # Optional - x64 or x86 architecture, defaults to x64
+                  architecture: 'x64'
+
+            - name: Display Python version
+              run: python -c "import sys; print(sys.version)"
+
+            - name: Install Dependencies
+              run: |
+                  python3 -m pip install --upgrade pip
+                  pip3 install -U packaging
+                  pip3 install -U setuptools
+                  pip3 install -U pipenv
+                  pipenv install --dev --system --deploy
+                  python3 setup.py build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
 
             - name: Initialize venv install Dependencies
               run: |
-                  python3 -n venv venv-1
+                  python3 -m venv venv-1
                   source venv-1//bin/activate
                   python3 -m pip install --upgrade pip
                   pip3 install -U packaging


### PR DESCRIPTION
Add build back into github workflows and include docker build. This is to flush out breaking builds before it gets to Jenkins (build/deploy to ECS).  

Unfortunately, can't test via workflow_dispatch until it's merged to main (default branch) .