### PR TITLE
Changed about page to use statistics from the database rather than manual entry

### DIFF
--- a/concordia/models.py
+++ b/concordia/models.py
@@ -1117,6 +1117,7 @@ class SiteReport(models.Model):
 
     class Meta:
         ordering = ("-created_on",)
+        get_latest_by = "created_on"
 
     # We have several places where these are exported as CSV/Excel. By default
     # the ORM will be told to retrieve these fields & lookups:

--- a/concordia/urls.py
+++ b/concordia/urls.py
@@ -105,7 +105,7 @@ urlpatterns = [
     path("", views.HomeView.as_view(), name="homepage"),
     path("healthz", views.healthz, name="health-check"),
     path("letter", views.AccountLetterView, name="user-letter"),
-    path("about/", views.simple_page, name="about"),
+    path("about/", views.about_simple_page, name="about"),
     # These patterns are to make sure various links to help-center URLs don't break
     # when the URLs are changed to not include help-center and can be removed after
     # all links are updated.


### PR DESCRIPTION
Added parsing of simple pages as Django templates. Added view to add context to about page to add data. The actual change to the about page requires modifying the template in the database to use the new context.

https://staff.loc.gov/tasks/browse/CONCD-884