### PR TITLE
CONCD-1037 remove extra blue outline around 'Not Started'

### DIFF
--- a/concordia/static/scss/base.scss
+++ b/concordia/static/scss/base.scss
@@ -933,7 +933,6 @@ li.breadcrumb-item.active {
             #fff 50%
         );
         background-size: 10px 10px;
-        border: 1px solid $primary;
         flex: 1 1 0%;
         opacity: 0.8;
     }


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-1037?focusedId=932007&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-932007