### PR TITLE
Fixed ocr and guide close button being disabled after saving a transcription (main)

### DIFF
--- a/concordia/static/js/src/contribute.js
+++ b/concordia/static/js/src/contribute.js
@@ -27,6 +27,8 @@ function unlockControls($container) {
     // results handlers.
     // The only buttons unlocked here are ones that should always be unlocked.
     $container.find('button#open-guide').removeAttr('disabled');
+    $container.find('button#ocr-transcription-button').removeAttr('disabled');
+    $container.find('button#close-guide').removeAttr('disabled');
 }
 
 $(document).on('keydown', function (event) {


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-926

This brings the hotfixes into main.