### PR TITLE
Changed welcome-guide URLs to get-started

### DIFF
--- a/concordia/tests/test_top_level_views.py
+++ b/concordia/tests/test_top_level_views.py
@@ -96,7 +96,7 @@ class TopLevelViewTests(
 
     def test_simple_page(self):
         s = SimplePage.objects.create(
-            title="Welcome Guide 123",
+            title="Get Started 123",
             body="not the real body",
             path=reverse("welcome-guide"),
         )
@@ -111,7 +111,7 @@ class TopLevelViewTests(
 
     def test_nested_simple_page(self):
         l1 = SimplePage.objects.create(
-            title="Welcome Guide",
+            title="Get Started",
             body="not the real body",
             path=reverse("welcome-guide"),
         )

--- a/concordia/urls.py
+++ b/concordia/urls.py
@@ -95,7 +95,7 @@ urlpatterns = [
     # all links are updated.
     path(
         "help-center/",
-        RedirectView.as_view(pattern_name="welcome-guide"),
+        RedirectView.as_view(pattern_name="get-started"),
         name="help-center",
     ),
     path(
@@ -111,29 +111,27 @@ urlpatterns = [
     ),
     path("help-center/<slug:page_slug>/", views.HelpCenterRedirectView.as_view()),
     # End of help-center patterns
-    path("welcome-guide/", views.simple_page, name="welcome-guide"),
+    path("get-started/", views.simple_page, name="welcome-guide"),
+    path("get-started/how-to-transcribe/", views.simple_page, name="how-to-transcribe"),
+    path("get-started/how-to-review/", views.simple_page, name="how-to-review"),
+    path("get-started/how-to-tag/", views.simple_page, name="how-to-tag"),
     path(
-        "welcome-guide/how-to-transcribe/", views.simple_page, name="how-to-transcribe"
-    ),
-    path("welcome-guide/how-to-review/", views.simple_page, name="how-to-review"),
-    path("welcome-guide/how-to-tag/", views.simple_page, name="how-to-tag"),
-    path(
-        "welcome-guide-esp/",
+        "get-started-esp/",
         views.simple_page,
         name="welcome-guide-spanish",
     ),
     path(
-        "welcome-guide-esp/how-to-transcribe-esp/",
+        "get-started-esp/how-to-transcribe-esp/",
         views.simple_page,
         name="how-to-transcribe-spanish",
     ),
     path(
-        "welcome-guide-esp/how-to-review-esp/",
+        "get-started-esp/how-to-review-esp/",
         views.simple_page,
         name="how-to-review-spanish",
     ),
     path(
-        "welcome-guide-esp/how-to-tag-esp/",
+        "get-started-esp/how-to-tag-esp/",
         views.simple_page,
         name="how-to-tag-spanish",
     ),

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -2285,14 +2285,14 @@ class ReviewListView(AssetListView):
 class HelpCenterRedirectView(RedirectView):
     def get_redirect_url(self, *args, **kwargs):
         path = kwargs["page_slug"]
-        return "/welcome-guide/" + path
+        return "/get-started/" + path
 
 
 class HelpCenterSpanishRedirectView(RedirectView):
     def get_redirect_url(self, *args, **kwargs):
         print("spanish")
         path = kwargs["page_slug"]
-        return "/welcome-guide-esp/" + path + "-esp/"
+        return "/get-started-esp/" + path + "-esp/"
 
 
 # End of help-center views


### PR DESCRIPTION
Changed the URLs to use get-started instead of get-started in order to make the breadcrumbs correctly show Get Started.

https://staff.loc.gov/tasks/browse/CONCD-269