### PR TITLE
change codeQL v2 to 3 and remove deprecated setup python dependency option

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -72,10 +72,9 @@ jobs:
 
             # Initializes the CodeQL tools for scanning.
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v2
+              uses: github/codeql-action/init@v3
               with:
                   languages: ${{ matrix.language }}
-                  setup-python-dependencies: false
                   # If you wish to specify custom queries, you can do so here or in a config file.
                   # By default, queries listed here will override any specified in a config file.
                   # Prefix the list here with "+" to use these queries and those in the config file.
@@ -84,7 +83,7 @@ jobs:
             # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
             # If this step fails, then you should remove it and run the build manually (see below)
             - name: Autobuild
-              uses: github/codeql-action/autobuild@v2
+              uses: github/codeql-action/autobuild@v3
 
             - run: |
                   pip install -U packaging
@@ -93,4 +92,4 @@ jobs:
                   pipenv install --dev --deploy
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v2
+              uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-793

Addresses the annotated warnings of deprecation.