### PR TITLE
Added error message display when OpenSeadragon can't load an asset image

### DIFF
--- a/concordia/static/js/src/viewer.js
+++ b/concordia/static/js/src/viewer.js
@@ -1,4 +1,4 @@
-/* global OpenSeadragon screenfull debounce */
+/* global OpenSeadragon screenfull debounce displayMessage */
 
 const viewerData = document.getElementById('viewer-data').dataset;
 
@@ -220,5 +220,14 @@ thresholdDown.addEventListener('click', function () {
 
 let reset = document.getElementById('viewer-reset');
 reset.addEventListener('click', resetImageFilterForms);
+
+seadragonViewer.addHandler('open-failed', function (eventData) {
+    let message = eventData.message;
+    displayMessage(
+        'error',
+        'Unable to display image: ' + message,
+        'openseadragon-open-failed',
+    );
+});
 
 export {seadragonViewer};


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-972

This can be tested with /campaigns/musical-theater/1916-to-1919/2016777124/2016777124-1/ at least until the dev S3 bucket is refreshed. Otherwise, can be tested by renaming or deleting an image in S3 (or modifying the code to try to load an invalid URL).