### PR TITLE
CONCD-599

### DIFF
--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -686,7 +686,7 @@
                         </button>
                     </div>
                     <div class="modal-body">
-                        <div class="bg-light px-3">
+                        <div class="px-3">
                             <h5 class="modal-title">Are you sure?</h5>
                             <p>Clicking "Transcribe with OCR" will remove all existing transcription text and replace it with automatically generated text. We recommend saving existing text in a separate document if you may want to revisit it.</p>
                         </div>
@@ -713,7 +713,7 @@
                     </div>
                     <form id="ocr-transcription-form" class="ajax-submission" method="post" action="{% url 'generate-ocr-transcription' asset_pk=asset.pk %}" data-lock-element="#transcription-editor">
                         <div class="modal-body">
-                            <div class="bg-light pb-4">
+                            <div class="pb-4">
                                 <h5 class="modal-title">Select language</h5>
                                 <p>Select the language the transcription is in from the list below.</p>
                                 <div class="text-center">

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -681,13 +681,13 @@
             <div class="modal-dialog modal-dialog-centered" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
+                        <h5 class="modal-title">Are you sure?</h5>
                         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                             <span aria-hidden="true" class="text-primary">&times;</span>
                         </button>
                     </div>
                     <div class="modal-body">
                         <div class="px-3">
-                            <h5 class="modal-title">Are you sure?</h5>
                             <p>Clicking "Transcribe with OCR" will remove all existing transcription text and replace it with automatically generated text. We recommend saving existing text in a separate document if you may want to revisit it.</p>
                         </div>
                     </div>
@@ -707,6 +707,7 @@
             <div class="modal-dialog modal-dialog-centered" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
+                        <h5 class="modal-title">Select language</h5>
                         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                             <span aria-hidden="true" class="text-primary">&times;</span>
                         </button>
@@ -714,7 +715,6 @@
                     <form id="ocr-transcription-form" class="ajax-submission" method="post" action="{% url 'generate-ocr-transcription' asset_pk=asset.pk %}" data-lock-element="#transcription-editor">
                         <div class="modal-body">
                             <div class="pb-4">
-                                <h5 class="modal-title">Select language</h5>
                                 <p>Select the language the transcription is in from the list below.</p>
                                 <div class="text-center">
                                     <select id="language" name="language" size="7">


### PR DESCRIPTION
- the bolded title text on each of the OCR workflow slides should actually be in the header
- we don't need/ want the gray box on either slide