### PR TITLE
Fixes for broken image messages

### DIFF
--- a/concordia/static/js/src/base.js
+++ b/concordia/static/js/src/base.js
@@ -53,10 +53,10 @@ function displayHtmlMessage(level, message, uniqueId) {
         If provided, uniqueId will be used to remove any existing elements which
         have that ID, allowing old messages to be replaced automatically.
     */
-    var $messages = $('#messages');
+    let $messages = $('#messages');
     $messages.removeAttr('hidden');
 
-    var $newMessage = $messages
+    let $newMessage = $messages
         .find('#message-template .alert')
         .clone()
         .removeAttr('hidden')
@@ -76,6 +76,11 @@ function displayHtmlMessage(level, message, uniqueId) {
 
     // Add a span to the message to ensure justified
     // styles don't end up splitting the text
+    // message might be a Text node, so we need to get
+    // the actual text if so
+    if (message instanceof Text) {
+        message = message.textContent;
+    }
     $newMessage.prepend('<span>' + message + '</span>');
 
     $messages.append($newMessage);

--- a/concordia/static/js/src/viewer.js
+++ b/concordia/static/js/src/viewer.js
@@ -228,7 +228,7 @@ seadragonViewer.addHandler('open-failed', function () {
     let contactUs =
         '<strong><a class="alert-link" href="' +
         viewerData.contactUrl +
-        '">contact us</a></strong>';
+        '" target="_blank">Contact us</a></strong>';
     displayHtmlMessage(
         'error',
         'Unable to display image - ' + contactUs,

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -29,7 +29,7 @@
     <script id="viewer-data"
             data-prefix-url="{% static 'openseadragon/build/openseadragon/images/' %}"
             data-tile-source-url="{% asset_media_url asset %}?canvas"
-            data-contact-url="{% url 'contact' %}"
+            data-contact-url="https://ask.loc.gov/crowd"
     ></script>
 
     <script type="importmap">


### PR DESCRIPTION
Fixed bug with displayHTMLMesage when receiving a Text node.
Changed contact link to be capitalized, use correct URL and open in a new tab.

https://staff.loc.gov/tasks/browse/COND-972