### PR TITLE
Added logic to determine whether the user needs to be validated by Turnstile, and get rid of the extraneous scripts and checks if not

### DIFF
--- a/concordia/static/js/src/modules/turnstile.js
+++ b/concordia/static/js/src/modules/turnstile.js
@@ -3,7 +3,11 @@
 function resetTurnstile(widgetId) {
     // widgetId is optional. If not provided, the latest
     // turnstile widget is used automatically
-    if (turnstile && typeof turnstile.reset === 'function') {
+    if (
+        typeof turnstile !== 'undefined' &&
+        turnstile !== null &&
+        typeof turnstile.reset === 'function'
+    ) {
         turnstile.reset(widgetId);
     } else {
         console.error(

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -42,7 +42,9 @@
     </script>
     <script module src="{% static 'openseadragon/build/openseadragon/openseadragon.min.js' %}"></script>
     <script module src="{% static 'openseadragon-filtering/openseadragon-filtering.js' %}"></script>
-    <script module src="{{ TURNSTILE_JS_API_URL }}"></script>
+    {% if anonymous_user_validation_required %}
+        <script module src="{{ TURNSTILE_JS_API_URL }}"></script>
+    {% endif %}
 
     <script type="module" src="{% static 'js/contribute.js' %}"></script>
     <script type="module" src="{% static 'js/viewer-split.js' %}"></script>

--- a/concordia/templates/transcriptions/asset_detail/editor.html
+++ b/concordia/templates/transcriptions/asset_detail/editor.html
@@ -117,7 +117,11 @@
                         {% endif %}
                     {% endif %}
                 {% endif %}
-                <div class="w-100 text-center mt-1 mb-1">{{ turnstile_form.turnstile }}</div>
+                {% if anonymous_user_validation_required %}
+                    {% if transcription_status == 'not_started' or transcription_status == 'in_progress' %}
+                        <div class="w-100 text-center mt-1 mb-1">{{ turnstile_form.turnstile }}</div>
+                    {% endif %}
+                {% endif %}
             </div>
         {% endspaceless %}
     </form>


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-952

This stops the interactive widget from appearing when there's no need to validate the user or when they're can't submit the form (such as when an asset is ready for review but the user is anonymous).

This also prevents a lot of extraneous calls to Turnstile from clients (since the script and widget won't be loaded if not needed), which is obviously preferable if it doesn't otherwise break anything.