### PR TITLE
Updates to the next-transcribable and next-reviewable views

### DIFF
--- a/concordia/models.py
+++ b/concordia/models.py
@@ -174,32 +174,20 @@ class UnlistedPublicationQuerySet(PublicationQuerySet):
     def unlisted(self):
         return self.filter(unlisted=True)
 
-    def get_next_transcription_campaign(self):
-        try:
-            return self.get(next_transcription_campaign=True)
-        except Campaign.DoesNotExist:
-            # If no campaign is configured, we use the latest to launch
-            return self.published().listed().latest("launch_date")
-        except Campaign.MultipleObjectsReturned:
-            return (
-                self.published()
-                .listed()
-                .filter(next_transcription_campaign=True)
-                .latest("launch_date")
-            )
+    def active(self):
+        return self.filter(status=Campaign.Status.ACTIVE)
 
-    def get_next_review_campaign(self):
-        try:
-            return self.get(next_review_campaign=True)
-        except Campaign.DoesNotExist:
-            return self.published().listed().latest("launch_date")
-        except Campaign.MultipleObjectsReturned:
-            return (
-                self.published()
-                .listed()
-                .filter(next_review_campaign=True)
-                .latest("launch_date")
-            )
+    def completed(self):
+        return self.filter(status=Campaign.Status.COMPLETED)
+
+    def retired(self):
+        return self.filter(status=Campaign.Status.RETIRED)
+
+    def get_next_transcription_campaigns(self):
+        return self.filter(next_transcription_campaign=True)
+
+    def get_next_review_campaigns(self):
+        return self.filter(next_review_campaign=True)
 
 
 class Campaign(MetricsModelMixin("campaign"), models.Model):

--- a/concordia/signals/handlers.py
+++ b/concordia/signals/handlers.py
@@ -14,7 +14,7 @@ from django.template import loader
 from django_registration.signals import user_activated, user_registered
 from flags.state import flag_enabled
 
-from ..models import Asset, Campaign, Transcription, TranscriptionStatus
+from ..models import Asset, Transcription, TranscriptionStatus
 from ..tasks import calculate_difficulty_values
 from .signals import reservation_obtained, reservation_released
 
@@ -176,18 +176,3 @@ def send_asset_reservation_message(
 @receiver(post_delete, sender=Asset)
 def remove_file_from_s3(sender, instance, using, **kwargs):
     instance.storage_image.delete(save=False)
-
-
-@receiver(post_save, sender=Campaign)
-def resolve_next_flags(sender, *, instance, **kwargs):
-    # We want to make sure only one campaign is ever set
-    # to be the campaign used for the "jump to a transcription"
-    # and "jump to a review" links
-    if instance.next_transcription_campaign:
-        sender.objects.filter(next_transcription_campaign=True).exclude(
-            pk=instance.pk
-        ).update(next_transcription_campaign=False)
-    if instance.next_review_campaign:
-        sender.objects.filter(next_review_campaign=True).exclude(pk=instance.pk).update(
-            next_review_campaign=False
-        )

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import os
+import random
 import re
 from functools import wraps
 from logging import getLogger
@@ -2012,7 +2013,18 @@ def filter_and_order_reviewable_assets(
 @never_cache
 @atomic
 def redirect_to_next_reviewable_asset(request):
-    campaign = Campaign.objects.get_next_review_campaign()
+    campaign_ids = list(
+        Campaign.objects.active()
+        .listed()
+        .published()
+        .get_next_review_campaigns()
+        .values_list("id", flat=True)
+    )
+    try:
+        campaign_id = random.choice(campaign_ids)  # nosec
+        campaign = Campaign.objects.get(id=campaign_id)
+    except IndexError:
+        campaign = Campaign.objects.active().listed().published().latest("launch_date")
     project_slug = request.GET.get("project", "")
     item_id = request.GET.get("item", "")
     asset_id = request.GET.get("asset", 0)
@@ -2059,7 +2071,18 @@ def find_transcribable_assets(campaign, project_slug, item_id, asset_id):
 @never_cache
 @atomic
 def redirect_to_next_transcribable_asset(request):
-    campaign = Campaign.objects.get_next_transcription_campaign()
+    campaign_ids = list(
+        Campaign.objects.active()
+        .listed()
+        .published()
+        .get_next_transcription_campaigns()
+        .values_list("id", flat=True)
+    )
+    try:
+        campaign_id = random.choice(campaign_ids)  # nosec
+        campaign = Campaign.objects.get(id=campaign_id)
+    except IndexError:
+        campaign = Campaign.objects.active().listed().published().latest("launch_date")
     project_slug = request.GET.get("project", "")
     item_id = request.GET.get("item", "")
     asset_id = request.GET.get("asset", 0)


### PR DESCRIPTION
Made the next review/next transcription campaign flags non-exclusive
Changed the next review/transcription views to randomly select one of the configured campaigns
Added active/completed/retired filters to campaign queryset

https://staff.loc.gov/tasks/browse/CONCD-643

\# nosec lines are to have bandit ignore those lines because it warns that random isn't cryptographically safe, but we're not using it for any kind of security here.