### PR TITLE
CONCD-770 ignoring this rule

### DIFF
--- a/concordia/static/scss/base.scss
+++ b/concordia/static/scss/base.scss
@@ -480,9 +480,11 @@ $card-progress-height: 12px;
     );
     z-index: 3;
 
-    .view-transcriptions-item-detail & {
+    /* stylelint-disable selector-class-pattern */
+    .view-transcriptions--item-detail & {
         top: 0;
     }
+    /* stylelint-enable selector-class-pattern */
 }
 
 .concordia-object-card .card-actions .btn {


### PR DESCRIPTION
our code uses double hyphens, which will cause our stylelint checks to fail. ignore the error

https://github.com/LibraryOfCongress/concordia/blob/main/concordia/context_processors.py#L23