### PR TITLE
CONCD-996 A few small styling issues

### DIFF
--- a/concordia/static/scss/base.scss
+++ b/concordia/static/scss/base.scss
@@ -1135,7 +1135,7 @@ body .disabled > .page-link {
 
     .btn {
         border-radius: 0;
-        padding: 1.25px 10px;
+        padding: 1.125px 10px;
     }
 }
 

--- a/concordia/templates/transcriptions/campaign_list_small_blocks.html
+++ b/concordia/templates/transcriptions/campaign_list_small_blocks.html
@@ -15,8 +15,8 @@
 {% block main_content %}
     <div class="container py-3">
         <h1>Completed Campaigns</h1>
-        <div id="campaign-options" class="d-flex justify-content-end mb-2 mt-3">
-            <div class="d-flex align-items-center mx-2">
+        <div id="campaign-options" class="d-flex flex-wrap justify-content-end my-2">
+            <div class="d-flex align-items-center ms-3 mt-2">
                 <label for="view-options" class="pe-1">View</label>
                 <select id="view-options">
                     <option value="grid"{% if request.GET.view != 'list' %} selected{% endif %}>Grid</option>
@@ -24,7 +24,7 @@
                 </select>
                 <a class="btn btn-primary" onclick="toggleCampaignView();">Go</a>
             </div>
-            <div class="d-flex align-items-center mx-2">
+            <div class="d-flex align-items-center ms-3 mt-2">
                 <label for="campaign-type" class="pe-1">Campaign Status</label>
                 <select id="campaign-type">
                     <option value="completed"{% if request.GET.type != 'retired' %} selected{% endif %}>Completed</option>
@@ -33,7 +33,7 @@
                 <a class="btn btn-primary" onclick="toggleCampaignType();" type="submit">Go</a>
             </div>
             {% if research_centers %}
-                <div class="d-flex align-items-center ms-2">
+                <div class="d-flex align-items-center ms-3 mt-2">
                     <label for="research-center" class="pe-1">Research Center</label>
                     <select id="research-center">
                         <option value="all"{% if 'research_center' not in request.GET %} selected{% endif %}>All</option>

--- a/concordia/templates/transcriptions/campaign_list_small_blocks.html
+++ b/concordia/templates/transcriptions/campaign_list_small_blocks.html
@@ -15,7 +15,7 @@
 {% block main_content %}
     <div class="container py-3">
         <h1>Completed Campaigns</h1>
-        <div id="campaign-options" class="d-flex justify-content-end mb-2">
+        <div id="campaign-options" class="d-flex justify-content-end mb-2 mt-3">
             <div class="d-flex align-items-center mx-2">
                 <label for="view-options" class="pe-1">View</label>
                 <select id="view-options">


### PR DESCRIPTION
- When browser window is narrowed filters go off the left edge. They should stack for responsivity
- Go button is larger than filters - they should be the exact same height so that their edges are seamless.
- More padding is needed between Completed Campaigns header and filters

https://staff.loc.gov/tasks/browse/CONCD-996?focusedId=929663&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-929663