### PR TITLE
Fixed empty link error on pagination

### DIFF
--- a/concordia/static/scss/base.scss
+++ b/concordia/static/scss/base.scss
@@ -1291,3 +1291,16 @@ table.table thead.border-y th {
 .view-user-profile .nav-tabs .nav-item.show .nav-link {
     border-color: #000 #000 #fff;
 }
+
+/* Accessibility */
+.visually-hidden {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
+}

--- a/concordia/templates/fragments/standard-pagination.html
+++ b/concordia/templates/fragments/standard-pagination.html
@@ -12,7 +12,7 @@ paginator, and page_obj variables defined.
             {% if page_obj.has_previous %}
                 <li class="page-item">
                     <a class="page-link" href="?{% qs_alter request.GET page=page_obj.previous_page_number %}" aria-title="Previous Page">
-                        <span class="fas fa-chevron-left"></span>
+                        <span class="fas fa-chevron-left"><span class="visually-hidden">Previous Page</span></span>
                     </a>
                 </li>
             {% else %}
@@ -83,8 +83,8 @@ paginator, and page_obj variables defined.
 
             {% if page_obj.has_next %}
                 <li class="page-item">
-                    <a class="page-link" href="?{% qs_alter request.GET page=page_obj.next_page_number %}">
-                        <span class="fas fa-chevron-right"></span>
+                    <a class="page-link" href="?{% qs_alter request.GET page=page_obj.next_page_number %}" aria-title="Next Page">
+                        <span class="fas fa-chevron-right"><span class="visually-hidden">Next Page</span></span>
                     </a>
                 </li>
             {% else %}


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-337

Also added a style to hidden elements visually but still have them appear for screen readers.

The low contrast errors mentioned in the ticket were resolved when we changed the progress bar display for project/item pages, based on what I could find.