### PR TITLE
Added support other languages in the OCR backend and the ability to set a list of allowed languages

### DIFF
--- a/concordia/models.py
+++ b/concordia/models.py
@@ -484,8 +484,18 @@ class Asset(MetricsModelMixin("asset"), models.Model):
     def latest_transcription(self):
         return self.transcription_set.order_by("-pk").first()
 
-    def get_ocr_transcript(self):
-        return pytesseract.image_to_string(Image.open(self.storage_image))
+    def get_ocr_transcript(self, language=None):
+        if language and language not in settings.PYTESSERACT_ALLOWED_LANGUAGES:
+            logger.warning(
+                "OCR language '%s' not in settings.PYTESSERACT_ALLOWED_LANGUAGES. "
+                "Allowed languages: %s",
+                language,
+                settings.PYTESSERACT_ALLOWED_LANGUAGES,
+            )
+            language = None
+        return pytesseract.image_to_string(
+            Image.open(self.storage_image), lang=language
+        )
 
     def get_contributor_count(self):
         transcriptions = Transcription.objects.filter(asset=self)

--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -399,3 +399,5 @@ TINYMCE_DEFAULT_CONFIG = {
     "content_css": "dark",
 }
 TINYMCE_JS_URL = "https://cdn.tiny.cloud/1/rf486i5f1ww9m8191oolczn7f0ry61mzdtfwbu7maiiiv2kv/tinymce/6/tinymce.min.js"
+
+PYTESSERACT_ALLOWED_LANGUAGES = ["eng"]

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -1362,7 +1362,7 @@ def generate_ocr_transcription(request, *, asset_pk):
         user = request.user
 
     supersedes_pk = request.POST.get("supersedes")
-    language = request.POST.get("language", "spa")
+    language = request.POST.get("language")
     superseded = get_transcription_superseded(asset, supersedes_pk)
     if superseded and isinstance(superseded, HttpResponse):
         return superseded

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -1362,10 +1362,11 @@ def generate_ocr_transcription(request, *, asset_pk):
         user = request.user
 
     supersedes_pk = request.POST.get("supersedes")
+    language = request.POST.get("language", "spa")
     superseded = get_transcription_superseded(asset, supersedes_pk)
     if superseded and isinstance(superseded, HttpResponse):
         return superseded
-    transcription_text = asset.get_ocr_transcript()
+    transcription_text = asset.get_ocr_transcript(language)
     transcription = Transcription(
         asset=asset,
         user=user,


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-600

This is just the basic implementation. The only allowed language is English at the moment, and if any other language is sent from the client (or if nothing is, as is currently the case since the frontend hasn't changed), it uses the default language which is English anyway.

The only change to this code that will be required when changing the frontend is adding additional allowed languages.