### PR TITLE
remove memcached from cloudformation templates

### DIFF
--- a/cloudformation/featurebranch.yaml
+++ b/cloudformation/featurebranch.yaml
@@ -66,8 +66,6 @@ Resources:
                 SecurityGroup: 'sg-04de21574623caca7'
                 RedisAddress: !GetAtt ElastiCache.Outputs.RedisAddress
                 RedisPort: !GetAtt ElastiCache.Outputs.RedisPort
-                MemcachedAddress: !GetAtt ElastiCache.Outputs.MemcachedAddress
-                MemcachedPort: !GetAtt ElastiCache.Outputs.MemcachedPort
                 DatabaseEndpoint: !GetAtt RDS.Outputs.DatabaseHostName
                 Priority: !Ref Priority
                 DataLoadStackName: !GetAtt DataLoadHost.Outputs.StackName

--- a/cloudformation/infrastructure/security-groups.yaml
+++ b/cloudformation/infrastructure/security-groups.yaml
@@ -121,11 +121,6 @@ Resources:
                   IpProtocol: tcp
                   FromPort: 6379
                   ToPort: 6379
-                - Description: 'Memcached service access from container hosts'
-                  SourceSecurityGroupId: !Ref 'ECSHostSecurityGroup'
-                  IpProtocol: tcp
-                  FromPort: 11211
-                  ToPort: 11211
             SecurityGroupEgress:
                 - Description: 'Explicit outbound access'
                   IpProtocol: '-1'

--- a/cloudformation/master.yaml
+++ b/cloudformation/master.yaml
@@ -214,8 +214,6 @@ Resources:
                 ConcordiaVersion: !Ref ConcordiaVersion
                 RedisAddress: !GetAtt ElastiCache.Outputs.RedisAddress
                 RedisPort: !GetAtt ElastiCache.Outputs.RedisPort
-                MemcachedAddress: !GetAtt ElastiCache.Outputs.MemcachedAddress
-                MemcachedPort: !GetAtt ElastiCache.Outputs.MemcachedPort
                 CanonicalHostName: !Ref CanonicalHostName
                 DatabaseEndpoint: !GetAtt RDS.Outputs.DatabaseHostName
                 FullEnvironmentName: !Ref FullEnvironmentName


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-767
All AWS ElastiCache moved to Redis in CY 2023.