### PR TITLE
Upgraded Django version to resolve vulnerability

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ celery = {extras = ["redis"],version = ">=5.0.5"}
 "boto3" = ">=1.9.16"
 botocore = '>=1.12.16'
 requests = "*"
-Django = ">=4.2.14, <5.0"
 bagit = "*"
 django-registration = "*"
 django-tinymce = "*"
@@ -54,6 +53,7 @@ prometheus-client = "*"
 xlsxwriter = "*"
 blinker = "<1.8.0"
 psycopg2 = "*"
+django = "<5.0,>=4.2.17"
 
 [dev-packages]
 invoke = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ab401e0828dc41da10c67979c82186c0e98e024b835c01565c1c6fd787462ec7"
+            "sha256": "1fb83f2affcdb08e9347fd3baf39dda8c8dffdb785911722b78b1d69ceb3dc73"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -640,11 +640,12 @@
         },
         "django": {
             "hashes": [
-                "sha256:1ddc333a16fc139fd253035a1606bb24261951bbc3a6ca256717fa06cc41a898",
-                "sha256:6f1616c2786c408ce86ab7e10f792b8f15742f7b7b7460243929cb371e7f1dad"
+                "sha256:3a93350214ba25f178d4045c0786c61573e7dbfa3c509b3551374f1e11ba8de0",
+                "sha256:6b56d834cc94c8b21a8f4e775064896be3b4a4ca387f2612d4406a5927cd2fdc"
             ],
             "index": "pypi",
-            "version": "==4.2.16"
+            "markers": "python_version >= '3.8'",
+            "version": "==4.2.17"
         },
         "django-admin-multiple-choice-list-filter": {
             "hashes": [
@@ -2174,11 +2175,11 @@
         },
         "sqlparse": {
             "hashes": [
-                "sha256:773dcbf9a5ab44a090f3441e2180efe2560220203dc2f8c0b0fa141e18b505e4",
-                "sha256:bb6b4df465655ef332548e24f08e205afc81b9ab86cb1c45657a7ff173a3a00e"
+                "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272",
+                "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.5.1"
+            "version": "==0.5.3"
         },
         "tesseract": {
             "hashes": [
@@ -2255,7 +2256,7 @@
                 "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
                 "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
             ],
-            "markers": "python_version < '3.11'",
+            "markers": "python_version >= '3.8'",
             "version": "==4.12.2"
         },
         "tzdata": {


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-1034

Upgrading to the latest version of pipenv allowed upgrading Django without forcing the upgrade of every other library, making this much simpler.