### PR TITLE
Modified rate limit message migration to use new pop-up message

### DIFF
--- a/configuration/migrations/0002_populate_configurations.py
+++ b/configuration/migrations/0002_populate_configurations.py
@@ -11,7 +11,7 @@ def populate_configuration(apps, schema_editor):
         {
             "key": "review_rate_limit_popup_message",
             "data_type": "html",
-            "value": "You cannot yet accept this page.<br />\r\nVolunteers can only accept {% configuration_value 'review_rate_limit' %} pages per minute. Please read all transcriptions completely to ensure they are whole and accurate.<br />\r\n<a href=\"{% url 'how-to-review' %}\">See review instructions.</a>",
+            "value": "<p>Volunteers can only accept {% configuration_value 'review_rate_limit' %} pages per minute.</p>\r\n<p>Please read all transcriptions completely to ensure they are whole and accurate. <a href=\"{% url 'how-to-review' %}\">See review instructions.</a></p>",
             "description": "Message shown in the pop-up when a user exceeds the review rate limit",
         },
         {
@@ -29,7 +29,7 @@ def populate_configuration(apps, schema_editor):
         {
             "key": "review_rate_limit_banner_message",
             "data_type": "html",
-            "value": "You cannot yet accept this page. Volunteers can only accept {% configuration_value 'review_rate_limit' %} pages per minute. See <a href=\"{% url 'how-to-review' %}\">review instructions</a>.",
+            "value": "Volunteers can only accept {% configuration_value 'review_rate_limit' %} pages per minute. See <a href=\"{% url 'how-to-review' %}\">review instructions</a>.",
             "description": "Message to display on the banner when a user exceeds the review rate limit",
         },
     ]

--- a/configuration/migrations/0002_populate_configurations.py
+++ b/configuration/migrations/0002_populate_configurations.py
@@ -29,7 +29,7 @@ def populate_configuration(apps, schema_editor):
         {
             "key": "review_rate_limit_banner_message",
             "data_type": "html",
-            "value": "Volunteers can only accept {% configuration_value 'review_rate_limit' %} pages per minute. See <a href=\"{% url 'how-to-review' %}\">review instructions</a>.",
+            "value": "You cannot yet accept this page. Volunteers can only accept {% configuration_value 'review_rate_limit' %} pages per minute. See <a href=\"{% url 'how-to-review' %}\">review instructions</a>.",
             "description": "Message to display on the banner when a user exceeds the review rate limit",
         },
     ]


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-1114

This won't change the data in the database if this migration has already been applied (though you can rollback to 0001 configuration migration and then reapply 0002 and 0003), but ensures the correct values are in place after database restores in dev/test and when these changes go to production.