### PR TITLE
Change GHA tests to run in parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,7 +124,8 @@ jobs:
             - name: Run Tests with Coverage
               run: |
                   mkdir -p coverage_report
-                  pipenv run coverage run ./manage.py test
+                  pipenv run coverage run --parallel-mode ./manage.py test --parallel auto
+                  pipenv run coverage combine  # Merge results from parallel test workers
                   # Save full report to coverage_report/coverage.txt and just the total coverage percent to pr_coverage.txt
                   pipenv run coverage report | tee coverage_report/coverage.txt | grep 'TOTAL' | awk '{print $6}' > pr_coverage.txt
                   echo "Stored PR coverage:"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,9 @@ jobs:
                     - 6379:6379
 
         steps:
+            - name: Remove Firefox
+              run: sudo apt purge firefox
+
             - name: Install system packages
               run: |
                   sudo apt-get update -qy && sudo apt-get dist-upgrade -qy && sudo apt-get install -qy \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
 
         steps:
             - name: Remove Firefox
-              run: sudo apt purge firefox
+              run: sudo apt-get purge firefox
 
             - name: Install system packages
               run: |
@@ -103,6 +103,7 @@ jobs:
                   pip3 install -U setuptools
                   pip3 install -U pipenv
                   pipenv install --dev --deploy
+                  pipenv install tblib # For parallel test debugging
 
             - name: Install Node Dependencies
               run: npm install
@@ -124,13 +125,10 @@ jobs:
                   chromepath=${chromepath%/chrome}
                   PATH=$PATH:$chromepath
 
-            - name: Install tblib (for parallel test debugging)
-              run: pip install tblib
-
             - name: Run Tests with Coverage
               run: |
                   mkdir -p coverage_report
-                  pipenv run coverage run --parallel-mode ./manage.py test --parallel 2
+                  pipenv run coverage run --parallel-mode ./manage.py test --parallel auto
                   pipenv run coverage combine  # Merge results from parallel test workers
                   # Save full report to coverage_report/coverage.txt and just the total coverage percent to pr_coverage.txt
                   pipenv run coverage report | tee coverage_report/coverage.txt | grep 'TOTAL' | awk '{print $6}' > pr_coverage.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,10 +121,13 @@ jobs:
                   chromepath=${chromepath%/chrome}
                   PATH=$PATH:$chromepath
 
+            - name: Install tblib (for parallel test debugging)
+              run: pip install tblib
+
             - name: Run Tests with Coverage
               run: |
                   mkdir -p coverage_report
-                  pipenv run coverage run --parallel-mode ./manage.py test --parallel auto
+                  pipenv run coverage run --parallel-mode ./manage.py test --parallel 2
                   pipenv run coverage combine  # Merge results from parallel test workers
                   # Save full report to coverage_report/coverage.txt and just the total coverage percent to pr_coverage.txt
                   pipenv run coverage report | tee coverage_report/coverage.txt | grep 'TOTAL' | awk '{print $6}' > pr_coverage.txt

--- a/concordia/settings_test.py
+++ b/concordia/settings_test.py
@@ -7,6 +7,21 @@ DEBUG = False
 
 DATABASES["default"].update({"PASSWORD": "", "USER": "postgres"})
 
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "default-location",
+    },
+    "view_cache": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "view-location",
+    },
+    "configuration_cache": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "configuration-location",
+    },
+}
+
 DEFAULT_TO_EMAIL = "rsar@loc.gov"
 
 ALLOWED_HOSTS = ["127.0.0.1", "0.0.0.0"]  # nosec


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-1111

I also removed Firefox before doing dist-upgrade because it kept hanging (this should hopefully eliminate that hang we get occasionally on installing the firefox snap).

The change to the cache settings is in order to allow each test runner to have its own cache. If we used a shared Redis instance, tests would overwrite or delete data from other runners.