### PR TITLE
Concd 199 feature branch wait dataload

### DIFF
--- a/.cfnlintrc.yaml
+++ b/.cfnlintrc.yaml
@@ -1,0 +1,5 @@
+# The W2001 check is used to ignore the featurebranch.yaml DataLoadStackName parameter in the nested
+# stack fargate-featurebranch.yaml used to signal when the DataLoadHost UserData commands are complete.
+# Check if Parameters are Used
+ignore_checks:
+    - W2001

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ deploystatus.log
 artifacts/
 /.*
 !.gitignore
+!.cfnlintrc.yaml
 !.github
 !.dockerignore
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Build Status](https://travis-ci.org/LibraryOfCongress/concordia.svg?branch=main)](https://travis-ci.org/LibraryOfCongress/concordia)
+[![Lint](https://github.com/LibraryOfCongress/concordia/actions/workflows/black.yml/badge.svg)](https://github.com/LibraryOfCongress/concordia/actions/workflows/black.yml)
+[![Test](https://github.com/LibraryOfCongress/concordia/actions/workflows/test.yml/badge.svg)](https://github.com/LibraryOfCongress/concordia/actions/workflows/test.yml)
+[![Build](https://github.com/LibraryOfCongress/concordia/actions/workflows/build.yml/badge.svg)](https://github.com/LibraryOfCongress/concordia/actions/workflows/build.yml)
 [![Coverage Status](https://coveralls.io/repos/github/LibraryOfCongress/concordia/badge.svg?branch=main)](https://coveralls.io/github/LibraryOfCongress/concordia?branch=main)
 
 # Welcome to Concordia

--- a/cloudformation/featurebranch.yaml
+++ b/cloudformation/featurebranch.yaml
@@ -70,3 +70,4 @@ Resources:
                 MemcachedPort: !GetAtt ElastiCache.Outputs.MemcachedPort
                 DatabaseEndpoint: !GetAtt RDS.Outputs.DatabaseHostName
                 Priority: !Ref Priority
+                DataLoadStackName: !GetAtt DataLoadHost.Outputs.StackName

--- a/cloudformation/infrastructure/data-load.yaml
+++ b/cloudformation/infrastructure/data-load.yaml
@@ -82,16 +82,14 @@ Resources:
                     echo "Running userdata for ${EnvironmentName}"
                     echo "export ENV_NAME=${EnvironmentName}" >> /home/ec2-user/.bash_profile
                     source /home/ec2-user/.bash_profile
-                    yum -y update aws-cfn-bootsrap
+                    yum -y update
                     amazon-linux-extras install -y postgresql12
                     aws s3 cp s3://crowd-deployment/database-dumps/concordia.latest.dmp concordia.dmp
                     echo "${PostgresqlHost}:5432:*:concordia:${PostgresqlPassword}" >> /root/.pgpass
                     chmod 0600 /root/.pgpass
-                    psql -U concordia -h "$POSTGRESQL_HOST" -d postgres -c "select pg_terminate_backend(pid) from pg_stat_activity where datname='concordia';"
-                    psql -U concordia -h "$POSTGRESQL_HOST" -d postgres -c "drop database concordia;"
                     pg_restore --create -Fc -U concordia -h ${PostgresqlHost} --dbname=postgres --no-password --no-owner --no-acl concordia.dmp
-                    # Signal the status from cfn-init
-                    /opt/aws/bin/cfn-signal -e 0 -r \"Instance Creation Complete\", { "Ref" : "WaitHandle" }
+                    # Signal the status from cfn-init #jkue need ssh keys for this to work
+                    # cloudformation/infrastructure/data-load.yaml/opt/aws/bin/cfn-signal -e 0 -r \"Instance Creation Complete\", { "Ref" : "WaitHandle" }
                     shutdown -h now
             Tags:
                 - Key: Name
@@ -102,5 +100,5 @@ Resources:
         Type: AWS::CloudFormation::WaitCondition
         DependsOn: DataLoadHost
         Properties:
-            Handle: !Ref 'WaitHandle'
+            Handle: Ref 'WaitHandle'
             Timeout: '1800'

--- a/cloudformation/infrastructure/data-load.yaml
+++ b/cloudformation/infrastructure/data-load.yaml
@@ -24,7 +24,7 @@ Parameters:
 Mappings:
     AWSRegionToAMI:
         us-east-1:
-            AMI: ami-0806bc468ce3a22ec #ami-0cabc39acf991f4f1
+            AMI: ami-0806bc468ce3a22ec
 
     EnvironmentMapping:
         IamInstanceProfileName:
@@ -91,7 +91,7 @@ Resources:
                     psql -U concordia -h "$POSTGRESQL_HOST" -d postgres -c "select pg_terminate_backend(pid) from pg_stat_activity where datname='concordia';"
                     psql -U concordia -h "$POSTGRESQL_HOST" -d postgres -c "drop database concordia;"
                     pg_restore --create -Fc -U concordia -h ${PostgresqlHost} --dbname=postgres --no-password --no-owner --no-acl concordia.dmp
-                    # Signal the status from cfn-init  #jkue need ssh keys for ec2-user for this to work
+                    # Signal the status from cfn-init
                     /opt/aws/bin/cfn-signal -e 0 -r \"Instance Creation Complete\", { "Ref" : "WaitHandle" }
                     shutdown -h now
             Tags:
@@ -105,4 +105,3 @@ Resources:
         Properties:
             Handle: !Ref 'WaitHandle'
             Timeout: '2000'
-            Count: '1'

--- a/cloudformation/infrastructure/data-load.yaml
+++ b/cloudformation/infrastructure/data-load.yaml
@@ -50,6 +50,9 @@ Mappings:
 Resources:
     DataLoadHost:
         Type: AWS::EC2::Instance
+        CreationPolicy:
+            ResourceSignal:
+                Timeout: PT30M
         Properties:
             ImageId:
                 Fn::FindInMap:
@@ -79,29 +82,25 @@ Resources:
             UserData:
                 Fn::Base64: !Sub |
                     #!/bin/bash -xe
+                    trap '/opt/aws/bin/cfn-signal --exit-code 1 --resource DataLoadHost --region ${AWS::Region} --stack ${AWS::StackName}' ERR
                     echo "Running userdata for ${EnvironmentName}"
                     echo "export ENV_NAME=${EnvironmentName}" >> /home/ec2-user/.bash_profile
                     source /home/ec2-user/.bash_profile
                     yum -y update
                     amazon-linux-extras install -y postgresql12
                     aws s3 cp s3://crowd-deployment/database-dumps/concordia.latest.dmp concordia.dmp
-                    sleep 600
                     echo "${PostgresqlHost}:5432:*:concordia:${PostgresqlPassword}" >> /root/.pgpass
                     chmod 0600 /root/.pgpass
-                    psql -U concordia -h "$POSTGRESQL_HOST" -d postgres -c "select pg_terminate_backend(pid) from pg_stat_activity where datname='concordia';"
-                    psql -U concordia -h "$POSTGRESQL_HOST" -d postgres -c "drop database concordia;"
+                    psql -U concordia -h ${PostgresqlHost} -d postgres -c "select pg_terminate_backend(pid) from pg_stat_activity where datname='concordia';"
+                    psql -U concordia -h ${PostgresqlHost} -d postgres -c "drop database concordia;"
                     pg_restore --create -Fc -U concordia -h ${PostgresqlHost} --dbname=postgres --no-password --no-owner --no-acl concordia.dmp
                     # Signal the status from cfn-init
-                    /opt/aws/bin/cfn-signal -e 0 -r \"Instance Creation Complete\", { "Ref" : "WaitHandle" }
+                    /opt/aws/bin/cfn-signal --exit-code 0 --resource DataLoadHost --region ${AWS::Region} --stack ${AWS::StackName}
                     shutdown -h now
             Tags:
                 - Key: Name
                   Value: !Sub ${EnvironmentName}-DataLoadHost
-    WaitHandle:
-        Type: AWS::CloudFormation::WaitConditionHandle
-    WaitCondition:
-        Type: AWS::CloudFormation::WaitCondition
-        DependsOn: DataLoadHost
-        Properties:
-            Handle: !Ref 'WaitHandle'
-            Timeout: '2000'
+Outputs:
+    StackName:
+        Description: 'Stackname for the DataLoadHost'
+        Value: !Ref AWS::StackName

--- a/cloudformation/infrastructure/data-load.yaml
+++ b/cloudformation/infrastructure/data-load.yaml
@@ -82,15 +82,25 @@ Resources:
                     echo "Running userdata for ${EnvironmentName}"
                     echo "export ENV_NAME=${EnvironmentName}" >> /home/ec2-user/.bash_profile
                     source /home/ec2-user/.bash_profile
-                    sudo yum -y update
-                    sudo amazon-linux-extras install -y postgresql12
+                    yum -y update aws-cfn-bootsrap
+                    amazon-linux-extras install -y postgresql12
                     aws s3 cp s3://crowd-deployment/database-dumps/concordia.latest.dmp concordia.dmp
                     echo "${PostgresqlHost}:5432:*:concordia:${PostgresqlPassword}" >> /root/.pgpass
                     chmod 0600 /root/.pgpass
                     psql -U concordia -h "$POSTGRESQL_HOST" -d postgres -c "select pg_terminate_backend(pid) from pg_stat_activity where datname='concordia';"
                     psql -U concordia -h "$POSTGRESQL_HOST" -d postgres -c "drop database concordia;"
                     pg_restore --create -Fc -U concordia -h ${PostgresqlHost} --dbname=postgres --no-password --no-owner --no-acl concordia.dmp
+                    # Signal the status from cfn-init
+                    /opt/aws/bin/cfn-signal -e 0 -r \"Instance Creation Complete\", { "Ref" : "WaitHandle" }
                     shutdown -h now
             Tags:
                 - Key: Name
                   Value: !Sub ${EnvironmentName}-DataLoadHost
+    WaitHandle:
+        Type: AWS::CloudFormation::WaitConditionHandle
+    WaitCondition:
+        Type: AWS::CloudFormation::WaitCondition
+        DependsOn: DataLoadHost
+        Properties:
+            Handle: !Ref 'WaitHandle'
+            Timeout: '1800'

--- a/cloudformation/infrastructure/data-load.yaml
+++ b/cloudformation/infrastructure/data-load.yaml
@@ -24,7 +24,7 @@ Parameters:
 Mappings:
     AWSRegionToAMI:
         us-east-1:
-            AMI: ami-0cabc39acf991f4f1
+            AMI: ami-0806bc468ce3a22ec #ami-0cabc39acf991f4f1
 
     EnvironmentMapping:
         IamInstanceProfileName:
@@ -84,7 +84,6 @@ Resources:
                     source /home/ec2-user/.bash_profile
                     yum -y update
                     amazon-linux-extras install -y postgresql12
-                    # yum install -y aws-cfn-bootsrap
                     aws s3 cp s3://crowd-deployment/database-dumps/concordia.latest.dmp concordia.dmp
                     sleep 600
                     echo "${PostgresqlHost}:5432:*:concordia:${PostgresqlPassword}" >> /root/.pgpass
@@ -93,16 +92,17 @@ Resources:
                     psql -U concordia -h "$POSTGRESQL_HOST" -d postgres -c "drop database concordia;"
                     pg_restore --create -Fc -U concordia -h ${PostgresqlHost} --dbname=postgres --no-password --no-owner --no-acl concordia.dmp
                     # Signal the status from cfn-init  #jkue need ssh keys for ec2-user for this to work
-                    # /opt/aws/bin/cfn-signal -e 0 -r \"Instance Creation Complete\", { "Ref" : "WaitHandle" }
+                    /opt/aws/bin/cfn-signal -e 0 -r \"Instance Creation Complete\", { "Ref" : "WaitHandle" }
                     shutdown -h now
             Tags:
                 - Key: Name
                   Value: !Sub ${EnvironmentName}-DataLoadHost
-    # WaitHandle:
-    #     Type: AWS::CloudFormation::WaitConditionHandle
-    # WaitCondition:
-    #     Type: AWS::CloudFormation::WaitCondition
-    #     DependsOn: DataLoadHost
-    #     Properties:
-    #         Handle: Ref 'WaitHandle'
-    #         Timeout: '1800'
+    WaitHandle:
+        Type: AWS::CloudFormation::WaitConditionHandle
+    WaitCondition:
+        Type: AWS::CloudFormation::WaitCondition
+        DependsOn: DataLoadHost
+        Properties:
+            Handle: !Ref 'WaitHandle'
+            Timeout: '2000'
+            Count: '1'

--- a/cloudformation/infrastructure/data-load.yaml
+++ b/cloudformation/infrastructure/data-load.yaml
@@ -84,21 +84,25 @@ Resources:
                     source /home/ec2-user/.bash_profile
                     yum -y update
                     amazon-linux-extras install -y postgresql12
+                    # yum install -y aws-cfn-bootsrap
                     aws s3 cp s3://crowd-deployment/database-dumps/concordia.latest.dmp concordia.dmp
+                    sleep 600
                     echo "${PostgresqlHost}:5432:*:concordia:${PostgresqlPassword}" >> /root/.pgpass
                     chmod 0600 /root/.pgpass
+                    psql -U concordia -h "$POSTGRESQL_HOST" -d postgres -c "select pg_terminate_backend(pid) from pg_stat_activity where datname='concordia';"
+                    psql -U concordia -h "$POSTGRESQL_HOST" -d postgres -c "drop database concordia;"
                     pg_restore --create -Fc -U concordia -h ${PostgresqlHost} --dbname=postgres --no-password --no-owner --no-acl concordia.dmp
-                    # Signal the status from cfn-init #jkue need ssh keys for this to work
-                    # cloudformation/infrastructure/data-load.yaml/opt/aws/bin/cfn-signal -e 0 -r \"Instance Creation Complete\", { "Ref" : "WaitHandle" }
+                    # Signal the status from cfn-init  #jkue need ssh keys for ec2-user for this to work
+                    # /opt/aws/bin/cfn-signal -e 0 -r \"Instance Creation Complete\", { "Ref" : "WaitHandle" }
                     shutdown -h now
             Tags:
                 - Key: Name
                   Value: !Sub ${EnvironmentName}-DataLoadHost
-    WaitHandle:
-        Type: AWS::CloudFormation::WaitConditionHandle
-    WaitCondition:
-        Type: AWS::CloudFormation::WaitCondition
-        DependsOn: DataLoadHost
-        Properties:
-            Handle: Ref 'WaitHandle'
-            Timeout: '1800'
+    # WaitHandle:
+    #     Type: AWS::CloudFormation::WaitConditionHandle
+    # WaitCondition:
+    #     Type: AWS::CloudFormation::WaitCondition
+    #     DependsOn: DataLoadHost
+    #     Properties:
+    #         Handle: Ref 'WaitHandle'
+    #         Timeout: '1800'

--- a/cloudformation/infrastructure/fargate-featurebranch.yaml
+++ b/cloudformation/infrastructure/fargate-featurebranch.yaml
@@ -71,6 +71,10 @@ Parameters:
         Description: Priority of the subdomain listener rule, must be unique in the set of listener rules
         Default: 100
 
+    DataLoadStackName:
+        Type: String
+        Description: Signal that the DataLoadHost UserData has completed
+
 Resources:
     ConcordiaAppLogsGroup:
         Type: AWS::Logs::LogGroup

--- a/cloudformation/infrastructure/rds.yaml
+++ b/cloudformation/infrastructure/rds.yaml
@@ -49,7 +49,7 @@ Resources:
             PreferredMaintenanceWindow: sun:07:14-sun:07:44
             DBName: concordia
             Engine: postgres
-            EngineVersion: '12.8'
+            EngineVersion: '12.11'
             LicenseModel: postgresql-license
             DBSubnetGroupName:
                 Ref: PostgresSubnetGroup


### PR DESCRIPTION
CONCD-199 This PR should resolve the duplicate data issue that occurs when the featurebranch.yaml cfn stack is launched that further causes the feature branch app container to not start successfully. This cfn stack contains nested cfn templates. The FargateCluster stack would launch before DataLoadHost UserData (pg_restore) completed causing duplicate data errors and unique indexes from being created - because both the DataLoadHost and the app and celerybeat containers in the FargateCluster were writing to the database at the same time (celerybeat tasking, app migrations, etc.).

Cfn sends a create complete signal as soon as the DataLoadHost's EC2 instance is created regardless of the status of UserData instructions. The FargateCluster had no dependency on the DataLoadHost.

A DataLoadHost completion signal using cfn signal helper scripts, cfn output and input parameter to featurebranch cloudformation nested stack was added so the FargateCluster nested stack will wait for signal parameter.

This change also resolves the issue of the DataLoadHost not shutting down at the end of UserData which appears to be a result of of the pg_restore errors.

