### PR TITLE
Removed Last-Modified header from simple pages

### DIFF
--- a/concordia/views.py
+++ b/concordia/views.py
@@ -262,7 +262,6 @@ def simple_page(request, path=None, slug=None, body_ctx=None):
 
     resp = render(request, "static-page.html", ctx)
     resp["Created"] = http_date(page.created_on.timestamp())
-    resp["Last-Modified"] = http_date(page.updated_on.timestamp())
     return resp
 
 


### PR DESCRIPTION
Since it was inaccurate and causing issues with CloudFlare caching

https://staff.loc.gov/tasks/browse/CONCD-1075