### PR TITLE
Added filtering for expected Turnstile errors in Sentry

### DIFF
--- a/concordia/templates/base.html
+++ b/concordia/templates/base.html
@@ -261,6 +261,8 @@ because it's not worth dealing with IE11 compatibility {% endcomment %}
                     integrity="sha384-PKOJCSVL6suo2Qz9Hs4hkrZqX7S6iLwadxXxBEa0h0ycsuoDNZCiAcHlPGHYxU6l"
                     crossorigin="anonymous"></script>
             <script>
+                // Don't load Sentry if this is the "always online" version of the page,
+                // which is the version CloudFlare serves if the actual site is down
                 if (navigator.userAgent.indexOf("CloudFlare-AlwaysOnline") < 0) {
                     Sentry.init({
                         'dsn': '{{ SENTRY_FRONTEND_DSN }}',
@@ -268,7 +270,9 @@ because it's not worth dealing with IE11 compatibility {% endcomment %}
                         'environment': '{{ CONCORDIA_ENVIRONMENT }}',
                         'blacklistUrls': [
                             /^moz-extension/
-                        ]
+                        ],
+                        // Turnstile 300xxx and 600xxx errors indicate the user failed validation. We don't want those in Sentry
+                        'ignoreErrors': ["[Cloudflare Turnstile] Error: 600", "[Cloudflare Turnstile] Error: 300"]
                     });
                 }
             </script>


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-976

I was unable to get these errors, at least the 600xxx ones, to log in my dev environment even before adding the filter (I was able to get Sentry to capture other messages, so it seems like it doesn't log 600xxx errors by default--I kept the filter to be safe). I was unable to trigger the 300xxx at all, since Turnstile doesn't provide a way to do so. Testing will need to be done in dev/test, to the extent it can be tested at all, since it depends on the user failing Turnstile validation.