### PR TITLE
Updated reservation tombstones to be applied after 24 hours, then deleted after another 24 hours

### DIFF
--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -383,10 +383,10 @@ BOOTSTRAP4 = {"required_css_class": "form-group-required", "set_placeholder": Fa
 TRANSCRIPTION_RESERVATION_SECONDS = 15 * 60
 
 #: Number of hours until an asset reservation is tombstoned
-TRANSCRIPTION_RESERVATION_TOMBSTONE_HOURS = 72
+TRANSCRIPTION_RESERVATION_TOMBSTONE_HOURS = 24
 
 #: Number of hours until a tombstoned reservation is deleted
-TRANSCRIPTION_RESERVATION_TOMBSTONE_LENGTH_HOURS = 48
+TRANSCRIPTION_RESERVATION_TOMBSTONE_LENGTH_HOURS = 24
 
 #: Web cache policy settings
 DEFAULT_PAGE_TTL = 5 * 60


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-953

Tombstoned reservations are automatically deleted when someone else tries to get the reservation for the asset, so this means effectively a reservation is always released after 24 hours, but it won't actually be deleted until someone else reserves the asset or 24 more hours pass after it's tombstoned.