### PR TITLE
Added status and dates to campaign admin list view and removed unused fields

### DIFF
--- a/concordia/admin/__init__.py
+++ b/concordia/admin/__init__.py
@@ -163,14 +163,23 @@ class CampaignAdmin(admin.ModelAdmin, CustomListDisplayFieldsMixin):
 
     list_display = (
         "title",
-        "short_description",
+        "status",
         "published",
         "unlisted",
         "display_on_homepage",
         "ordering",
-        "truncated_metadata",
+        "launch_date",
+        "completed_date",
     )
-    list_editable = ("display_on_homepage", "ordering", "published", "unlisted")
+    list_editable = (
+        "display_on_homepage",
+        "ordering",
+        "published",
+        "unlisted",
+        "status",
+        "launch_date",
+        "completed_date",
+    )
     list_display_links = ("title",)
     prepopulated_fields = {"slug": ("title",)}
     search_fields = ["title", "description"]


### PR DESCRIPTION
* Added status to campaign admin list view and removed unused fields

* Added started and completed dates to campaign admin list display

https://staff.loc.gov/tasks/browse/CONCD-244

This was previously merged into feature-retire-campaign, but is slated for the 7.2 release, so this pull request will add it to main.