### PR TITLE
Concd 360 jkue build failing step17 dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN pip3 install pipenv
 WORKDIR /app
 COPY . /app
 
-RUN npm install --silent --global npm@8.19.4 && /usr/local/bin/npm install --silent && npx gulp build
+RUN npm install --silent --global npm@8.19 && /usr/local/bin/npm install --silent && npx gulp build
 
 RUN pipenv install --system --dev --deploy && rm -rf ~/.cache/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN pip3 install pipenv
 WORKDIR /app
 COPY . /app
 
-RUN npm install --silent --global npm@8.19.3 && /usr/local/bin/npm install --silent && npx gulp build
+RUN npm install --silent --global npm@8.19.4 && /usr/local/bin/npm install --silent && npx gulp build
 
 RUN pipenv install --system --dev --deploy && rm -rf ~/.cache/
 


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-360
This resolved the github build workflow npm notify that caused the build to fail. The npm version is now pinned at the minor version release vs patch.

Should buy us more time as we wait for Debian 12 (Bookworm) to be released and the Python 3.10 slim image to offer an updated base image version.