### PR TITLE
Fixed some modal Close buttons not working correctly

### DIFF
--- a/concordia/static/js/src/asset-reservation.js
+++ b/concordia/static/js/src/asset-reservation.js
@@ -1,4 +1,4 @@
-/* global jQuery displayMessage displayHtmlMessage buildErrorMessage Sentry */
+/* global jQuery displayMessage displayHtmlMessage buildErrorMessage Sentry bootstrap */
 
 const assetReservationData = document.getElementById(
     'asset-reservation-data',
@@ -6,6 +6,16 @@ const assetReservationData = document.getElementById(
 
 function attemptToReserveAsset(reservationURL, findANewPageURL, actionType) {
     let $transcriptionEditor = jQuery('#transcription-editor');
+    // We need to do this because BS5 does not automatically initialize modals when you
+    // try to show them; without new boostrap.Modal, it doesn't recognize it as a modal
+    // at all (it's treated as ordinary HTML), so BS controls do not work
+    var reservationModalElement = document.getElementById(
+        'asset-reservation-failure-modal',
+    );
+    // This tries to get the modal if it exists, otherwise it initializes it
+    var reservationModal =
+        bootstrap.Modal.getInstance(reservationModalElement) ||
+        new bootstrap.Modal(reservationModalElement);
 
     jQuery
         .ajax({
@@ -33,7 +43,8 @@ function attemptToReserveAsset(reservationURL, findANewPageURL, actionType) {
                     $transcriptionEditor
                         .data('hasReservation', false)
                         .trigger('update-ui-state');
-                    jQuery('#asset-reservation-failure-modal').show();
+                    //jQuery('#asset-reservation-failure-modal').show();
+                    reservationModal.show();
                 } else {
                     displayHtmlMessage(
                         'warning',
@@ -54,7 +65,8 @@ function attemptToReserveAsset(reservationURL, findANewPageURL, actionType) {
                 $transcriptionEditor
                     .data('hasReservation', false)
                     .trigger('update-ui-state');
-                jQuery('#asset-reservation-failure-modal').show();
+                //jQuery('#asset-reservation-failure-modal').show();
+                reservationModal.show();
                 Sentry.captureException(errorThrown, function (scope) {
                     scope.setTransactionName(
                         '408 error when attempting to reserve asset at ' +

--- a/concordia/static/js/src/asset-reservation.js
+++ b/concordia/static/js/src/asset-reservation.js
@@ -43,7 +43,6 @@ function attemptToReserveAsset(reservationURL, findANewPageURL, actionType) {
                     $transcriptionEditor
                         .data('hasReservation', false)
                         .trigger('update-ui-state');
-                    //jQuery('#asset-reservation-failure-modal').show();
                     reservationModal.show();
                 } else {
                     displayHtmlMessage(
@@ -65,7 +64,6 @@ function attemptToReserveAsset(reservationURL, findANewPageURL, actionType) {
                 $transcriptionEditor
                     .data('hasReservation', false)
                     .trigger('update-ui-state');
-                //jQuery('#asset-reservation-failure-modal').show();
                 reservationModal.show();
                 Sentry.captureException(errorThrown, function (scope) {
                     scope.setTransactionName(

--- a/concordia/static/js/src/contribute.js
+++ b/concordia/static/js/src/contribute.js
@@ -1,4 +1,4 @@
-/* global $ displayMessage buildErrorMessage */
+/* global $ displayMessage buildErrorMessage bootstrap */
 
 import {selectLanguage} from 'ocr';
 import {reserveAssetForEditing} from 'asset-reservation';
@@ -174,6 +174,24 @@ function setupPage() {
     var rollforwardButton = document.getElementById(
         'rollforward-transcription-button',
     );
+    // We need to do this because BS5 does not automatically initialize modals when you
+    // try to show them; without new boostrap.Modal, it doesn't recognize it as a modal
+    // at all (it's treated as ordinary HTML), so BS controls do not work
+    // We try to get Modal.getInstance in case the modal is already initialized
+    var errorModalElement = document.getElementById('error-modal');
+    var errorModal =
+        bootstrap.Modal.getInstance(errorModalElement) ||
+        new bootstrap.Modal(errorModalElement);
+    var submissionModalElement = document.getElementById(
+        'successful-submission-modal',
+    );
+    var submissionModal =
+        bootstrap.Modal.getInstance(submissionModalElement) ||
+        new bootstrap.Modal(submissionModalElement);
+    var reviewModalElement = document.getElementById('review-accepted-modal');
+    var reviewModal =
+        bootstrap.Modal.getInstance(reviewModalElement) ||
+        new bootstrap.Modal(reviewModalElement);
 
     let firstEditorUpdate = true;
     let editorPlaceholderText = $transcriptionEditor
@@ -354,11 +372,13 @@ function setupPage() {
                     .removeAttr('hidden')
                     .find('#message-contributors-num')
                     .html(data.asset.contributors);
-                $('#successful-submission-modal')
-                    .show()
-                    .on('hidden.bs.modal', function () {
+                submissionModal.show();
+                submissionModalElement.addEventListener(
+                    'hidden.bs.modal',
+                    function () {
                         window.location.reload(true);
-                    });
+                    },
+                );
             })
             .fail(function (jqXHR, textStatus, errorThrown) {
                 displayMessage(
@@ -447,11 +467,13 @@ function setupPage() {
                         .removeAttr('hidden')
                         .find('#message-contributors-num')
                         .html(data.asset.contributors);
-                    $('#review-accepted-modal')
-                        .show()
-                        .on('hidden.bs.modal', function () {
+                    reviewModal.show();
+                    reviewModalElement.addEventListener(
+                        'hidden.bs.modal',
+                        function () {
                             window.location.reload(true);
-                        });
+                        },
+                    );
                 }
             })
             .fail(function (jqXHR, textStatus, errorThrown) {
@@ -477,7 +499,7 @@ function setupPage() {
                         .find('#error-modal-message')
                         .first()
                         .html(popupErrorMessage);
-                    $('#error-modal').show();
+                    errorModal.show();
                 }
             });
     }

--- a/concordia/templates/transcriptions/asset_detail/asset_reservation_failure_modal.html
+++ b/concordia/templates/transcriptions/asset_detail/asset_reservation_failure_modal.html
@@ -2,9 +2,7 @@
     <div class="modal-content">
         <div class="modal-header">
             <h5 class="modal-title">Someone else is already transcribing this page</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" onclick="$('#asset-reservation-failure-modal').hide();">
-
-            </button>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
             <p>You can help by transcribing a new page, adding tags to this page, or coming back later to review this page's transcription.</p>

--- a/concordia/templates/transcriptions/asset_detail/error_modal.html
+++ b/concordia/templates/transcriptions/asset_detail/error_modal.html
@@ -2,8 +2,7 @@
     <div class="modal-content">
         <div class="modal-header">
             <h5 class="modal-title" id="error-modal-title">An error ocurred</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" onclick="$('#error-modal').hide();">
-            </button>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body" id="error-modal-message">
             <p>An error occurred.</p>

--- a/concordia/templates/transcriptions/asset_detail/language_selection_modal.html
+++ b/concordia/templates/transcriptions/asset_detail/language_selection_modal.html
@@ -1,9 +1,7 @@
 <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
         <div class="modal-header d-flex justify-content-end">
-            <a data-bs-dismiss="modal" aria-label="Close">
-                <span aria-hidden="true" class="text-primary fw-bold">&times;</span>
-            </a>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <form id="ocr-transcription-form" class="ajax-submission" method="post" action="{% url 'generate-ocr-transcription' asset_pk=asset.pk %}" data-lock-element="#transcription-editor">
             <div class="modal-body">

--- a/concordia/templates/transcriptions/asset_detail/ocr_help_modal.html
+++ b/concordia/templates/transcriptions/asset_detail/ocr_help_modal.html
@@ -3,9 +3,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">About Transcribe with OCR</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-
-                </button>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
                 <h6 class="modal-title">What is OCR?</h6>

--- a/concordia/templates/transcriptions/asset_detail/ocr_transcription_modal.html
+++ b/concordia/templates/transcriptions/asset_detail/ocr_transcription_modal.html
@@ -1,9 +1,7 @@
 <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
         <div class="modal-header d-flex justify-content-end">
-            <a data-bs-dismiss="modal" aria-label="Close" onclick="$('#ocr-transcription-modal').hide();">
-                <span aria-hidden="true" class="text-primary fw-bold">&times;</span>
-            </a>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
             <div class="bg-light p-3">

--- a/concordia/templates/transcriptions/asset_detail/review_accepted_modal.html
+++ b/concordia/templates/transcriptions/asset_detail/review_accepted_modal.html
@@ -2,9 +2,7 @@
     <div class="modal-content">
         <div class="modal-header">
             <h5 class="modal-title">Nice Job!</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" onclick="window.location.reload(true);">
-
-            </button>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
             <p>

--- a/concordia/templates/transcriptions/asset_detail/successful_submission_modal.html
+++ b/concordia/templates/transcriptions/asset_detail/successful_submission_modal.html
@@ -2,9 +2,7 @@
     <div class="modal-content">
         <div class="modal-header">
             <h5 class="modal-title">Submitted!</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" onclick="$('#successful-submission-modal').hide();">
-
-            </button>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
             <p>Thanks for helping complete this page!</p>


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-1112

The problem happened due to BS 5 not automatically initializing modals on page load. They're normally initialized when the button to toggle the modal is pressed, but it doesn't work if you trigger the modal through JS directly. Further, BS 5 doesn't integrate with jQuery directly, so I switched some things to use vanilla JavaScript (which is preferable to jQuery in any case).

I also fixed the X buttons on the modals to use the the built-in BS functionality rather than a custom onClick handler and jQuery.