### PR TITLE
Revert "Bump follow-redirects from 1.15.3 to 1.15.4"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4303,9 +4303,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.4",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-            "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+            "version": "1.15.3",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+            "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
             "dev": true,
             "funding": [
                 {
@@ -14410,9 +14410,9 @@
             }
         },
         "follow-redirects": {
-            "version": "1.15.4",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-            "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+            "version": "1.15.3",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+            "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
             "dev": true
         },
         "for-in": {


### PR DESCRIPTION
Reverts LibraryOfCongress/concordia#2228

app container healthz check and metrics are failing - ECS can't reach a steady state.
Need to troubleshoot that first.