### PR TITLE
Fixed asset images having an extraneous period

### DIFF
--- a/importer/tasks.py
+++ b/importer/tasks.py
@@ -450,17 +450,22 @@ def import_item(self, import_item):
 
         for idx, asset_url in enumerate(asset_urls, start=1):
             asset_title = f"{import_item.item.item_id}-{idx}"
+            file_extension = (
+                os.path.splitext(urlparse(asset_url).path)[1].lstrip(".").lower()
+            )
             item_asset = Asset(
                 item=import_item.item,
                 campaign=import_item.item.project.campaign,
                 title=asset_title,
                 slug=slugify(asset_title, allow_unicode=True),
                 sequence=idx,
-                media_url=f"{idx}.jpg",
+                media_url=f"{idx}.{file_extension}",
                 media_type=MediaType.IMAGE,
                 download_url=asset_url,
                 resource_url=item_resource_url,
-                storage_image="/".join([relative_asset_file_path, f"{idx}.jpg"]),
+                storage_image="/".join(
+                    [relative_asset_file_path, f"{idx}.{file_extension}"]
+                ),
             )
             # Previously, any asset that raised a validation error was just ignored.
             # We don't want that--we want to see if an asset fails validation
@@ -602,7 +607,9 @@ def download_asset(self, job):
         download_url = job.url
     else:
         download_url = asset.download_url
-    file_extension = os.path.splitext(urlparse(download_url).path)[1].lower()
+    file_extension = (
+        os.path.splitext(urlparse(download_url).path)[1].lstrip(".").lower()
+    )
     if not file_extension or file_extension == "jpeg":
         file_extension = "jpg"
 
@@ -617,6 +624,7 @@ def download_asset(self, job):
         asset.id,
     )
     asset.storage_image = storage_image
+    asset.media_url = os.path.basename(storage_image)
     asset.save()
 
 

--- a/importer/tests/test_tasks.py
+++ b/importer/tests/test_tasks.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+import os.path
 import uuid
 from unittest import mock
 
@@ -805,6 +806,10 @@ class AssetImportTests(TestCase):
 
             self.assertEqual(get_mock.call_args[0], ("http://example.com",))
             self.assertTrue(get_mock.call_args[1]["stream"])
+            self.assertEqual(
+                os.path.basename(self.import_asset.asset.storage_image.path),
+                self.import_asset.asset.media_url,
+            )
 
     @override_settings(
         STORAGES={"default": {"BACKEND": "django.core.files.storage.InMemoryStorage"}},
@@ -1019,7 +1024,7 @@ class AssetImportTests(TestCase):
         mock_download.return_value = "stored_image.png"
         tasks.download_asset(self.task_mock, self.job)
 
-        asset_image_filename = self.asset.get_asset_image_filename(".png")
+        asset_image_filename = self.asset.get_asset_image_filename("png")
         mock_download.assert_called_once_with(
             self.asset.download_url, asset_image_filename
         )


### PR DESCRIPTION
Hotfix for release.

https://staff.loc.gov/tasks/browse/CONCD-1145

The larger issue of media_url and the way we form image URLs on the front-end will need to be fixed in the future, but these are the most low-impact changes to fix the immediate bug, since this is a hotfix for a release.