### PR TITLE
Fixed transcription admin causing crashes due to loading all transcriptions into a drop-down (release hotfix)

### DIFF
--- a/concordia/admin/__init__.py
+++ b/concordia/admin/__init__.py
@@ -790,6 +790,7 @@ class TranscriptionAdmin(admin.ModelAdmin):
         "reviewed_by",
         "supersedes",
         "text",
+        "source",
     )
 
     EXPORT_FIELDS = (


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-925

This is a hotfix for release.