### PR TITLE
Added test for update_task_status decorator

### DIFF
--- a/importer/models.py
+++ b/importer/models.py
@@ -51,7 +51,7 @@ class ImportJob(TaskStatusModel):
 
     def __str__(self):
         return "ImportJob(created_by=%s, project=%s, url=%s)" % (
-            self.created_by.username,
+            self.created_by.username if self.created_by else None,
             self.project.title,
             self.url,
         )

--- a/importer/tests/test_tasks.py
+++ b/importer/tests/test_tasks.py
@@ -4,10 +4,11 @@ from unittest import mock
 import requests
 from django.core.cache.backends.base import BaseCache
 from django.test import TestCase, override_settings
+from django.utils import timezone
 
 from concordia.tests.utils import CreateTestUsers, create_asset, create_project
-
-from ..tasks import (
+from importer.models import ImportJob
+from importer.tasks import (
     fetch_all_urls,
     get_collection_items,
     get_item_id_from_item_url,
@@ -17,7 +18,9 @@ from ..tasks import (
     import_items_into_project_from_url,
     normalize_collection_url,
     redownload_image_task,
+    update_task_status,
 )
+
 from .utils import create_import_job
 
 
@@ -48,6 +51,78 @@ class MockCache(BaseCache):
     def get(self, key, default=None, version=None):
         resp = MockResponse()
         return resp
+
+
+class TaskDecoratorTests(TestCase):
+    def test_update_task_status(self):
+        def test_function(self, task_status_object, raise_exception=False):
+            task_status_object.test_function_ran = True
+            if raise_exception:
+                raise Exception("Test Exception")
+            task_status_object.test_function_finished = True
+
+        wrapped_test_function = update_task_status(test_function)
+
+        # We create this non-mocked completed job here to use in a later test
+        # because we can't easily do this once we mock ImportJob.save
+        test_job = create_import_job(completed=timezone.now())
+
+        # We can't just mock the entire model here or use easily use a custom
+        # class because update_task_status depends on Django model internals,
+        # particularly __class__._default_manager. __class__ cannot be overriden
+        # (it points to MagicMock), Model._default_manager cannot be set directly
+        # and mocking Model.objects does not cause called on Model._default_manager
+        # to properly use the mock--it continues to use the actual Model.objects
+        with mock.patch.multiple(
+            ImportJob,
+            save=mock.MagicMock(),
+            __str__=mock.MagicMock(return_value="Mock Job"),
+        ):
+            job = ImportJob()
+            wrapped_test_function(mock.MagicMock(), job)
+            self.assertTrue(hasattr(job, "test_function_ran"))
+            self.assertTrue(job.test_function_ran)
+            self.assertTrue(hasattr(job, "test_function_finished"))
+            self.assertTrue(job.test_function_finished)
+            self.assertNotEqual(job.last_started, None)
+            self.assertNotEqual(job.task_id, None)
+            self.assertTrue(job.completed)
+            self.assertTrue(job.save.called)
+
+            ImportJob.save.reset_mock()
+            job2 = ImportJob()
+            job2.status = "Original Status"
+            with self.assertRaisesRegex(Exception, "Test Exception"):
+                wrapped_test_function(mock.MagicMock(), job2, True)
+            self.assertTrue(hasattr(job2, "test_function_ran"))
+            self.assertTrue(job2.test_function_ran)
+            self.assertFalse(hasattr(job2, "test_function_finished"))
+            self.assertNotEqual(job2.last_started, None)
+            self.assertNotEqual(job2.task_id, None)
+            self.assertFalse(job2.completed)
+            self.assertTrue(job2.save.called)
+            self.assertEqual(
+                job2.status, "Original Status\n\nUnhandled exception: Test Exception"
+            )
+
+            ImportJob.save.reset_mock()
+            job3 = ImportJob()
+            job3.id = test_job.id
+            with self.assertLogs("importer.tasks", level="WARNING") as log:
+                wrapped_test_function(mock.MagicMock(), job3)
+                self.assertEqual(
+                    log.output,
+                    [
+                        "WARNING:importer.tasks:Task Mock Job was "
+                        "already completed and will not be repeated"
+                    ],
+                )
+            self.assertFalse(hasattr(job3, "test_function_ran"))
+            self.assertFalse(hasattr(job3, "test_function_finished"))
+            self.assertEqual(job3.last_started, None)
+            self.assertEqual(job3.task_id, None)
+            self.assertFalse(job3.completed)
+            self.assertFalse(job3.save.called)
 
 
 class ImportItemCountFromUrlTests(TestCase):


### PR DESCRIPTION
Also:
 * Modified update_task_status to call the passed object an object rather than a model
 * Modified ImportJob.__str__ to properly handle when created_by is None

https://staff.loc.gov/tasks/browse/CONCD-852