### PR TITLE
Fixed how-to guide close button being disabled after saving a transcription

### DIFF
--- a/concordia/static/js/src/contribute.js
+++ b/concordia/static/js/src/contribute.js
@@ -28,6 +28,7 @@ function unlockControls($container) {
     // we want to unlock here
     $container.find('button#open-guide').removeAttr('disabled');
     $container.find('button#ocr-transcription-button').removeAttr('disabled');
+    $container.find('button#close-guide').removeAttr('disabled');
 }
 
 $(document).on('keydown', function (event) {


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/COND-926

This is the hotfix for release.