### PR TITLE
Modified test action to generate coverage reports

### DIFF
--- a/.github/workflows/renew_coverage.yml
+++ b/.github/workflows/renew_coverage.yml
@@ -1,0 +1,18 @@
+name: Renew Coverage Cache
+
+on:
+    schedule:
+        - cron: '0 0 */5 * *' # Runs every 5 days at midnight UTC
+    workflow_dispatch:
+
+jobs:
+    renew-cache:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Access Coverage Cache to Renew Expiration
+              uses: actions/cache@v4
+              with:
+                  path: coverage.txt
+                  key: release-coverage
+                  restore-keys: |
+                      release-coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,9 +142,11 @@ jobs:
 
             # Store coverage results if running on the release branch
             - name: Cache Release Coverage (if running on release branch)
+              if: github.ref == 'refs/heads/release'
+              run: cp pr_coverage.txt coverage.txt
               uses: actions/cache@v4
               with:
-                  path: pr_coverage.txt
+                  path: coverage.txt
                   key: release-coverage
 
             # Download the stored release branch coverage for PR comparison, if it exists

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,11 +123,14 @@ jobs:
 
             - name: Run Tests with Coverage
               run: |
+                  mkdir -p coverage_report
                   pipenv run coverage run ./manage.py test
-                  pipenv run coverage report
-                  pipenv run coverage report | grep 'TOTAL' | awk '{print $6 "%"}' > pr_coverage.txt
+                  # Save full report to coverage_report/coverage.txt and just the total coverage percent to pr_coverage.txt
+                  pipenv run coverage report | tee coverage_report/coverage.txt | grep 'TOTAL' | awk '{print $6 "%"}' > pr_coverage.txt
                   echo "Stored PR coverage:"
                   cat pr_coverage.txt  # Debugging output to verify correct storage
+                  pipenv run coverage html
+                  mv htmlcov coverage_report/html  # Move HTML report into a separate directory
               env:
                   PGPASSWORD: postgres
                   # The hostname used to communicate with the PostgreSQL service container
@@ -152,6 +155,13 @@ jobs:
               with:
                   path: coverage.txt
                   key: release-coverage
+
+            # Upload full coverage report as an artifact
+            - name: Upload Full Coverage Report
+              uses: actions/upload-artifact@v4
+              with:
+                  name: coverage-report
+                  path: coverage_report
 
             # Download the stored release branch coverage for PR comparison, if it exists
             - name: Restore Release Coverage (if running on PR)
@@ -185,10 +195,13 @@ jobs:
                   fi
 
                   if [ "$COMPARISON_AVAILABLE" = true ]; then
-                      if (( $(echo "$PR_COVERAGE > $RELEASE_COVERAGE" | bc -l) )); then
-                          CHANGE="🔼 Coverage increased (+$(echo "$PR_COVERAGE - $RELEASE_COVERAGE" | bc -l)%)!"
-                      elif (( $(echo "$PR_COVERAGE < $RELEASE_COVERAGE" | bc -l) )); then
-                          CHANGE="🔽 Coverage decreased (-$(echo "$RELEASE_COVERAGE - $PR_COVERAGE" | bc -l)%)!"
+                      # Strip '%' from PR_COVERAGE and RELEASE_COVERAGE for numerical comparison
+                      PR_COVERAGE_NUM=${PR_COVERAGE%\%}
+                      RELEASE_COVERAGE_NUM=${RELEASE_COVERAGE%\%}
+                      if (( $(echo "$PR_COVERAGE_NUM > $RELEASE_COVERAGE_NUM" | bc -l) )); then
+                          CHANGE="🔼 Coverage increased (+$(echo "$PR_COVERAGE_NUM - $RELEASE_COVERAGE_NUM" | bc -l)%)!"
+                      elif (( $(echo "$PR_COVERAGE_NUM < $RELEASE_COVERAGE_NUM" | bc -l) )); then
+                          CHANGE="🔽 Coverage decreased (-$(echo "$RELEASE_COVERAGE_NUM - $PR_COVERAGE_NUM" | bc -l)%)!"
                       else
                           CHANGE="✅ Coverage remained the same."
                       fi
