### PR TITLE
Added ability to undo an OCR transcription even if it's the first transcription on an asset

### DIFF
--- a/concordia/models.py
+++ b/concordia/models.py
@@ -662,7 +662,6 @@ class Asset(MetricsModelMixin("asset"), models.Model):
         transcriptions = (
             self.transcription_set.exclude(rolled_forward=True)
             .exclude(source_of__rolled_forward=True)
-            .exclude(rolled_back=True)
             .exclude(pk__gte=latest_transcription.pk)
             .order_by("-pk")
         )
@@ -677,9 +676,13 @@ class Asset(MetricsModelMixin("asset"), models.Model):
 
         transcription_to_rollback_to = None
         for transcription in transcriptions:
+            if transcription.source:
+                transcription_to_check = transcription.source
+            else:
+                transcription_to_check = transcription
             if (
                 latest_transcription.rolled_back is False
-                or latest_transcription.supersedes != transcription
+                or latest_transcription.supersedes != transcription_to_check
             ):
                 transcription_to_rollback_to = transcription
                 break


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-944

A blank transcription by the anonymous user is added automatically when an OCR transcription is being generated if there are no other transcriptions on the asset.

There was a bug in the undo code when rolling back to a "rolled back" transcription (i.e., one that is the result of someone doing undo) that caused the rolled back transcription to be skipped over. These changes also fix that (which was required for the blank transcription to work as expected.)