### PR TITLE
CONCD-1079 replace deprecated methods

### DIFF
--- a/concordia/tests/test_admin.py
+++ b/concordia/tests/test_admin.py
@@ -217,7 +217,7 @@ class ResourceFileAdminTest(TestCase, CreateTestUsers):
             resource = MockResource()
 
         result = self.resource_file_admin.resource_url(MockResourceFile())
-        self.assertEquals(result, "http://example.com")
+        self.assertEqual(result, "http://example.com")
 
     def test_get_fields(self):
         request = self.request_factory.get("/")
@@ -247,15 +247,15 @@ class ProjectAdminTest(TestCase, CreateTestUsers):
     def test_item_import_view(self):
         self.client.force_login(self.staff_user)
         response = self.client.get(reverse(self.url_lookup, args=[self.project.id]))
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
         self.client.logout()
 
         self.client.force_login(self.super_user)
         response = self.client.get(reverse(self.url_lookup, args=[self.project.id + 1]))
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
         response = self.client.get(reverse(self.url_lookup, args=[self.project.id]))
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(
             response, template_name="admin/concordia/project/item_import.html"
         )
@@ -264,7 +264,7 @@ class ProjectAdminTest(TestCase, CreateTestUsers):
             reverse(self.url_lookup, args=[self.project.id]),
             {"bad_param": "https://example.com"},
         )
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(
             response, template_name="admin/concordia/project/item_import.html"
         )
@@ -315,35 +315,35 @@ class ItemAdminTest(TestCase, CreateTestUsers):
         deleted_objects, model_count, perms_needed, protected = (
             self.admin.get_deleted_objects(mock_objs, request)
         )
-        self.assertEquals(len(deleted_objects), 4)
-        self.assertEquals(model_count, {"items": 50, "assets": 1, "transcriptions": 1})
-        self.assertNotEquals(perms_needed, set())
-        self.assertEquals(protected, [])
+        self.assertEqual(len(deleted_objects), 4)
+        self.assertEqual(model_count, {"items": 50, "assets": 1, "transcriptions": 1})
+        self.assertNotEqual(perms_needed, set())
+        self.assertEqual(protected, [])
 
         request.user = self.super_user
         deleted_objects, model_count, perms_needed, protected = (
             self.admin.get_deleted_objects(mock_objs, request)
         )
-        self.assertEquals(len(deleted_objects), 4)
-        self.assertEquals(model_count, {"items": 50, "assets": 1, "transcriptions": 1})
-        self.assertEquals(perms_needed, set())
-        self.assertEquals(protected, [])
+        self.assertEqual(len(deleted_objects), 4)
+        self.assertEqual(model_count, {"items": 50, "assets": 1, "transcriptions": 1})
+        self.assertEqual(perms_needed, set())
+        self.assertEqual(protected, [])
 
         deleted_objects, model_count, perms_needed, protected = (
             self.admin.get_deleted_objects([self.item], request)
         )
-        self.assertEquals(len(deleted_objects), 1)
-        self.assertEquals(model_count, {"items": 1, "assets": 1, "transcriptions": 1})
-        self.assertEquals(perms_needed, set())
-        self.assertEquals(protected, [])
+        self.assertEqual(len(deleted_objects), 1)
+        self.assertEqual(model_count, {"items": 1, "assets": 1, "transcriptions": 1})
+        self.assertEqual(perms_needed, set())
+        self.assertEqual(protected, [])
 
     def test_get_queryset(self):
         request = self.request_factory.get("/")
         qs = self.admin.get_queryset(request)
-        self.assertEquals(qs.count(), 1)
+        self.assertEqual(qs.count(), 1)
 
     def test_campaign_title(self):
