### PR TITLE
CONCD-996 Remaining issues

### DIFF
--- a/concordia/static/scss/base.scss
+++ b/concordia/static/scss/base.scss
@@ -1135,14 +1135,14 @@ body .disabled > .page-link {
     select {
         background-color: $white;
         border-color: $blue;
-        font-size: 12px;
+        font-size: 16px;
         height: 2.286rem;
-        padding: 0.321rem 0.6rem;
+        padding: 0.3rem;
     }
 
     .btn {
         border-radius: 0;
-        font-size: 12px;
+        font-size: 16px;
         height: 2.286rem;
     }
 }


### PR DESCRIPTION
- Font of the dropdown and Go are too small.  In mocks they look to be the same size as the field name (View, etc.)
- Padding around button/dropdown should be reduced (maybe cut in half)