### PR TITLE
Made text for image filter buttons white instead of blue due to the dark background

### DIFF
--- a/concordia/static/scss/base.scss
+++ b/concordia/static/scss/base.scss
@@ -1381,6 +1381,7 @@ button.btn-outline-primary:hover {
 */
 
 #image-filters .btn-dark {
+    color: $light;
     text-decoration: underline;
     border-radius: 0;
 


### PR DESCRIPTION
http://staff.loc.gov/tasks/browse/CONCD-1068