### PR TITLE
Fixes for get_pages unit tests

### DIFF
--- a/concordia/tests/test_account_views.py
+++ b/concordia/tests/test_account_views.py
@@ -8,7 +8,12 @@ from django.urls import reverse
 
 from concordia.models import ConcordiaUser, User
 
-from .utils import CacheControlAssertions, CreateTestUsers, JSONAssertMixin
+from .utils import (
+    CacheControlAssertions,
+    CreateTestUsers,
+    JSONAssertMixin,
+    create_campaign,
+)
 
 
 @override_settings(RATELIMIT_ENABLE=False)
@@ -173,26 +178,23 @@ class ConcordiaViewTests(
 
     def test_get_pages(self):
         self.login_user()
+        create_campaign()
         url = reverse("get_pages")
 
-        response = self.client.get(url, kwargs={"activity": "transcribed"})
+        response = self.client.get(url, {"activity": "transcribed"})
         self.assertEqual(response.status_code, 200)
 
         response = self.client.get(
-            url, kwargs={"activity": "reviewed", "order_by": "date-ascending"}
+            url, {"activity": "reviewed", "order_by": "date-ascending"}
         )
         self.assertEqual(response.status_code, 200)
         self.assertUncacheable(response)
 
-        response = self.client.get(url, kwargs={"campaign_slug": "slug"})
+        response = self.client.get(url, {"status": ["completed"], "campaign": 1})
         self.assertEqual(response.status_code, 200)
         self.assertUncacheable(response)
 
-        response = self.client.get(url, kwargs={"status": ["completed"], "campaign": 1})
-        self.assertEqual(response.status_code, 200)
-        self.assertUncacheable(response)
-
-        response = self.client.get(url, kwargs={"status": ["in_progress", "submitted"]})
+        response = self.client.get(url, {"status": ["in_progress", "submitted"]})
         self.assertEqual(response.status_code, 200)
         self.assertUncacheable(response)
 
@@ -202,12 +204,10 @@ class ConcordiaViewTests(
         self.assertEqual(response.status_code, 200)
         self.assertUncacheable(response)
 
-        response = self.client.get(url, kwargs={"end": "1999-12-31"})
+        response = self.client.get(url, {"end": "1999-12-31"})
         self.assertEqual(response.status_code, 200)
         self.assertUncacheable(response)
 
-        response = self.client.get(
-            url, kwargs={"start": "1900-01-01", "end": "1999-12-31"}
-        )
+        response = self.client.get(url, {"start": "1900-01-01", "end": "1999-12-31"})
         self.assertEqual(response.status_code, 200)
         self.assertUncacheable(response)

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -49,6 +49,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.template import loader
 from django.template.loader import render_to_string
 from django.urls import reverse, reverse_lazy
+from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.http import http_date
 from django.utils.timezone import now
@@ -390,6 +391,7 @@ def AccountLetterView(request):
 def _get_pages(request):
     user = request.user
     activity = request.GET.get("activity", None)
+
     if activity == "transcribed":
         q = Q(user=user)
     elif activity == "reviewed":
@@ -398,12 +400,7 @@ def _get_pages(request):
         q = Q(user=user) | Q(reviewed_by=user)
     transcriptions = Transcription.objects.filter(q)
 
-    qId = request.GET.get("campaign_slug", None)
-
     assets = Asset.objects.filter(transcription__in=transcriptions)
-    if qId:
-        campaignSlug = qId
-        assets = Asset.objects.filter(item__project__campaign__pk=campaignSlug)
     status_list = request.GET.getlist("status")
     if status_list and status_list != []:
         if "completed" not in status_list:
@@ -436,11 +433,11 @@ def _get_pages(request):
     start_date = None
     start = request.GET.get("start", None)
     if start is not None and len(start) > 0:
-        start_date = datetime.datetime.strptime(start, fmt)
+        start_date = timezone.make_aware(datetime.datetime.strptime(start, fmt))
     end_date = None
     end = request.GET.get("end", None)
     if end is not None and len(end) > 0:
-        end_date = datetime.datetime.strptime(end, fmt)
+        end_date = timezone.make_aware(datetime.datetime.strptime(end, fmt))
     if start_date is not None and end_date is not None:
         end_date += datetime.timedelta(days=1)
         end = end_date.strftime(fmt)
@@ -491,6 +488,7 @@ def get_pages(request):
         context[param] = request.GET.get(param, None)
     campaign = request.GET.get("campaign", None)
     context["statuses"] = request.GET.getlist("status")
+
     if campaign is not None:
         context["campaign"] = Campaign.objects.get(pk=int(campaign))
 


### PR DESCRIPTION
Removal of some code in get_pages that wasn't used. Made the datetimes in get_pages timezone aware to get rid of warnings.