### PR TITLE
Asset import task tests

### DIFF
--- a/importer/tasks.py
+++ b/importer/tasks.py
@@ -488,7 +488,10 @@ def get_asset_urls_from_item_resources(resources):
     """
 
     assets = []
-    item_resource_url = resources[0]["url"] or ""
+    try:
+        item_resource_url = resources[0]["url"] or ""
+    except (IndexError, KeyError):
+        item_resource_url = ""
 
     for resource in resources:
         # The JSON response for each file is a list of available image versions
@@ -498,6 +501,7 @@ def get_asset_urls_from_item_resources(resources):
             candidates = []
 
             for variant in item_file:
+
                 if any(i for i in ("url", "height", "width") if i not in variant):
                     continue
 

--- a/importer/tasks.py
+++ b/importer/tasks.py
@@ -566,6 +566,7 @@ def download_asset(self, import_asset):
                 temp_file.write(chunk)
 
             # Rewind the tempfile back to the first byte so we can
+            # save it to storage
             temp_file.flush()
             temp_file.seek(0)
 

--- a/importer/tests/test_tasks.py
+++ b/importer/tests/test_tasks.py
@@ -26,7 +26,7 @@ from importer.tasks import (
     update_task_status,
 )
 
-from .utils import create_import_item, create_import_job
+from .utils import create_import_asset, create_import_item, create_import_job
 
 
 class MockResponse:
@@ -679,3 +679,12 @@ class AssetImportTests(TestCase):
             ]
         )
         self.assertEqual(results, ([], "http://example.com"))
+
+    def test_download_asset_task(self):
+        import_asset = create_import_asset()
+        with mock.patch("importer.tasks.download_asset") as task_mock:
+            tasks.download_asset_task(import_asset.pk)
+            self.assertTrue(task_mock.called)
+            task, called_import_asset, redownload = task_mock.call_args.args
+            self.assertTrue(called_import_asset, import_asset)
+            self.assertEqual(redownload, None)

--- a/importer/tests/test_tasks.py
+++ b/importer/tests/test_tasks.py
@@ -602,3 +602,80 @@ class ItemImportTests(TestCase):
         self.assertEqual(item.title, "Test Title")
         self.assertEqual(item.description, "Test description")
         self.assertEqual(item.thumbnail_url, "http://example.com/image.jpg")
+
+
+class AssetImportTests(TestCase):
+    def test_get_asset_urls_from_item_resources_empty(self):
+        self.assertEqual(tasks.get_asset_urls_from_item_resources([]), ([], ""))
+
+    def test_get_asset_urls_from_item_resources_url_only(self):
+        results = tasks.get_asset_urls_from_item_resources(
+            [{"url": "http://example.com"}]
+        )
+        self.assertEqual(results, ([], "http://example.com"))
+
+    def test_get_asset_urls_from_item_resources_valid(self):
+        results = tasks.get_asset_urls_from_item_resources(
+            [
+                {
+                    "url": "http://example.com",
+                    "files": [
+                        [
+                            {
+                                "url": "http://example.com/1.jpg",
+                                "height": 1,
+                                "width": 1,
+                                "mimetype": "image/jpeg",
+                            },
+                            {"url": "http://example.com/2.jpg"},
+                            {
+                                "url": "http://example.com/3.jpg",
+                                "height": 2,
+                                "width": 2,
+                                "mimetype": "image/jpeg",
+                            },
+                            {
+                                "url": "http://example.com/4.jpg",
+                                "height": 100,
+                                "width": 100,
+                                "mimetype": "image/gif",
+                            },
+                        ]
+                    ],
+                }
+            ]
+        )
+        self.assertEqual(results, (["http://example.com/3.jpg"], "http://example.com"))
+
+    def test_get_asset_urls_from_item_resource_no_valid(self):
+        results = tasks.get_asset_urls_from_item_resources(
+            [
+                {
+                    "url": "http://example.com",
+                    "files": [
+                        [
+                            {
+                                "url": "http://example.com/1.jpg",
+                                "height": 1,
+                                "width": 1,
+                                "mimetype": "file/pdf",
+                            },
+                            {"url": "http://example.com/2.jpg"},
+                            {
+                                "url": "http://example.com/3.jpg",
+                                "height": 2,
+                                "width": 2,
+                                "mimetype": "video/mov",
+                            },
+                            {
+                                "url": "http://example.com/4.jpg",
+                                "height": 100,
+                                "width": 100,
+                                "mimetype": "image/gif",
+                            },
+                        ]
+                    ],
+                }
+            ]
+        )
+        self.assertEqual(results, ([], "http://example.com"))

--- a/importer/tests/test_tasks.py
+++ b/importer/tests/test_tasks.py
@@ -605,6 +605,9 @@ class ItemImportTests(TestCase):
 
 
 class AssetImportTests(TestCase):
+    def setUp(self):
+        self.import_asset = create_import_asset()
+
     def test_get_asset_urls_from_item_resources_empty(self):
         self.assertEqual(tasks.get_asset_urls_from_item_resources([]), ([], ""))
 
@@ -681,10 +684,8 @@ class AssetImportTests(TestCase):
         self.assertEqual(results, ([], "http://example.com"))
 
     def test_download_asset_task(self):
-        import_asset = create_import_asset()
         with mock.patch("importer.tasks.download_asset") as task_mock:
-            tasks.download_asset_task(import_asset.pk)
+            tasks.download_asset_task(self.import_asset.pk)
             self.assertTrue(task_mock.called)
-            task, called_import_asset, redownload = task_mock.call_args.args
-            self.assertTrue(called_import_asset, import_asset)
-            self.assertEqual(redownload, None)
+            task, called_import_asset = task_mock.call_args.args
+            self.assertTrue(called_import_asset, self.import_asset)


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-1023

I removed the redownload_asset code from the download_asset task because it's impossible to run the code and there's no place in the system to run the code, either (that is, there isn't even any vestigial code that tries to call it). If we need the functionality (and we haven't for at least a few years), we will need to do development to get it to work regardless, so better to remove the cruft here.