### PR TITLE
Fixing potentially unsafe external links

### DIFF
--- a/concordia/templates/admin/bulk_import.html
+++ b/concordia/templates/admin/bulk_import.html
@@ -28,7 +28,7 @@
             <ul>
                 {% for import_job in import_jobs %}
                     <li>
-                        <a target="_blank" href="{% url 'admin:importer_importjob_change' object_id=import_job.pk %}">{{ import_job }}</a>
+                        <a target="_blank" rel=noopener href="{% url 'admin:importer_importjob_change' object_id=import_job.pk %}">{{ import_job }}</a>
                     </li>
                 {% endfor %}
             </ul>

--- a/concordia/templates/admin/bulk_review.html
+++ b/concordia/templates/admin/bulk_review.html
@@ -28,7 +28,7 @@
             <ul>
                 {% for import_job in import_jobs %}
                     <li>
-                        <a target="_blank" href="{% url 'admin:importer_importjob_change' object_id=import_job.pk %}">{{ import_job }}</a>
+                        <a target="_blank" rel=noopener href="{% url 'admin:importer_importjob_change' object_id=import_job.pk %}">{{ import_job }}</a>
                     </li>
                 {% endfor %}
             </ul>

--- a/concordia/templates/admin/concordia/project/item_import.html
+++ b/concordia/templates/admin/concordia/project/item_import.html
@@ -7,17 +7,17 @@
     <div id="content-main">
         {% if import_job %}
             <p>
-                Task ID <a target="_blank" href="{% url 'admin:importer_importjob_change' object_id=import_job.pk %}">{{ import_job }}</a>
-                created to import <a target="_blank" href="{{ form.cleaned_data.import_url }}">{{ form.cleaned_data.import_url }}</a>
+                Task ID <a target="_blank" rel=noopener href="{% url 'admin:importer_importjob_change' object_id=import_job.pk %}">{{ import_job }}</a>
+                created to import <a target="_blank" rel=noopener href="{{ form.cleaned_data.import_url }}">{{ form.cleaned_data.import_url }}</a>
             </p>
             <ul>
                 <li>
-                    <a target="_blank" href="{% url 'admin:concordia_item_changelist' %}?project__pk={{ object_id }}">
+                    <a target="_blank" rel=noopener href="{% url 'admin:concordia_item_changelist' %}?project__pk={{ object_id }}">
                         View Project Items
                     </a>
                 </li>
                 <li>
-                    <a target="_blank" href="{% url 'admin:concordia_asset_changelist' %}?project__pk={{ object_id }}">
+                    <a target="_blank" rel=noopener href="{% url 'admin:concordia_asset_changelist' %}?project__pk={{ object_id }}">
                         View Project Assets
                     </a>
                 </li>

--- a/concordia/templates/admin/redownload_images.html
+++ b/concordia/templates/admin/redownload_images.html
@@ -43,14 +43,14 @@
                             {{ forloop.counter }}
                         </td>
                         <td>
-                            <a target="_blank" href="{% url 'admin:concordia_asset_change' object_id=asset.pk %}">{{ asset }}</a>
+                            <a target="_blank" rel=noopener href="{% url 'admin:concordia_asset_change' object_id=asset.pk %}">{{ asset }}</a>
                         </td>
                         <td>{{ asset.download_url }}</td>
                         <td><a href="{{ asset.get_absolute_url }}">{{ asset.get_absolute_url }}</a></td>
                         <td>{{ asset.published }}</td>
                         <td>{{ asset.transcription_status }}</td>
                         <td>{% if asset.correct_asset_pk %}
-                            <a target="_blank" href="{% url 'admin:concordia_asset_change' object_id=asset.correct_asset_pk %}">{{ asset.correct_asset_slug }}</a>
+                            <a target="_blank" rel=noopener href="{% url 'admin:concordia_asset_change' object_id=asset.correct_asset_pk %}">{{ asset.correct_asset_slug }}</a>
                         {% endif %}
                         </td>
                         <td><pre>{{ asset.latest_transcription.text }}</pre></td>

