### PR TITLE
Added resetting to the turnstile widget after form submission

### DIFF
--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -327,7 +327,9 @@ TURNSTILE_VERIFY_URL = os.environ.get(
 TURNSTILE_SITEKEY = os.environ.get("TURNSTILE_SITEKEY", "")
 TURNSTILE_SECRET = os.environ.get("TURNSTILE_SECRET", "")
 TURNSTILE_TIMEOUT = os.environ.get("TURNSTILE_TIMEOUT", 5)
-TURNSTILE_DEFAULT_CONFIG = os.environ.get("TURNSTILE_DEFAULT_CONFIG", {})
+TURNSTILE_DEFAULT_CONFIG = os.environ.get(
+    "TURNSTILE_DEFAULT_CONFIG", {"appearance": "interaction-only"}
+)
 TURNSTILE_PROXIES = os.environ.get("TURNSTILE_PROXIES", {})
 
 STORAGES = {

--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -331,6 +331,7 @@ TURNSTILE_DEFAULT_CONFIG = os.environ.get(
     "TURNSTILE_DEFAULT_CONFIG", {"appearance": "interaction-only"}
 )
 TURNSTILE_PROXIES = os.environ.get("TURNSTILE_PROXIES", {})
+ANONYMOUS_USER_VALIDATION_INTERVAL = 86400
 
 STORAGES = {
     "default": {

--- a/concordia/static/js/src/contribute.js
+++ b/concordia/static/js/src/contribute.js
@@ -1,6 +1,7 @@
 /* global $ displayMessage buildErrorMessage */
 
 import {reserveAssetForEditing} from 'asset-reservation';
+import {resetTurnstile} from 'turnstile';
 
 function lockControls($container) {
     if (!$container) {
@@ -298,6 +299,7 @@ function setupPage() {
             if (responseData.redo_available) {
                 $('#rollforward-transcription-button').removeAttr('disabled');
             }
+            resetTurnstile();
             let messageChildren = $('#transcription-status-message').children();
             messageChildren
                 .attr('hidden', 'hidden')
@@ -321,6 +323,7 @@ function setupPage() {
                     ),
                 'transcription-save-result',
             );
+            resetTurnstile();
             $transcriptionEditor.trigger('update-ui-state');
         });
 

--- a/concordia/static/js/src/modules/turnstile.js
+++ b/concordia/static/js/src/modules/turnstile.js
@@ -1,0 +1,15 @@
+/* global turnstile */
+
+function resetTurnstile(widgetId) {
+    // widgetId is optional. If not provided, the latest
+    // turnstile widget is used automatically
+    if (turnstile && typeof turnstile.reset === 'function') {
+        turnstile.reset(widgetId);
+    } else {
+        console.error(
+            'Unable to reset turnstile. Turnstile.reset is not a function.',
+        );
+    }
+}
+
+export {resetTurnstile};

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -35,7 +35,8 @@
         {
             "imports": {
                 "asset-reservation": "{% static 'js/asset-reservation.js' %}",
-                "viewer": "{% static 'js/viewer.js' %}"
+                "viewer": "{% static 'js/viewer.js' %}",
+                "turnstile" : "{% static 'js/modules/turnstile.js' %}"
             }
         }
     </script>

--- a/concordia/templates/transcriptions/asset_detail/editor.html
+++ b/concordia/templates/transcriptions/asset_detail/editor.html
@@ -86,7 +86,6 @@
                         </a>
                     </div>
 
-                    <div class="w-100 text-center mt-0 mb-3">{{ turnstile_form.turnstile }}</div>
 
                     <button id="save-transcription-button" disabled type="submit" class="btn btn-primary mx-1" title="Save the text you entered above">
                         Save
@@ -118,6 +117,7 @@
                         {% endif %}
                     {% endif %}
                 {% endif %}
+                <div class="w-100 text-center mt-1 mb-1">{{ turnstile_form.turnstile }}</div>
             </div>
         {% endspaceless %}
     </form>


### PR DESCRIPTION
Also changed turnstile to only display a widget when interaction is required. Moved the widget to below the form buttons so it has room to appear but doesn't change the spacing on the form when not visible.

Added caching for validation of anonymous users. Users should only be tested against Turnstile once per day (so long as they keep the same session), which is the same interval as used with captcha.

https://staff.loc.gov/tasks/browse/CONCD-952