@@ -207,6 +220,8 @@ jobs:
                   echo "**Current PR Coverage:** ${{ env.PR_COVERAGE }}" >> $GITHUB_STEP_SUMMARY
                   echo "**Release Branch Coverage:** ${{ env.RELEASE_COVERAGE }}" >> $GITHUB_STEP_SUMMARY
                   echo "**Result:** ${{ env.COVERAGE_CHANGE }}" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "📊 **[View Full Coverage Report (Download)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**" >> $GITHUB_STEP_SUMMARY
 
             # Post a comment on the PR with the coverage results
             - name: Comment Coverage Change on PR
@@ -218,3 +233,4 @@ jobs:
                       - **Current PR Coverage:** ${{ env.PR_COVERAGE }}
                       - **Release Branch Coverage:** ${{ env.RELEASE_COVERAGE }}
                       - **${{ env.COVERAGE_CHANGE }}**
+                      - 📊 **[View Full Coverage Report (Download)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,28 +209,31 @@ jobs:
                       CHANGE="⚠️ No baseline coverage available from 'release' branch."
                   fi
 
-                  printf "COVERAGE_CHANGE=$CHANGE" >> $GITHUB_ENV
-                  printf "RELEASE_COVERAGE=$RELEASE_COVERAGE" >> $GITHUB_ENV
-                  printf "PR_COVERAGE=$PR_COVERAGE" >> $GITHUB_ENV
+                  echo "COVERAGE_CHANGE=$CHANGE" >> $GITHUB_ENV
+                  printf "RELEASE_COVERAGE=%s\n" "$RELEASE_COVERAGE" >> $GITHUB_ENV
+                  printf "PR_COVERAGE=%s\n" "$PR_COVERAGE" >> $GITHUB_ENV
+
+            # Generate and store command for display on the Action UI and PR (if any)
+            - name: Generate Coverage Report Comment
+              run: |
+                  echo "**🛡 Test Coverage Report 🛡**" > coverage_comment.txt
+                  echo "- **Current PR Coverage:** ${{ env.PR_COVERAGE }}" >> coverage_comment.txt
+                  echo "- **Release Branch Coverage:** ${{ env.RELEASE_COVERAGE }}" >> coverage_comment.txt
+                  echo "- **${{ env.COVERAGE_CHANGE }}**" >> coverage_comment.txt
+                  echo "- 📊 **[View Full Coverage Report (Download Artifact)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)**" >> coverage_comment.txt
+                  echo "" >> coverage_comment.txt
+                  echo "### 📜 Full Text Coverage Report 📜" >> coverage_comment.txt
+                  echo '```text' >> coverage_comment.txt
+                  cat coverage_report/coverage.txt >> coverage_comment.txt
+                  echo '```' >> coverage_comment.txt
 
             # Display the coverage summary in the GitHub Actions UI
             - name: Post Coverage Summary
-              run: |
-                  echo "### 🛡 Test Coverage Report 🛡" >> $GITHUB_STEP_SUMMARY
-                  echo "**Current PR Coverage:** ${{ env.PR_COVERAGE }}" >> $GITHUB_STEP_SUMMARY
-                  echo "**Release Branch Coverage:** ${{ env.RELEASE_COVERAGE }}" >> $GITHUB_STEP_SUMMARY
-                  echo "**Result:** ${{ env.COVERAGE_CHANGE }}" >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "📊 **[View Full Coverage Report (Download Artifact)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)**" >> $GITHUB_STEP_SUMMARY
+              run: cat coverage_comment.txt >> $GITHUB_STEP_SUMMARY
 
             # Post a comment on the PR with the coverage results
             - name: Comment Coverage Change on PR
               if: github.event_name == 'pull_request'
               uses: mshick/add-pr-comment@v2
               with:
-                  message: |
-                      **🛡 Test Coverage Report 🛡**
-                      - **Current PR Coverage:** ${{ env.PR_COVERAGE }}
-                      - **Release Branch Coverage:** ${{ env.RELEASE_COVERAGE }}
-                      - **${{ env.COVERAGE_CHANGE }}**
-                      - 📊 **[View Full Coverage Report (Download Artifact)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)**
+                  message-path: coverage_comment.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,10 +220,10 @@ jobs:
                   echo "- **Current PR Coverage:** ${{ env.PR_COVERAGE }}" >> coverage_comment.txt
                   echo "- **Release Branch Coverage:** ${{ env.RELEASE_COVERAGE }}" >> coverage_comment.txt
                   echo "- **${{ env.COVERAGE_CHANGE }}**" >> coverage_comment.txt
-                  echo "- 📊 **[View Full Coverage Report (Download Artifact)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)**" >> coverage_comment.txt
+                  echo "- 📊 **[Download Full Coverage Report (Under "Artifacts")](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)**" >> coverage_comment.txt
                   echo "" >> coverage_comment.txt
                   echo "<details>" >> coverage_comment.txt
-                  echo "<summary>📜 **Click to view full text coverage report**</summary>" >> coverage_comment.txt
+                  echo "<summary>📜 Click to view full text coverage report</summary>" >> coverage_comment.txt
                   echo "" >> coverage_comment.txt
                   echo '```text' >> coverage_comment.txt
                   cat coverage_report/coverage.txt >> coverage_comment.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,10 +222,13 @@ jobs:
                   echo "- **${{ env.COVERAGE_CHANGE }}**" >> coverage_comment.txt
                   echo "- 📊 **[View Full Coverage Report (Download Artifact)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)**" >> coverage_comment.txt
                   echo "" >> coverage_comment.txt
-                  echo "### 📜 Full Text Coverage Report 📜" >> coverage_comment.txt
+                  echo "<details>" >> coverage_comment.txt
+                  echo "<summary>📜 **Click to view full text coverage report**</summary>" >> coverage_comment.txt
+                  echo "" >> coverage_comment.txt
                   echo '```text' >> coverage_comment.txt
                   cat coverage_report/coverage.txt >> coverage_comment.txt
                   echo '```' >> coverage_comment.txt
+                  echo "</details>" >> coverage_comment.txt
 
             # Display the coverage summary in the GitHub Actions UI
             - name: Post Coverage Summary

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
               run: |
                   pipenv run coverage run ./manage.py test
                   pipenv run coverage report
-                  pipenv run coverage report | grep 'TOTAL' | awk '{print $4 "%"}' > pr_coverage.txt
+                  pipenv run coverage report | grep 'TOTAL' | awk '{print $6 "%"}' > pr_coverage.txt
                   echo "Stored PR coverage:"
                   cat pr_coverage.txt  # Debugging output to verify correct storage
               env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,22 +101,29 @@ jobs:
                   pip3 install -U pipenv
                   pipenv install --dev --deploy
 
-            - name: Run Tests with Coverage
+            - name: Configure Logs
               run: |
                   mkdir logs
                   touch ./logs/concordia-celery.log
+
+            - name: Build and Collect Static Files
+              run: |
                   npm install
                   npx gulp build
+                  pipenv run ./manage.py collectstatic --no-input
+
+            - name: Install Chrome for Testing
+              run: |
                   chromepath=$(npx @puppeteer/browsers install chrome@stable)
                   chromepath=${chromepath#* }
                   chromepath=${chromepath%/chrome}
-                  OLDPATH=$PATH
                   PATH=$PATH:$chromepath
-                  pipenv run ./manage.py collectstatic --no-input
+
+            - name: Run Tests with Coverage
+              run: |
                   pipenv run coverage run ./manage.py test
                   pipenv run coverage report
                   pipenv run coverage report | grep 'TOTAL' | awk '{print $4}' | tr -d '%' > pr_coverage.txt
-                  PATH=$OLDPATH
               env:
                   PGPASSWORD: postgres
                   # The hostname used to communicate with the PostgreSQL service container
@@ -148,9 +155,10 @@ jobs:
                   name: release-coverage
                   path: coverage.txt
 
-            # Download the stored release branch coverage for PR comparison
+            # Download the stored release branch coverage for PR comparison, if it exists
             - name: Download Release Coverage (if running on PR)
               if: github.event_name == 'pull_request'
+              continue-on-error: true
               uses: actions/download-artifact@v4
               with:
                   name: release-coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,9 +141,13 @@ jobs:
                   # COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
 
             # Store coverage results if running on the release branch
-            - name: Cache Release Coverage (if running on release branch)
+            - name: Store Release Coverage (if running on release branch)
               if: github.ref == 'refs/heads/release'
               run: cp pr_coverage.txt coverage.txt
+
+            # Cache coverage results if running on the release branch
+            - name: Cache Release Coverage (if running on release branch)
+              if: github.ref == 'refs/heads/release'
               uses: actions/cache@v4
               with:
                   path: coverage.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,9 +209,9 @@ jobs:
                       CHANGE="⚠️ No baseline coverage available from 'release' branch."
                   fi
 
-                  echo "COVERAGE_CHANGE=$CHANGE" >> $GITHUB_ENV
-                  echo "RELEASE_COVERAGE=$RELEASE_COVERAGE" >> $GITHUB_ENV
-                  echo "PR_COVERAGE=$PR_COVERAGE" >> $GITHUB_ENV
+                  printf "COVERAGE_CHANGE=$CHANGE" >> $GITHUB_ENV
+                  printf "RELEASE_COVERAGE=$RELEASE_COVERAGE" >> $GITHUB_ENV
+                  printf "PR_COVERAGE=$PR_COVERAGE" >> $GITHUB_ENV
 
             # Display the coverage summary in the GitHub Actions UI
             - name: Post Coverage Summary
@@ -221,7 +221,7 @@ jobs:
                   echo "**Release Branch Coverage:** ${{ env.RELEASE_COVERAGE }}" >> $GITHUB_STEP_SUMMARY
                   echo "**Result:** ${{ env.COVERAGE_CHANGE }}" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "📊 **[View Full Coverage Report (Download)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**" >> $GITHUB_STEP_SUMMARY
+                  echo "📊 **[View Full Coverage Report (Download Artifact)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)**" >> $GITHUB_STEP_SUMMARY
 
             # Post a comment on the PR with the coverage results
             - name: Comment Coverage Change on PR
@@ -233,4 +233,4 @@ jobs:
                       - **Current PR Coverage:** ${{ env.PR_COVERAGE }}
                       - **Release Branch Coverage:** ${{ env.RELEASE_COVERAGE }}
                       - **${{ env.COVERAGE_CHANGE }}**
-                      - 📊 **[View Full Coverage Report (Download)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**
+                      - 📊 **[View Full Coverage Report (Download Artifact)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)**

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,8 +113,7 @@ jobs:
                   OLDPATH=$PATH
                   PATH=$PATH:$chromepath
                   pipenv run ./manage.py collectstatic --no-input
-                  pipenv run coverage run --parallel-mode ./manage.py test --parallel
-                  pipenv run coverage combine
+                  pipenv run coverage run ./manage.py test
                   pipenv run coverage report
                   pipenv run coverage report | grep 'TOTAL' | awk '{print $4}' | tr -d '%' > pr_coverage.txt
                   PATH=$OLDPATH

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
                   pip3 install -U pipenv
                   pipenv install --dev --deploy
 
-            - name: Run Tests
+            - name: Run Tests with Coverage
               run: |
                   mkdir logs
                   touch ./logs/concordia-celery.log
@@ -113,7 +113,10 @@ jobs:
                   OLDPATH=$PATH
                   PATH=$PATH:$chromepath
                   pipenv run ./manage.py collectstatic --no-input
-                  pipenv run coverage run ./manage.py test
+                  pipenv run coverage run --parallel-mode ./manage.py test --parallel
+                  pipenv run coverage combine
+                  pipenv run coverage report
+                  pipenv run coverage report | grep 'TOTAL' | awk '{print $4}' | tr -d '%' > pr_coverage.txt
                   PATH=$OLDPATH
               env:
                   PGPASSWORD: postgres
@@ -126,3 +129,78 @@ jobs:
                   # The default Redis port
                   REDIS_PORT: 6379
                   # COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+
+            - name: Upload PR Coverage Report
+              uses: actions/upload-artifact@v4
+              with:
+                  name: coverage-report
+                  path: pr_coverage.txt
+
+            # Store coverage results if running on the release branch
+            - name: Store Release Coverage (if running on release branch)
+              if: github.ref == 'refs/heads/release'
+              run: |
+                  mv pr_coverage.txt coverage.txt
+
+            - name: Upload Release Coverage (if running on release branch)
+              if: github.ref == 'refs/heads/release'
+              uses: actions/upload-artifact@v4
+              with:
+                  name: release-coverage
+                  path: coverage.txt
+
+            # Download the stored release branch coverage for PR comparison
+            - name: Download Release Coverage (if running on PR)
+              if: github.event_name == 'pull_request'
+              uses: actions/download-artifact@v4
+              with:
+                  name: release-coverage
+                  path: .
+
+            # Compare PR coverage against stored release coverage
+            - name: Compare Coverage (if running on PR)
+              if: github.event_name == 'pull_request'
+              run: |
+                  PR_COVERAGE=$(cat pr_coverage.txt)
+                  if [ -f "coverage.txt" ]; then
+                      RELEASE_COVERAGE=$(cat coverage.txt)
+                      COMPARISON_AVAILABLE=true
+                  else
+                      COMPARISON_AVAILABLE=false
+                      RELEASE_COVERAGE="N/A"
+                  fi
+
+                  if [ "$COMPARISON_AVAILABLE" = true ]; then
+                      if (( $(echo "$PR_COVERAGE > $RELEASE_COVERAGE" | bc -l) )); then
+                          CHANGE="🔼 Coverage increased (+$(echo "$PR_COVERAGE - $RELEASE_COVERAGE" | bc -l)%)!"
+                      elif (( $(echo "$PR_COVERAGE < $RELEASE_COVERAGE" | bc -l) )); then
+                          CHANGE="🔽 Coverage decreased (-$(echo "$RELEASE_COVERAGE - $PR_COVERAGE" | bc -l)%)!"
+                      else
+                          CHANGE="✅ Coverage remained the same."
+                      fi
+                  else
+                      CHANGE="⚠️ No baseline coverage available from 'release' branch."
+                  fi
+
+                  echo "COVERAGE_CHANGE=$CHANGE" >> $GITHUB_ENV
+                  echo "RELEASE_COVERAGE=$RELEASE_COVERAGE" >> $GITHUB_ENV
+
+            # Display the coverage summary in the GitHub Actions UI
+            - name: Post Coverage Summary
+              run: |
+                  echo "### 🛡 Test Coverage Report 🛡" >> $GITHUB_STEP_SUMMARY
+                  echo "**Current PR Coverage:** ${{ env.PR_COVERAGE }}%" >> $GITHUB_STEP_SUMMARY
+                  echo "**Release Branch Coverage:** $RELEASE_COVERAGE%" >> $GITHUB_STEP_SUMMARY
+                  echo "**Result:** ${{ env.COVERAGE_CHANGE }}" >> $GITHUB_STEP_SUMMARY
+
+            # Post a comment on the PR with the coverage results
+            - name: Comment Coverage Change on PR
+              if: github.event_name == 'pull_request'
+              uses: mshick/add-pr-comment@v2
+              with:
+                  message: |
+                      **🛡 Test Coverage Report 🛡**
+                      - **Current PR Coverage:** ${{ env.PR_COVERAGE }}%
+                      - **Release Branch Coverage:** $RELEASE_COVERAGE%
+                      - **${{ env.COVERAGE_CHANGE }}**
+              repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
                   mkdir -p coverage_report
                   pipenv run coverage run ./manage.py test
                   # Save full report to coverage_report/coverage.txt and just the total coverage percent to pr_coverage.txt
-                  pipenv run coverage report | tee coverage_report/coverage.txt | grep 'TOTAL' | awk '{print $6 "%"}' > pr_coverage.txt
+                  pipenv run coverage report | tee coverage_report/coverage.txt | grep 'TOTAL' | awk '{print $6}' > pr_coverage.txt
                   echo "Stored PR coverage:"
                   cat pr_coverage.txt  # Debugging output to verify correct storage
                   pipenv run coverage html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,9 @@ jobs:
                   pip3 install -U pipenv
                   pipenv install --dev --deploy
 
+            - name: Install Node Dependencies
+              run: npm install
+
             - name: Configure Logs
               run: |
                   mkdir logs
@@ -108,7 +111,6 @@ jobs:
 
             - name: Build and Collect Static Files
               run: |
-                  npm install
                   npx gulp build
                   pipenv run ./manage.py collectstatic --no-input
 
@@ -123,7 +125,9 @@ jobs:
               run: |
                   pipenv run coverage run ./manage.py test
                   pipenv run coverage report
-                  pipenv run coverage report | grep 'TOTAL' | awk '{print $4}' | tr -d '%' > pr_coverage.txt
+                  pipenv run coverage report | grep 'TOTAL' | awk '{print $4 "%"}' > pr_coverage.txt
+                  echo "Stored PR coverage:"
+                  cat pr_coverage.txt  # Debugging output to verify correct storage
               env:
                   PGPASSWORD: postgres
                   # The hostname used to communicate with the PostgreSQL service container
@@ -136,39 +140,36 @@ jobs:
                   REDIS_PORT: 6379
                   # COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
 
-            - name: Upload PR Coverage Report
-              uses: actions/upload-artifact@v4
-              with:
-                  name: coverage-report
-                  path: pr_coverage.txt
-
             # Store coverage results if running on the release branch
-            - name: Store Release Coverage (if running on release branch)
-              if: github.ref == 'refs/heads/release'
-              run: |
-                  mv pr_coverage.txt coverage.txt
-
-            - name: Upload Release Coverage (if running on release branch)
-              if: github.ref == 'refs/heads/release'
-              uses: actions/upload-artifact@v4
+            - name: Cache Release Coverage (if running on release branch)
+              uses: actions/cache@v4
               with:
-                  name: release-coverage
-                  path: coverage.txt
+                  path: pr_coverage.txt
+                  key: release-coverage
 
             # Download the stored release branch coverage for PR comparison, if it exists
-            - name: Download Release Coverage (if running on PR)
+            - name: Restore Release Coverage (if running on PR)
               if: github.event_name == 'pull_request'
-              continue-on-error: true
-              uses: actions/download-artifact@v4
+              uses: actions/cache@v4
               with:
-                  name: release-coverage
-                  path: .
+                  path: coverage.txt
+                  key: release-coverage
+                  restore-keys: |
+                      release-coverage
 
             # Compare PR coverage against stored release coverage
             - name: Compare Coverage (if running on PR)
               if: github.event_name == 'pull_request'
               run: |
+                  echo "Reading PR coverage from pr_coverage.txt..."
+                  cat pr_coverage.txt || echo "⚠️ ERROR: pr_coverage.txt not found or empty"
                   PR_COVERAGE=$(cat pr_coverage.txt)
+                  if [ -z "$PR_COVERAGE" ]; then
+                      echo "⚠️ ERROR: PR_COVERAGE is empty!"
+                      PR_COVERAGE="N/A"
+                  fi
+
+                  echo "PR Coverage: $PR_COVERAGE"
                   if [ -f "coverage.txt" ]; then
                       RELEASE_COVERAGE=$(cat coverage.txt)
                       COMPARISON_AVAILABLE=true
@@ -191,13 +192,14 @@ jobs:
 
                   echo "COVERAGE_CHANGE=$CHANGE" >> $GITHUB_ENV
                   echo "RELEASE_COVERAGE=$RELEASE_COVERAGE" >> $GITHUB_ENV
+                  echo "PR_COVERAGE=$PR_COVERAGE" >> $GITHUB_ENV
 
             # Display the coverage summary in the GitHub Actions UI
             - name: Post Coverage Summary
               run: |
                   echo "### 🛡 Test Coverage Report 🛡" >> $GITHUB_STEP_SUMMARY
-                  echo "**Current PR Coverage:** ${{ env.PR_COVERAGE }}%" >> $GITHUB_STEP_SUMMARY
-                  echo "**Release Branch Coverage:** $RELEASE_COVERAGE%" >> $GITHUB_STEP_SUMMARY
+                  echo "**Current PR Coverage:** ${{ env.PR_COVERAGE }}" >> $GITHUB_STEP_SUMMARY
+                  echo "**Release Branch Coverage:** ${{ env.RELEASE_COVERAGE }}" >> $GITHUB_STEP_SUMMARY
                   echo "**Result:** ${{ env.COVERAGE_CHANGE }}" >> $GITHUB_STEP_SUMMARY
 
             # Post a comment on the PR with the coverage results
@@ -207,6 +209,6 @@ jobs:
               with:
                   message: |
                       **🛡 Test Coverage Report 🛡**
-                      - **Current PR Coverage:** ${{ env.PR_COVERAGE }}%
-                      - **Release Branch Coverage:** $RELEASE_COVERAGE%
+                      - **Current PR Coverage:** ${{ env.PR_COVERAGE }}
+                      - **Release Branch Coverage:** ${{ env.RELEASE_COVERAGE }}
                       - **${{ env.COVERAGE_CHANGE }}**

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,4 +203,3 @@ jobs:
                       - **Current PR Coverage:** ${{ env.PR_COVERAGE }}%
                       - **Release Branch Coverage:** $RELEASE_COVERAGE%
                       - **${{ env.COVERAGE_CHANGE }}**
-              repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/concordia/settings_template.py
+++ b/concordia/settings_template.py
@@ -570,6 +570,7 @@ DEFAULT_AXE_SCRIPT = os.path.join(
     SITE_ROOT_DIR, "node_modules", "axe-core", "axe.min.js"
 )
 
+# Used for tracking accepts for the review rate limit
 TRANSCRIPTION_ACCEPTED_TRACKING_KEY = "TRANSCRIPTION_ACCEPTED_{user_id}"
 
 CONFIGURATION_CACHE_TIMEOUT = 3600  # One hour


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-1111

Parallelization will be added in a future PR once these changes are merged.

This generates a coverage report, stores it as an artifact and compares the total coverage to that of the latest release.

Right now, there is no data for the current release. Once this is merged, I will run the Test action against the release branch in order to generate and cache that value.

The renew_coverage.yml action is used to keep the cached release coverage value by accessing it every five days. Normally, cached values are discarded after they're not accessed for seven days. To avoid that, the task simply accessing the value so it's not lost in case we have a seven-day period with no pull requests.

The comment added to settings_template.py is just so tests would be run against the branch, since modifying the action itself does not cause it to be run.