--- a/concordia/templates/fragments/sharing-button-group.html
+++ b/concordia/templates/fragments/sharing-button-group.html
@@ -1,5 +1,5 @@
 <div class="concordia-share-button-group btn-group" role="navigation" aria-label="Links to share this page">
     <a class="facebook-share-button btn btn-link px-1 py-0" target="_blank" role="button" title="Share this page on Facebook" href="https://www.facebook.com/share.php?u={{ url|urlencode:"" }}"><span class="bitmap-icon facebook-icon"></span></a>
     <a class="twitter-share-button btn btn-link px-1 py-0" target="_blank" role="button" title="Share this page on Twitter" href="https://twitter.com/intent/tweet?text={% filter urlencode %}”{{ title }}” {{ url }} #ByThePeople @Crowd_LOC{% endfilter %}&amp;source=webclient"><span class="bitmap-icon twitter-icon"></span></a>
-    <a class="copy-url-button btn btn-link px-1 py-0" target="_blank" role="button" data-toggle="tooltip" data-trigger="manual" data-placement="bottom" aria-label="Copy this link to your clipboard" href="{{ url }}"><span class="bitmap-icon copy-link-icon"></span></a>
+    <a class="copy-url-button btn btn-link px-1 py-0" target="_blank" rel=noopener role="button" data-toggle="tooltip" data-trigger="manual" data-placement="bottom" aria-label="Copy this link to your clipboard" href="{{ url }}"><span class="bitmap-icon copy-link-icon"></span></a>
 </div>

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -77,7 +77,7 @@
                 <div class="btn-group align-self-end">
                     {% if asset.resource_url %}
                         <div class="btn-group-sm p-1" role="navigation" aria-label="Link to the original source for this item">
-                            <a class="btn btn-outline-primary text-nowrap" target="_blank" title="View the original source for this item in a new tab" href="{{ asset.resource_url }}{% if 'sp=' not in asset.resource_url %}?sp={{ asset.sequence }}{% endif %}">View on www.loc.gov <i class="fa fa-external-link-alt"></i></a>
+                            <a class="btn btn-outline-primary text-nowrap" target="_blank" rel=noopener title="View the original source for this item in a new tab" href="{{ asset.resource_url }}{% if 'sp=' not in asset.resource_url %}?sp={{ asset.sequence }}{% endif %}">View on www.loc.gov <i class="fa fa-external-link-alt"></i></a>
                         </div>
                     {% endif %}
 

--- a/concordia/templates/transcriptions/campaign_detail.html
+++ b/concordia/templates/transcriptions/campaign_detail.html
@@ -107,9 +107,9 @@
                             <ul class="list-unstyled m-0">
                                 {% for resource in campaign.resource_set.related_links %}
                                     {% if 'loc.gov' in resource.resource_url   %}
-                                        <li class="mb-3"><a href="{{ resource.resource_url }}" target="_blank">{{ resource.title }}</a></li>
+                                        <li class="mb-3"><a href="{{ resource.resource_url }}" target="_blank" rel=noopener>{{ resource.title }}</a></li>
                                     {%else%}
-                                        <li class="mb-3"><a href="{{ resource.resource_url }}" target="_blank">{{ resource.title }} <i class="fa fa-external-link-alt"></i></a></li>
+                                        <li class="mb-3"><a href="{{ resource.resource_url }}" target="_blank" rel=noopener>{{ resource.title }} <i class="fa fa-external-link-alt"></i></a></li>
                                     {% endif %}
                                 {% endfor %}
                             </ul>

--- a/concordia/templates/transcriptions/campaign_detail_completed.html
+++ b/concordia/templates/transcriptions/campaign_detail_completed.html
@@ -48,7 +48,7 @@
                                     {% else %}
                                         <li class="mb-3">
                                     {% endif %}
