### PR TITLE
Fixed reconfirmation email to properly send to the new email address instead of the old

### DIFF
--- a/concordia/templates/emails/email_reconfirmation_body.txt
+++ b/concordia/templates/emails/email_reconfirmation_body.txt
@@ -3,7 +3,7 @@ To complete your email change, please verify your email address in the next {{ e
 
 https://{{ site }}{% url "email-reconfirmation" confirmation_key %}
 
-Once its verified, your email will be active on your account, and your previous email address will no longer be used.
+Once it's verified, your email will be active on your account, and your previous email address will no longer be used.
 
 Happy transcribing,
 -- The By the People team

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -605,7 +605,18 @@ class AccountProfileView(LoginRequiredMixin, FormView, ListView):
             context=context,
             request=self.request,
         )
-        user.email_user(subject, message, settings.DEFAULT_FROM_EMAIL)
+        try:
+            send_mail(
+                subject,
+                message=message,
+                from_email=settings.DEFAULT_FROM_EMAIL,
+                recipient_list=[user.get_email_for_reconfirmation()],
+            )
+        except SMTPException:
+            logger.exception(
+                "Unable to send email reconfirmation to %s",
+                user.get_email_for_reconfirmation(),
+            )
 
 
 @method_decorator(default_cache_control, name="dispatch")


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-66