### PR TITLE
Additional tests for the Concordia app

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [run]
+dynamic_context = test_function
 branch = true
 include =
     concordia/*
@@ -8,6 +9,7 @@ omit =
     */migrations/*
     */tests/*
     */settings*.py
+    */urls.py
     */static/*
 
 [report]

--- a/concordia/__init__.py
+++ b/concordia/__init__.py
@@ -3,10 +3,3 @@ from __future__ import absolute_import, unicode_literals
 from concordia.celery import app as celery_app
 
 __all__ = ["celery_app"]
-
-
-VERSION = (0, 0, 1)
-
-
-def get_version():
-    return ".".join(map(str, VERSION))

--- a/concordia/celery.py
+++ b/concordia/celery.py
@@ -29,8 +29,3 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 
 # Load task modules from all registered Django app configs.
 app.autodiscover_tasks()
-
-
-@app.task(bind=True)
-def debug_task(self):
-    print("Request: {0!r}".format(self.request))

--- a/concordia/tests/test_account_views.py
+++ b/concordia/tests/test_account_views.py
@@ -105,6 +105,17 @@ class ConcordiaAccountViewTests(
         self.login_user()
 
         with self.settings(REQUIRE_EMAIL_RECONFIRMATION=False):
+            # First, test trying to 'update' to the already used email
+            response = self.client.post(
+                reverse("user-profile"),
+                {"email": self.user.email, "username": "tester"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("form", response.context)
+        self.assertFalse(response.context["form"].is_valid())
+
+        with self.settings(REQUIRE_EMAIL_RECONFIRMATION=False):
             response = self.client.post(
                 reverse("user-profile"), {"email": test_email, "username": "tester"}
             )

--- a/concordia/tests/test_api_views.py
+++ b/concordia/tests/test_api_views.py
@@ -54,6 +54,16 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
                 cls.assets.append(
                     create_asset(title=f"{item.id} — {i}", item=item, do_save=False)
                 )
+            cls.assets.append(
+                create_asset(
+                    title=f"Thumbnail URL test for {item.id}",
+                    item=item,
+                    download_url="http://tile.loc.gov/image-services/iiif/"
+                    "service:music:mussuffrage:mussuffrage-100183:mussuffrage-100183.0001/"
+                    "full/pct:100/0/default.jpg",
+                    do_save=False,
+                )
+            )
         Asset.objects.bulk_create(cls.assets)
 
         cls.transcriptions = []
@@ -347,3 +357,5 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
             self.assertIn("slug", obj)
             self.assertIn("url", obj)
             self.assertIn("year", obj)
+            if "Thumbnail test" in obj["title"]:
+                self.assertIn("https", obj["thumbnail_url"])

--- a/concordia/tests/test_api_views.py
+++ b/concordia/tests/test_api_views.py
@@ -104,10 +104,6 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
 
         cls.assets = []
         for item in cls.items:
-            for i in range(0, 15):
-                cls.assets.append(
-                    create_asset(title=f"{item.id} — {i}", item=item, do_save=False)
-                )
             cls.assets.append(
                 create_asset(
                     title=f"Thumbnail URL test for {item.id}",
@@ -118,6 +114,10 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
                     do_save=False,
                 )
             )
+            for i in range(0, 15):
+                cls.assets.append(
+                    create_asset(title=f"{item.id} — {i}", item=item, do_save=False)
+                )
         Asset.objects.bulk_create(cls.assets)
 
         cls.transcriptions = []

--- a/concordia/tests/test_api_views.py
+++ b/concordia/tests/test_api_views.py
@@ -1,9 +1,12 @@
+from datetime import date
+from unittest import mock
 from urllib.parse import urlparse
 
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.timezone import now
 
+from concordia import api_views
 from concordia.models import (
     Asset,
     Campaign,
@@ -21,6 +24,57 @@ from .utils import (
     create_project,
     create_topic,
 )
+
+
+class URLAwareEncoderTest(TestCase):
+    def test_default(self):
+        encoder = api_views.URLAwareEncoder()
+        self.assertEqual(encoder.default(None), None)
+
+        obj = mock.Mock(spec=["url"])
+        self.assertEqual(encoder.default(obj), obj.url)
+
+        obj = mock.Mock(spec=["get_absolute_url"])
+        self.assertEqual(encoder.default(obj), obj.get_absolute_url())
+
+        # Test non-model object
+        obj = date.today()
+        self.assertEqual(encoder.default(obj), date.today().isoformat())
+
+
+class APIViewMixinTest(TestCase):
+    def setUp(self):
+        self.mixin = api_views.APIViewMixin()
+
+    def test_serialize_conctext(self):
+        context = {"test-key": "test-value"}
+        self.assertEqual(self.mixin.serialize_context(context), context)
+
+    @mock.patch("concordia.api_views.model_to_dict")
+    def test_serialize_object(self, mtd_mock):
+        return_data = {"test-key": "test-value"}
+        mtd_mock.return_value = return_data
+
+        obj = mock.Mock(spec=["get_absolute_url"])
+        data = self.mixin.serialize_object(obj)
+
+        self.assertEqual(data, return_data | {"url": obj.get_absolute_url()})
+
+        obj = mock.Mock(spec=[])
+        data = self.mixin.serialize_object(obj)
+
+        self.assertEqual(data, return_data)
+
+
+@mock.patch("concordia.api_views.time")
+class APIListViewTest(TestCase):
+    def test_serialize_context(self, time_mock):
+        time_mock.return_value = "test-time"
+        view = api_views.APIListView()
+        context = {"object_list": []}
+
+        data = view.serialize_context(context)
+        self.assertEqual(data, {"objects": [], "sent": "test-time"})
 
 
 @override_settings(RATELIMIT_ENABLE=False)
@@ -102,7 +156,7 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
         data = self.assertValidJSON(resp)
         return resp, data
 
-    def get_api_list_response(self, url, page_size=23, **request_args):
+    def get_api_list_response(self, url, page_size=10, **request_args):
         """
         This issues a call to one of our API views and confirms that the
         response follows our basic conventions of returning a top level object

--- a/concordia/tests/test_authentication.py
+++ b/concordia/tests/test_authentication.py
@@ -1,0 +1,69 @@
+from django.test import RequestFactory, TestCase
+
+from concordia.authentication_backends import EmailOrUsernameModelBackend
+
+from .utils import CreateTestUsers
+
+
+class AuthenticationBackendTests(TestCase, CreateTestUsers):
+    def test_EmailOrUsernameModelBackend(self):
+        backend = EmailOrUsernameModelBackend()
+        request_factory = RequestFactory()
+        test_user = self.create_user("tester")
+        request = request_factory.get("/")
+
+        # Fail to authenticate with no information
+        user = backend.authenticate(request)
+        self.assertEqual(user, None)
+
+        # Fail to authenticate with no password, using username
+        user = backend.authenticate(request, test_user.username)
+        self.assertEqual(user, None)
+
+        # Authenticate with correct password, using username
+        user = backend.authenticate(request, test_user.username, test_user._password)
+        self.assertEqual(user, test_user)
+
+        # Fail to authenticate with no password, using email
+        user = backend.authenticate(request, test_user.email)
+        self.assertEqual(user, None)
+
+        # Authenticate with correct password, using email
+        user = backend.authenticate(request, test_user.email, test_user._password)
+        self.assertEqual(user, test_user)
+
+        # Fail to authenticate with incorrect password, using username
+        user = backend.authenticate(request, test_user.username, "bad-password")
+        self.assertEqual(user, None)
+
+        # Fail to authenticate with incorrect password, using email
+        user = backend.authenticate(request, test_user.email, "bad-password")
+        self.assertEqual(user, None)
+
+        # Same tests, with user with a username
+        # the same as the first user's email address
+        test_user2 = self.create_user(test_user.email)
+
+        # Fail to authenticate with no password, using username
+        user = backend.authenticate(request, test_user2.username)
+        self.assertEqual(user, None)
+
+        # Authenticate with correct password, using username
+        user = backend.authenticate(request, test_user2.username, test_user2._password)
+        self.assertEqual(user, test_user2)
+
+        # Fail to authenticate with no password, using email
+        user = backend.authenticate(request, test_user2.email)
+        self.assertEqual(user, None)
+
+        # Authenticate with correct password, using email
+        user = backend.authenticate(request, test_user2.email, test_user2._password)
+        self.assertEqual(user, test_user2)
+
+        # Fail to authenticate with incorrect password, using username
+        user = backend.authenticate(request, test_user2.username, "bad-password")
+        self.assertEqual(user, None)
+
+        # Fail to authenticate with incorrect password, using email
+        user = backend.authenticate(request, test_user2.email, "bad-password")
+        self.assertEqual(user, None)

--- a/concordia/tests/test_fields.py
+++ b/concordia/tests/test_fields.py
@@ -25,7 +25,7 @@ class TestFields(TestCase):
             open_mock = opener_mock.return_value.open
             read_mock = open_mock.return_value.read
 
-            field = TurnstileField()
+            field = TurnstileField(required=False)
 
             self.assertEqual(
                 field.widget_attrs(field.widget),

--- a/concordia/tests/test_fields.py
+++ b/concordia/tests/test_fields.py
@@ -1,0 +1,70 @@
+from unittest import mock
+from urllib.error import HTTPError
+
+from django.forms import ValidationError
+from django.test import TestCase, override_settings
+
+from concordia.turnstile.fields import TurnstileField
+
+
+class TestFields(TestCase):
+    @override_settings(
+        TURNSTILE_PROXIES={},
+        TURNSTILE_SECRET="test-secret",
+        TURNSTILE_VERIFY_URL="http://example.com",
+        TURNSTILE_TIMEOUT=0,
+    )
+    def test_TurnstileField(self):
+        with (
+            override_settings(
+                TURNSTILE_DEFAULT_CONFIG={"appearance": "interaction-only"}
+            ),
+            mock.patch("concordia.turnstile.fields.Request"),
+            mock.patch("concordia.turnstile.fields.build_opener") as opener_mock,
+        ):
+            open_mock = opener_mock.return_value.open
+            read_mock = open_mock.return_value.read
+
+            field = TurnstileField()
+
+            self.assertEqual(
+                field.widget_attrs(field.widget),
+                {"data-appearance": "interaction-only"},
+            )
+
+            # Successful validation from Turnstile
+            read_mock.return_value = '{"success" : true}'.encode()
+            self.assertEqual(field.validate("test-value"), None)
+
+            # Unsuccessful validation from Turnstile
+            read_mock.return_value = '{"test-key" : "test-value"}'.encode()
+            self.assertRaises(ValidationError, field.validate, "test-value")
+
+            # Error trying to contact Turnstile
+            open_mock.side_effect = HTTPError(
+                "http://example.com", 404, "Test message%", "", mock.MagicMock()
+            )
+            self.assertRaises(ValidationError, field.validate, "test-value")
+
+            # Testing special parameters on the widget
+            field = TurnstileField(
+                onload="testOnload()",
+                render="test-render",
+                hl="test-hl",
+                test_parameter="test-data",
+            )
+            self.assertEqual(
+                field.widget_attrs(field.widget),
+                {
+                    "data-appearance": "interaction-only",
+                    "data-test_parameter": "test-data",
+                },
+            )
+            self.assertEqual(
+                field.widget.extra_url,
+                {
+                    "onload": "testOnload()",
+                    "render": "test-render",
+                    "hl": "test-hl",
+                },
+            )

--- a/concordia/tests/test_maintenance.py
+++ b/concordia/tests/test_maintenance.py
@@ -1,0 +1,53 @@
+from django.core.cache import cache
+from django.test import RequestFactory, TestCase
+from maintenance_mode.core import set_maintenance_mode
+
+from concordia.maintenance import need_maintenance_response
+
+from .utils import CreateTestUsers
+
+
+class TestMaintenance(TestCase, CreateTestUsers):
+    def setUp(self):
+        self.request_factory = RequestFactory()
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_need_maintenance_response_maintenance_default(self):
+        request = self.request_factory.get("/")
+        self.assertFalse(need_maintenance_response(request))
+
+    def test_need_maintenance_response_maintenance_off(self):
+        set_maintenance_mode(False)
+        request = self.request_factory.get("/")
+        self.assertFalse(need_maintenance_response(request))
+
+    def test_need_maintenance_response_maintenance_on(self):
+        set_maintenance_mode(True)
+        request = self.request_factory.get("/")
+        self.assertTrue(need_maintenance_response(request))
+
+        request.user = self.create_test_user()
+        request.user.is_staff = True
+
+        # User is set and is staff, but frontend is off
+        # (the default) so they should still get a maintenance
+        # mode response
+        self.assertTrue(need_maintenance_response(request))
+
+    def test_need_maintenance_response_maintenance_frontend(self):
+        set_maintenance_mode(True)
+        request = self.request_factory.get("/")
+        request.user = self.create_test_user()
+        cache.set("maintenance_mode_frontend_available", True)
+
+        # User is set but isn't super user, so they should get
+        # a maintenance mode response
+        self.assertTrue(need_maintenance_response(request))
+
+        request.user.is_staff = True
+        # User is staff, so they shouldn't get a maintenance
+        # mode response
+        self.assertFalse(need_maintenance_response(request))

--- a/concordia/tests/test_registration_views.py
+++ b/concordia/tests/test_registration_views.py
@@ -3,6 +3,7 @@ Tests for user registration-related views
 """
 
 from logging import getLogger
+from unittest import mock
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.tokens import default_token_generator
@@ -47,7 +48,8 @@ class ConcordiaViewTests(
 
         self.assertEqual(len(mail.outbox), 1)
 
-    def test_password_reset_will_activate_user(self):
+    @mock.patch("concordia.forms.user_activated.send")
+    def test_password_reset_will_activate_user(self, signal_mock):
         self.user = self.create_inactive_user("tester2")
         fake_pw = "ASdf12&&"
         new_password_data = {"new_password1": fake_pw, "new_password2": fake_pw}
@@ -72,3 +74,36 @@ class ConcordiaViewTests(
         # Verify the User was correctly activated
         updated_user = User.objects.get(pk=self.user.pk)
         self.assertEqual(updated_user.is_active, True)
+
+        # Verify activation signal was sent
+        self.assertTrue(signal_mock.called)
+
+    @mock.patch("concordia.forms.user_activated.send")
+    def test_password_reset_with_activate_user(self, signal_mock):
+        self.user = self.create_user("tester")
+        fake_pw = "ASdf12&&"
+        new_password_data = {"new_password1": fake_pw, "new_password2": fake_pw}
+        password_reset_token = default_token_generator.make_token(self.user)
+        uidb64 = urlsafe_base64_encode(force_bytes(self.user.pk))
+
+        session = self.client.session
+        session[INTERNAL_RESET_SESSION_TOKEN] = password_reset_token
+        session.save()
+
+        confirm_response = self.client.post(
+            reverse(
+                "password_reset_confirm",
+                kwargs={"uidb64": uidb64, "token": INTERNAL_RESET_URL_TOKEN},
+            ),
+            new_password_data,
+        )
+
+        self.assertRedirects(confirm_response, "/account/reset/done/")
+        self.assertUncacheable(confirm_response)
+
+        # Verify the User is still activated
+        updated_user = User.objects.get(pk=self.user.pk)
+        self.assertEqual(updated_user.is_active, True)
+
+        # Verify activation signal was not sent
+        self.assertFalse(signal_mock.called)

--- a/concordia/tests/test_sentry.py
+++ b/concordia/tests/test_sentry.py
@@ -1,0 +1,31 @@
+import importlib
+import os
+from unittest import mock
+
+from django.test import TestCase
+
+from concordia import celery
+
+
+class TestSentry(TestCase):
+    @mock.patch.dict(
+        os.environ,
+        {
+            "SENTRY_BACKEND_DSN": "http://example.com",
+            "CONCORDIA_ENVIRONMENT": "dummy_environment",
+        },
+    )
+    def test_sentry_config(self):
+        # Because the celery module is imported during start up,
+        # we need to reload it after patching Sentry.
+        # release and integrations aren't tested because they
+        # are impossible to mock due to the how everything is imported
+        # and the functions called are tested elsewhere
+        with mock.patch("concordia.celery.sentry_sdk.init") as sentry_mock:
+            importlib.reload(celery)
+            sentry_mock.assert_called_with(
+                "http://example.com",
+                environment="dummy_environment",
+                release=mock.ANY,
+                integrations=mock.ANY,
+            )

--- a/concordia/tests/test_signals.py
+++ b/concordia/tests/test_signals.py
@@ -35,6 +35,21 @@ class TestSignalHandlers(CreateTestUsers, TestCase):
             self.assertTrue(request.user.is_authenticated)
             self.assertEqual(len(mail.outbox), 1)
 
+    def test_user_successfully_activated_no_request(self):
+        with mock.patch("concordia.signals.handlers.flag_enabled") as flag_mock:
+            flag_mock.return_value = True
+            user_activated.send(sender=self.__class__, user=self.user, request=None)
+            self.assertEqual(len(mail.outbox), 1)
+
+    def test_user_successfully_activated_no_welcome_email(self):
+        with mock.patch("concordia.signals.handlers.flag_enabled") as flag_mock:
+            flag_mock.return_value = False
+            response = self.client.get("/")
+            request = response.wsgi_request
+            user_activated.send(sender=self.__class__, user=self.user, request=request)
+            self.assertTrue(request.user.is_authenticated)
+            self.assertEqual(len(mail.outbox), 0)
+
     def test_add_user_to_newsletter(self):
         self.login_user()
         response = self.client.post("/")

--- a/concordia/tests/test_validators.py
+++ b/concordia/tests/test_validators.py
@@ -1,6 +1,9 @@
+import string
+
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
+from concordia.passwords.validators import ComplexityValidator
 from concordia.validators import DjangoPasswordsValidator
 
 
@@ -38,3 +41,158 @@ class TestValidators(TestCase):
             validator.get_help_text(),
             "Your password fails to meet our complexity requirements.",
         )
+
+
+class ComplexityValidatorTests(TestCase):
+    def assertValid(self, validator, string):
+        try:
+            validator(string)
+        except ValidationError:
+            self.fail(f"String {string} failed validation unexpectedly")
+
+    def assertInvalid(self, validator, string):
+        self.assertRaises(ValidationError, validator, string)
+
+    def make_validator(self, **complexities):
+        return ComplexityValidator(complexities=complexities)
+
+    def test_empty_validator(self):
+        validator = ComplexityValidator(complexities=None)
+        self.assertValid(validator, "")
+
+    def test_minimum_uppercase_count(self):
+        validator = self.make_validator(UPPER=0)
+        self.assertValid(validator, "no uppercase")
+        self.assertValid(validator, "Some UpperCase")
+        self.assertValid(validator, "ALL UPPERCASE")
+
+        validator = self.make_validator(UPPER=1)
+        self.assertInvalid(validator, "no uppercase")
+        self.assertValid(validator, "Some UpperCase")
+        self.assertValid(validator, "ALL UPPERCASE")
+
+        validator = self.make_validator(UPPER=100)
+        self.assertInvalid(validator, "no uppercase")
+        self.assertInvalid(validator, "Some UpperCase")
+        self.assertInvalid(validator, "ALL UPPERCASE")
+
+    def test_minimum_lowercase_count(self):
+        validator = self.make_validator(LOWER=0)
+        self.assertValid(validator, "NO LOWERCASE")
+        self.assertValid(validator, "sOME lOWERCASE")
+        self.assertValid(validator, "all lowercase")
+
+        validator = self.make_validator(LOWER=1)
+        self.assertInvalid(validator, "NO LOWERCASE")
+        self.assertValid(validator, "sOME lOWERCASE")
+        self.assertValid(validator, "all lowercase")
+
+        validator = self.make_validator(LOWER=100)
+        self.assertInvalid(validator, "NO LOWERCASE")
+        self.assertInvalid(validator, "sOME lOWERCASE")
+        self.assertInvalid(validator, "all lowercase")
+
+    def test_minimum_letter_count(self):
+        validator = self.make_validator(LETTERS=0)
+        self.assertValid(validator, "1234. ?")
+        self.assertValid(validator, "soME 123")
+        self.assertValid(validator, "allletters")
+
+        validator = self.make_validator(LETTERS=1)
+        self.assertInvalid(validator, "1234. ?")
+        self.assertValid(validator, "soME 123")
+        self.assertValid(validator, "allletters")
+
+        validator = self.make_validator(LETTERS=100)
+        self.assertInvalid(validator, "1234. ?")
+        self.assertInvalid(validator, "soME 123")
+        self.assertInvalid(validator, "allletters")
+
+    def test_minimum_digit_count(self):
+        validator = self.make_validator(DIGITS=0)
+        self.assertValid(validator, "")
+        self.assertValid(validator, "0")
+        self.assertValid(validator, "1")
+        self.assertValid(validator, "11")
+        self.assertValid(validator, "one 1")
+
+        validator = self.make_validator(DIGITS=1)
+        self.assertInvalid(validator, "")
+        self.assertValid(validator, "0")
+        self.assertValid(validator, "1")
+        self.assertValid(validator, "11")
+        self.assertValid(validator, "one 1")
+
+    def test_minimum_punctuation_count(self):
+        none = "no punctuation"
+        one = "ffs!"
+        mixed = r"w@oo%lo(om!ol~oo&"
+        allpunc = string.punctuation
+
+        validator = self.make_validator(SPECIAL=0)
+        self.assertValid(validator, none)
+        self.assertValid(validator, one)
+        self.assertValid(validator, mixed)
+        self.assertValid(validator, allpunc)
+
+        validator = self.make_validator(SPECIAL=1)
+        self.assertInvalid(validator, none)
+        self.assertValid(validator, one)
+        self.assertValid(validator, mixed)
+        self.assertValid(validator, allpunc)
+
+        validator = self.make_validator(SPECIAL=100)
+        self.assertInvalid(validator, none)
+        self.assertInvalid(validator, one)
+        self.assertInvalid(validator, mixed)
+        self.assertInvalid(validator, allpunc)
+
+    def test_minimum_nonascii_count(self):
+        none = "regularchars and numbers 100"
+        one = "\x00"  # null
+        many = "\x00\x01\x02\x03\x04\x05\t\n\r"
+
+        validator = self.make_validator(SPECIAL=0)
+        self.assertValid(validator, none)
+        self.assertValid(validator, one)
+        self.assertValid(validator, many)
+
+        validator = self.make_validator(SPECIAL=1)
+        self.assertInvalid(validator, none)
+        self.assertValid(validator, one)
+        self.assertValid(validator, many)
+
+        validator = self.make_validator(SPECIAL=100)
+        self.assertInvalid(validator, none)
+        self.assertInvalid(validator, one)
+        self.assertInvalid(validator, many)
+
+    def test_minimum_words_count(self):
+        none = ""
+        one = "oneword"
+        some = "one or two words"
+        many = "a b c d e f g h i 1 2 3 4 5 6 7 8 9 { $ # ! )}"
+
+        validator = self.make_validator(WORDS=0)
+        self.assertValid(validator, none)
+        self.assertValid(validator, one)
+        self.assertValid(validator, some)
+        self.assertValid(validator, many)
+
+        validator = self.make_validator(WORDS=1)
+        self.assertInvalid(validator, none)
+        self.assertValid(validator, one)
+        self.assertValid(validator, some)
+        self.assertValid(validator, many)
+
+        validator = self.make_validator(WORDS=10)
+        self.assertInvalid(validator, none)
+        self.assertInvalid(validator, one)
+        self.assertInvalid(validator, some)
+        self.assertValid(validator, many)
+
+        validator = self.make_validator(WORDS=100)
+        self.assertInvalid(validator, none)
+        self.assertInvalid(validator, one)
+        self.assertInvalid(validator, some)
+        self.assertInvalid(validator, many)

--- a/concordia/tests/test_widgets.py
+++ b/concordia/tests/test_widgets.py
@@ -1,5 +1,6 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
+from concordia.turnstile.widgets import TurnstileWidget
 from concordia.widgets import EmailWidget
 
 
@@ -23,4 +24,57 @@ class TestWidgets(TestCase):
             output,
             '<input class="fst-italic form-control" display="none;"'
             ' name="email" type="email">',
+        )
+
+    @override_settings(TURNSTILE_SITEKEY="test-key", TURNSTILE_JS_API_URL="test-url")
+    def test_TurnstileWidget(self):
+        widget = TurnstileWidget()
+
+        self.assertEqual(widget.value_from_datadict({}, None, None), None)
+
+        data = {"cf-turnstile-response": "test-data"}
+        self.assertEqual(widget.value_from_datadict(data, None, None), "test-data")
+
+        self.assertEqual(widget.build_attrs({}), {"data-sitekey": "test-key"})
+
+        self.assertEqual(
+            widget.build_attrs(
+                {"id": "test-id"}, extra_attrs={"custom-attr": "test-attr"}
+            ),
+            {"data-sitekey": "test-key", "id": "test-id", "custom-attr": "test-attr"},
+        )
+
+        self.assertEqual(
+            widget.get_context("test-name", "test value", {}),
+            {
+                "widget": {
+                    "name": "test-name",
+                    "is_hidden": False,
+                    "required": False,
+                    "value": "test value",
+                    "attrs": {"data-sitekey": "test-key"},
+                    "template_name": "forms/widgets/turnstile_widget.html",
+                },
+                "api_url": "test-url",
+            },
+        )
+
+        widget.extra_url = {
+            "test-parameter1": "test-value1",
+            "test-parameter2": "test-value2",
+        }
+        self.assertEqual(
+            widget.get_context("test-name", "test value", {}),
+            {
+                "widget": {
+                    "name": "test-name",
+                    "is_hidden": False,
+                    "required": False,
+                    "value": "test value",
+                    "attrs": {"data-sitekey": "test-key"},
+                    "template_name": "forms/widgets/turnstile_widget.html",
+                },
+                "api_url": "test-url?test-parameter1=test-value1&"
+                "test-parameter2=test-value2",
+            },
         )

--- a/concordia/tests/test_widgets.py
+++ b/concordia/tests/test_widgets.py
@@ -30,13 +30,17 @@ class TestWidgets(TestCase):
     def test_TurnstileWidget(self):
         widget = TurnstileWidget()
 
+        # Testing basic validation
         self.assertEqual(widget.value_from_datadict({}, None, None), None)
 
+        # Testing validation with data
         data = {"cf-turnstile-response": "test-data"}
         self.assertEqual(widget.value_from_datadict(data, None, None), "test-data")
 
+        # Testing basic attrs
         self.assertEqual(widget.build_attrs({}), {"data-sitekey": "test-key"})
 
+        # Testing with extra ttrs
         self.assertEqual(
             widget.build_attrs(
                 {"id": "test-id"}, extra_attrs={"custom-attr": "test-attr"}
@@ -44,6 +48,7 @@ class TestWidgets(TestCase):
             {"data-sitekey": "test-key", "id": "test-id", "custom-attr": "test-attr"},
         )
 
+        # Testing basic context
         self.assertEqual(
             widget.get_context("test-name", "test value", {}),
             {
@@ -59,6 +64,7 @@ class TestWidgets(TestCase):
             },
         )
 
+        # Testing with special context
         widget.extra_url = {
             "test-parameter1": "test-value1",
             "test-parameter2": "test-value2",

--- a/concordia/tests/utils.py
+++ b/concordia/tests/utils.py
@@ -16,6 +16,7 @@ from concordia.models import (
     Item,
     MediaType,
     Project,
+    ResearchCenter,
     Resource,
     ResourceFile,
     SimplePage,
@@ -316,6 +317,13 @@ def create_campaign_retirement_progress(
     if do_save:
         progress.save()
     return progress
+
+
+def create_research_center(*, title="Test Research Center", do_save=True, **kwargs):
+    center = ResearchCenter(title=title, **kwargs)
+    if do_save:
+        center.save()
+    return center
 
 
 class JSONAssertMixin(object):

--- a/concordia/turnstile/fields.py
+++ b/concordia/turnstile/fields.py
@@ -67,7 +67,7 @@ class TurnstileField(forms.Field):
         try:
             response = opener.open(request, timeout=settings.TURNSTILE_TIMEOUT)
         except HTTPError as exc:
-            logger.exception("HTTPError received from Turnstile: ", exc, exc_info=exc)
+            logger.exception("HTTPError received from Turnstile: %s", exc, exc_info=exc)
             raise forms.ValidationError(
                 self.error_messages["error_turnstile"], code="error_turnstile"
             ) from exc

--- a/concordia/turnstile/widgets.py
+++ b/concordia/turnstile/widgets.py
@@ -1,5 +1,5 @@
 # Originally from
-# https://github.com/zmh-program/django-turnstile/blob/main/turnstile/fields.py
+# https://github.com/zmh-program/django-turnstile/blob/main/turnstile/widgets.py
 
 from urllib.parse import urlencode
 

--- a/concordia/views.py
+++ b/concordia/views.py
@@ -909,7 +909,9 @@ class CampaignListView(APIListView):
 
 @method_decorator(default_cache_control, name="dispatch")
 class CompletedCampaignListView(APIListView):
+    model = Campaign
     template_name = "transcriptions/campaign_list_small_blocks.html"
+    context_object_name = "campaigns"
 
     def _get_all_campaigns(self):
         if self.request.GET.get("type", "completed") == "retired":
@@ -932,8 +934,6 @@ class CompletedCampaignListView(APIListView):
         ).distinct()
 
         return data
-
-    context_object_name = "campaigns"
 
 
 def calculate_asset_stats(asset_qs, ctx):


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-1054

A few non-test changes:

Added dynamic context to .coveragerc. This allows us to see which tests which run which part of the code in the HTML coverage report.

Added urls.py to be ignored by coverage, since nothing in there needs to be tested.

Some small bugfixes uncovered while writing the tests (primarily just a logging statement that was incorrectly formatted).

Removed an outdated implementation to get the version of the app that had never been updated.

Removed unneeded Celery debug task.