-        self.assertEquals(
+        self.assertEqual(
             self.item.project.campaign.title, self.admin.campaign_title(self.item)
         )
 
@@ -362,7 +362,7 @@ class AssetAdminTest(TestCase, CreateTestUsers):
     def test_get_queryset(self):
         request = self.request_factory.get("/")
         qs = self.admin.get_queryset(request)
-        self.assertEquals(qs.count(), 1)
+        self.assertEqual(qs.count(), 1)
 
     def test_lookup_allowed(self):
         self.assertTrue(self.admin.lookup_allowed("item__project__id__exact", 0))
@@ -372,16 +372,16 @@ class AssetAdminTest(TestCase, CreateTestUsers):
         self.assertFalse(self.admin.lookup_allowed("item__project", 0))
 
     def test_item_id(self):
-        self.assertEquals(self.asset.item.item_id, self.admin.item_id(self.asset))
+        self.assertEqual(self.asset.item.item_id, self.admin.item_id(self.asset))
 
     def test_truncated_media_url(self):
         truncated_url = self.admin.truncated_media_url(self.asset)
-        self.assertEquals(truncated_url.count(self.asset.media_url), 2)
+        self.assertEqual(truncated_url.count(self.asset.media_url), 2)
 
         self.asset.media_url = "".join([str(i) for i in range(200)])
         truncated_url = self.admin.truncated_media_url(self.asset)
-        self.assertEquals(truncated_url.count(self.asset.media_url), 1)
-        self.assertEquals(truncated_url.count(self.asset.media_url[:99]), 2)
+        self.assertEqual(truncated_url.count(self.asset.media_url), 1)
+        self.assertEqual(truncated_url.count(self.asset.media_url[:99]), 2)
 
     def test_get_readonly_fields(self):
         request = self.request_factory.get("/")
@@ -479,11 +479,11 @@ class TranscriptionAdminTest(TestCase, CreateTestUsers, StreamingTestMixin):
     def test_truncated_text(self):
         self.transcription.text = self.fake.text(50)
         result = self.admin.truncated_text(self.transcription)
-        self.assertEquals(result, self.transcription.text)
+        self.assertEqual(result, self.transcription.text)
 
         self.transcription.text = self.fake.text(500)
         result = self.admin.truncated_text(self.transcription)
-        self.assertNotEquals(result, self.transcription.text)
+        self.assertNotEqual(result, self.transcription.text)
         self.assertIn(result[:-1], self.transcription.text)
 
     def test_export_to_csv(self):

--- a/concordia/tests/test_api_views.py
+++ b/concordia/tests/test_api_views.py
@@ -11,6 +11,7 @@ from concordia.models import (
     Asset,
     Campaign,
     Item,
+    Project,
     Topic,
     Transcription,
     User,
@@ -86,6 +87,10 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
         cls.reviewer = User.objects.create_user(
             username="reviewer", email="tester@example.com"
         )
+
+        # clear data from other tests
+        Project.objects.all().delete()
+        Topic.objects.all().delete()
 
         cls.test_project = create_project()
 
@@ -270,9 +275,11 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
             serialized_project,
             serialized_project
             | {
+                "id": topic.id,
                 "title": topic.title,
                 "description": topic.description,
                 "slug": topic.slug,
+                "thumbnail_image": topic.thumbnail_image,
             },
         )
         self.assertURLEqual(

--- a/concordia/tests/test_api_views.py
+++ b/concordia/tests/test_api_views.py
@@ -251,7 +251,7 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
         for obj in data["objects"]:
             self.assertIn("id", obj)
             self.assertIn("url", obj)
-            self.assertDictContainsSubset(test_topics[obj["id"]], obj)
+            self.assertEqual(obj, obj | test_topics[obj["id"]])
 
     def test_topic_detail(self):
         resp, data = self.get_api_response(
@@ -266,15 +266,14 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
         self.assertIn("id", serialized_project)
         self.assertIn("url", serialized_project)
         topic = self.test_topic
-        self.assertDictContainsSubset(
-            {
-                "id": topic.id,
+        self.assertEqual(
+            serialized_project,
+            serialized_project
+            | {
                 "title": topic.title,
                 "description": topic.description,
                 "slug": topic.slug,
-                "thumbnail_image": topic.thumbnail_image,
             },
-            serialized_project,
         )
         self.assertURLEqual(
             serialized_project["url"], f"http://testserver{topic.get_absolute_url()}"
@@ -295,7 +294,7 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
         for obj in data["objects"]:
             self.assertIn("id", obj)
             self.assertIn("url", obj)
-            self.assertDictContainsSubset(test_campaigns[obj["id"]], obj)
+            self.assertEqual(obj, obj | test_campaigns[obj["id"]])
 
     def test_campaign_detail(self):
         resp, data = self.get_api_response(
@@ -313,8 +312,10 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
         self.assertIn("id", serialized_project)
         self.assertIn("url", serialized_project)
         campaign = self.test_project.campaign
-        self.assertDictContainsSubset(
-            {
+        self.assertEqual(
+            serialized_project,
+            serialized_project
+            | {
                 "id": campaign.id,
                 "title": campaign.title,
                 "description": campaign.description,
@@ -322,7 +323,6 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
                 "metadata": campaign.metadata,
                 "thumbnail_image": campaign.thumbnail_image,
             },
-            serialized_project,
         )
         self.assertURLEqual(
             serialized_project["url"], f"http://testserver{campaign.get_absolute_url()}"
@@ -348,8 +348,10 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
         self.assertURLEqual(
             serialized_project["url"], f"http://testserver{project.get_absolute_url()}"
         )
-        self.assertDictContainsSubset(
-            {
+        self.assertEqual(
+            serialized_project,
+            serialized_project
+            | {
                 "description": project.description,
                 "id": project.id,
                 "metadata": project.metadata,
@@ -357,7 +359,6 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
                 "thumbnail_image": project.thumbnail_image,
                 "title": project.title,
             },
-            serialized_project,
         )
 
         for obj in data["objects"]:
@@ -389,15 +390,16 @@ class ConcordiaViewTests(JSONAssertMixin, TestCase):
         self.assertURLEqual(
             serialized_item["url"], f"http://testserver{item.get_absolute_url()}"
         )
-        self.assertDictContainsSubset(
-            {
+        self.assertEqual(
+            serialized_item,
+            serialized_item
+            | {
                 "description": item.description,
                 "id": item.id,
                 "item_id": item.item_id,
                 "metadata": item.metadata,
                 "title": item.title,
             },
-            serialized_item,
         )
 
         for obj in data["objects"]:


### PR DESCRIPTION
- CONCD-916: assertEquals, assertNotEquals
- CONCD-1056: assertDictContainsSubset

https://staff.loc.gov/tasks/browse/CONCD-1079