### PR TITLE
CONCD-823 Prevent button label from wrapping to a second line

### DIFF
--- a/concordia/static/scss/base.scss
+++ b/concordia/static/scss/base.scss
@@ -1116,6 +1116,8 @@ $card-progress-height: 12px;
     font-size: 0.75rem;
     margin-right: -55px;
     margin-top: 39px;
+    max-height: 32px;
+    white-space: nowrap;
     width: 110px;
 }
 


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-823