### PR TITLE
CONCD-287 Fixed campaign list page to match percentages on detail page

### DIFF
--- a/concordia/models.py
+++ b/concordia/models.py
@@ -119,20 +119,10 @@ class UnlistedPublicationQuerySet(PublicationQuerySet):
                     Round(100 * F("completed_count") * 1.0 / F("asset_count")),
                     output_field=models.FloatField(),
                 ),
-                submitted_percent=ExpressionWrapper(
+                needs_review_percent=ExpressionWrapper(
                     Round(100 * F("submitted_count") * 1.0 / F("asset_count")),
                     output_field=models.FloatField(),
                 ),
-                in_progress_percent=ExpressionWrapper(
-                    Round(100 * F("in_progress_count") * 1.0 / F("asset_count")),
-                    output_field=models.FloatField(),
-                ),
-            )
-            # We add these percentages together here after rounding (rather can adding
-            # the counts together first) in order to match the calculations used in
-            # the campaign detail view
-            .annotate(
-                needs_review_percent=F("submitted_percent") + F("in_progress_percent")
             )
         )
 

--- a/concordia/models.py
+++ b/concordia/models.py
@@ -7,7 +7,8 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db import models
-from django.db.models import Count, F, JSONField, Q
+from django.db.models import Count, ExpressionWrapper, F, JSONField, Q
+from django.db.models.functions import Round
 from django.urls import reverse
 from django_prometheus_metrics.models import MetricsModelMixin
 
@@ -110,10 +111,28 @@ class UnlistedPublicationQuerySet(PublicationQuerySet):
                     for k, v in STATUS_COUNT_KEYS.items()
                 }
             )
-            .annotate(needs_review_count=F("in_progress_count") + F("submitted_count"))
+            # PostgreSQL does integer division when given two integers, which results
+            # in the decimal results being dropped. We implicitly cast one field to
+            # be a float through multiplication in order to do floating point division
             .annotate(
-                completed_percent=100 * F("completed_count") / F("asset_count"),
-                submitted_percent=100 * F("needs_review_count") / F("asset_count"),
+                completed_percent=ExpressionWrapper(
+                    Round(100 * F("completed_count") * 1.0 / F("asset_count")),
+                    output_field=models.FloatField(),
+                ),
+                submitted_percent=ExpressionWrapper(
+                    Round(100 * F("submitted_count") * 1.0 / F("asset_count")),
+                    output_field=models.FloatField(),
+                ),
+                in_progress_percent=ExpressionWrapper(
+                    Round(100 * F("in_progress_count") * 1.0 / F("asset_count")),
+                    output_field=models.FloatField(),
+                ),
+            )
+            # We add these percentages together here after rounding (rather can adding
+            # the counts together first) in order to match the calculations used in
+            # the campaign detail view
+            .annotate(
+                needs_review_percent=F("submitted_percent") + F("in_progress_percent")
             )
         )
 

--- a/concordia/templates/transcriptions/campaign_topic_list.html
+++ b/concordia/templates/transcriptions/campaign_topic_list.html
@@ -44,23 +44,23 @@
                                 <div
                                     class="progress-bar bg-completed"
                                     role="progressbar"
-                                    style="width: {{ campaign.completed_percent }}%"
-                                    aria-valuenow="{{ campaign.completed_percent }}"
+                                    style="width: {{ campaign.completed_percent|floatformat:'0' }}%"
+                                    aria-valuenow="{{ campaign.completed_percent|floatformat:'0' }}"
                                 ></div>
                                 <div
                                     class="progress-bar bg-submitted"
                                     role="progressbar"
-                                    style="width: {{ campaign.submitted_percent }}%"
-                                    aria-valuenow="{{ campaign.submitted_percent }}"
+                                    style="width: {{ campaign.needs_review_percent|floatformat:'0' }}%"
+                                    aria-valuenow="{{ campaign.needs_review_percent|floatformat:'0' }}"
                                 ></div>
                             </div>
                             <div class="progress-bar-label">
                                 {% if campaign.completed_percent %}
-                                    <span>{{ campaign.completed_percent }}% Completed</span>
-                                    {% if campaign.submitted_percent %} | {%endif %}
+                                    <span>{{ campaign.completed_percent|floatformat:'0' }}% Completed</span>
+                                    {% if campaign.needs_review_percent %} | {%endif %}
                                 {% endif %}
-                                {% if campaign.submitted_percent %}
-                                    <span>{{ campaign.submitted_percent }}% Needs Review</span>
+                                {% if campaign.needs_review_percent %}
+                                    <span>{{ campaign.needs_review_percent|floatformat:'0' }}% Needs Review</span>
                                 {% endif %}
                             </div>
                         </div>


### PR DESCRIPTION
Also changed 'needs review' percentage on list page to not include 'in progress' assets.

https://staff.loc.gov/tasks/browse/CONCD-287