### PR TITLE
Renamed 'Quick Tips' to 'Campaign Tips' on places that face the user

### DIFF
--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -425,7 +425,7 @@
                             </span>
                             <div class="align-items-center align-self-end btn-group">
                                 <a class="font-weight-bold" id="quick-tips" data-toggle="modal" data-target="#tutorial-popup" role="button">
-                                    <u>Quick Tips</u>
+                                    <u>Campaign Tips</u>
                                 </a>
                             </div>
                         </div>
@@ -761,7 +761,7 @@
             <div class="modal-dialog modal-dialog-centered" role="document">
                 <div class="modal-content">
                     <div class="modal-header border-bottom-0">
-                        <h4>Quick Tips</h4>
+                        <h4>Campaign Tips</h4>
                         <button type="button" class="close text-primary" data-dismiss="modal" aria-label="Close">
                             <span aria-hidden="true">x</span>
                         </button>


### PR DESCRIPTION
Left 'quick tips' as an identifier in the code (analytics, element ids, etc.)

https://staff.loc.gov/tasks/browse/CONCD-890