### PR TITLE
CONCD-1113 partial revert

### DIFF
--- a/concordia/tests/test_account_views.py
+++ b/concordia/tests/test_account_views.py
@@ -9,11 +9,13 @@ from django import forms
 from django.contrib.messages import get_messages
 from django.core import mail, signing
 from django.core.cache import cache
+from django.db.models.signals import post_save
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.timezone import now
 
 from concordia.models import ConcordiaUser, Transcription, User
+from concordia.signals.handlers import on_transcription_save
 from concordia.utils import get_anonymous_user
 
 from .utils import (
@@ -36,6 +38,7 @@ class ConcordiaAccountViewTests(
     """
 
     def setUp(self):
+        post_save.disconnect(on_transcription_save, sender=Transcription)
         cache.clear()
 
     def tearDown(self):

--- a/concordia/tests/test_models.py
+++ b/concordia/tests/test_models.py
@@ -338,6 +338,19 @@ class TranscriptionTestCase(CreateTestUsers, TestCase):
         with self.assertRaises(ValidationError):
             bad_transcription3.clean()
 
+    @mock.patch("concordia.tests.test_models.on_transcription_save")
+    def test_save(self, mock_handler):
+        signals.post_save.connect(on_transcription_save, sender=Transcription)
+
+        transcription = create_transcription(asset=self.asset)
+        self.assertTrue(mock_handler.called)
+        self.assertEqual(mock_handler.call_count, 1)
+
+        transcription.save()
+        self.assertEqual(mock_handler.call_count, 2)
+
+        signals.post_save.disconnect(on_transcription_save, sender=Transcription)
+
     def test_status(self):
         transcription = create_transcription(user=self.user, asset=self.asset)
         self.assertEqual(

--- a/concordia/tests/test_models.py
+++ b/concordia/tests/test_models.py
@@ -385,20 +385,6 @@ class SignalHandlersTest(CreateTestUsers, TestCase):
         expected_value = {reviewed_by.id: (0, 1)}
         mock_set.assert_called_with(expected_key, expected_value)
 
-    @mock.patch("concordia.signals.handlers.update_useractivity_cache.delay")
-    def test_on_transcription_save(self, mock_update):
-        instance = mock.MagicMock()
-        instance.user = self.create_test_user(username="anonymous")
-        on_transcription_save(None, instance, **{"created": True})
-        self.assertEqual(mock_update.call_count, 0)
-
-        instance.user = self.create_test_user()
-        on_transcription_save(None, instance, **{"created": True})
-        self.assertEqual(mock_update.call_count, 1)
-
-        on_transcription_save(None, instance, **{"created": False})
-        self.assertEqual(mock_update.call_count, 2)
-
 
 class AssetTranscriptionReservationTest(CreateTestUsers, TestCase):
     def setUp(self):


### PR DESCRIPTION
 - reverting the change to the signal handler
 - Leaving in both of the new celery tasks, although for now they won't actually be called
 - removed the unit test that calls the signal handler directly. replaced it with a new unit test to verify that we receive the post_save signal whenever a transcription object is created or saved