-                                    <a class="underline-link" href="{{ resource.resource_url }}" target="_blank">{{ resource.title }}</a>
+                                    <a class="underline-link" href="{{ resource.resource_url }}" target="_blank" rel=noopener>{{ resource.title }}</a>
                                     {% if 'loc.gov' not in resource.resource_url  %}
                                         <i class="fa fa-external-link-alt"></i>
                                     {% endif %}
@@ -107,7 +107,7 @@
                                     {% else %}
                                         <li class="mb-3">
                                     {% endif %}
-                                    <a class="underline-link" href="{{ resource.resource_url }}" target="_blank">{{ resource.title }}</a>
+                                    <a class="underline-link" href="{{ resource.resource_url }}" target="_blank" rel=noopener>{{ resource.title }}</a>
                                     {% if 'loc.gov' not in resource.resource_url  %}
                                         <i class="fa fa-external-link-alt"></i>
                                     {% endif %}

--- a/concordia/templates/transcriptions/campaign_detail_retired.html
+++ b/concordia/templates/transcriptions/campaign_detail_retired.html
@@ -48,7 +48,7 @@
                                     {% else %}
                                         <li class="mb-3">
                                     {% endif %}
-                                    <a class="underline-link" href="{{ resource.resource_url }}" target="_blank">{{ resource.title }}</a>
+                                    <a class="underline-link" href="{{ resource.resource_url }}" target="_blank" rel=noopener>{{ resource.title }}</a>
                                     {% if 'loc.gov' not in resource.resource_url  %}
                                         <i class="fa fa-external-link-alt"></i>
                                     {% endif %}
@@ -79,7 +79,7 @@
                                     {% else %}
                                         <li class="mb-3">
                                     {% endif %}
-                                    <a class="underline-link" href="{{ resource.resource_url }}" target="_blank">{{ resource.title }}</a>
+                                    <a class="underline-link" href="{{ resource.resource_url }}" target="_blank" rel=noopener>{{ resource.title }}</a>
                                     {% if 'loc.gov' not in resource.resource_url  %}
                                         <i class="fa fa-external-link-alt"></i>
                                     {% endif %}

--- a/concordia/templates/transcriptions/item_detail.html
+++ b/concordia/templates/transcriptions/item_detail.html
@@ -32,7 +32,7 @@
             </div>
             <div class="col-md-2 align-bottom">
                 <div>
-                    <a href="{{ item.item_url }}" class="btn btn-light" title="View the original source for this item in a new tab" target="_blank">View this item on www.loc.gov<i class="fa fa-external-link-alt"></i></a>
+                    <a href="{{ item.item_url }}" class="btn btn-light" title="View the original source for this item in a new tab" target="_blank" rel=noopener>View this item on www.loc.gov<i class="fa fa-external-link-alt"></i></a>
                 </div>
             </div>
         </div>

--- a/concordia/templates/transcriptions/topic_detail.html
+++ b/concordia/templates/transcriptions/topic_detail.html
@@ -31,9 +31,9 @@
                         <ul class="list-unstyled m-0">
                             {% for resource in topic.resource_set.all %}
                                 {% if 'loc.gov' in resource.resource_url   %}
-                                    <li class="mb-3"><a href="{{ resource.resource_url }}" target="_blank">{{ resource.title }}</a></li>
+                                    <li class="mb-3"><a href="{{ resource.resource_url }}" target="_blank" rel=noopener>{{ resource.title }}</a></li>
                                 {% else %}
-                                    <li class="mb-3"><a href="{{ resource.resource_url }}" target="_blank">{{ resource.title }} <i class="fa fa-external-link-alt"></i></a></li>
+                                    <li class="mb-3"><a href="{{ resource.resource_url }}" target="_blank" rel=noopener>{{ resource.title }} <i class="fa fa-external-link-alt"></i></a></li>
                                 {% endif %}
                             {% endfor %}
                         </ul>


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-543

Many of these are false positives, but adding rel=noopener also doesn't hurt anything in our use cases, so this will eliminate all these alerts.