### PR TITLE
Removed flag middleware

### DIFF
--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -138,7 +138,6 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django_ratelimit.middleware.RatelimitMiddleware",
-    "flags.middleware.FlagConditionsMiddleware",
 ]
 
 RATELIMIT_VIEW = "concordia.views.ratelimit_view"


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-621

Very simple change because django-flags added it's functionality to other code (with lazy loading.)