### PR TITLE
CONCD-480 Link styling

### DIFF
--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -407,7 +407,7 @@
                                     {% endif %}
                                 {% endif %}
                             </span>
-                            <a class="align-self-end" data-toggle="modal" data-target="#tutorial-popup">
+                            <a class="align-self-end font-weight-bold" data-toggle="modal" data-target="#tutorial-popup" role="button">
                                 Quick Tips
                             </a>
                         </div>


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-480

- Link text should be bolded
- Cursor should change to a hand when hovering over the link.