### PR TITLE
CONCD-1073 revert botocore

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 gunicorn = "*"
 celery = {extras = ["redis"],version = ">=5.0.5"}
 "boto3" = ">=1.9.16"
-botocore = '>=1.12.16,<1.31.25'
+botocore = '==1.31.25'
 requests = "*"
 bagit = "*"
 django-registration = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 gunicorn = "*"
 celery = {extras = ["redis"],version = ">=5.0.5"}
 "boto3" = ">=1.9.16"
-botocore = '>=1.12.16'
+botocore = '>=1.12.16,<1.31.25'
 requests = "*"
 bagit = "*"
 django-registration = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,6 @@ name = "pypi"
 gunicorn = "*"
 celery = {extras = ["redis"],version = ">=5.0.5"}
 "boto3" = ">=1.9.16"
-botocore = '==1.31.25'
 requests = "*"
 bagit = "*"
 django-registration = "*"
@@ -54,6 +53,7 @@ xlsxwriter = "*"
 blinker = "<1.8.0"
 psycopg2 = "*"
 django = "==4.2.20"
+botocore = "==1.31.25"
 
 [dev-packages]
 invoke = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1301d87debd492ffc7a3596a725155d3be9889cdc5aa2708ab96561a09a845bd"
+            "sha256": "d657b0af5d99bebff121a60ec3149de3c2f3d02fcde41d7771e453561840dd56"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -158,11 +158,12 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:136ecef8d5a1088f1ba485c0bbfca40abd42b9f9fe9e11d8cde4e53b4c05b188",
-                "sha256:965d3b99179ac04aa98e4c4baf4a970ebce77a5e02bb2a0a21cb6304e2bc0955"
+                "sha256:17cc6db84644251a5b519aeccd5eb1c313a18ef2e92616ec16182aa30c877152",
+                "sha256:b8a40b0ca1e3c8290a4c0d473c8e1575d2e8b2ddc3c61dd8814c3976357cac84"
             ],
             "index": "pypi",
-            "version": "==1.35.50"
+            "markers": "python_version >= '3.7'",
+            "version": "==1.31.25"
         },
         "brotli": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -158,12 +158,11 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:143fd7cdb0d73f43aa1f14799124de7b857da7d7ab996af5c89a49e3032a9e66",
-                "sha256:a86d1ffbe344bfb183d9acc24de3428118fc166cb89d0f1ce1d412857edfacd7"
+                "sha256:136ecef8d5a1088f1ba485c0bbfca40abd42b9f9fe9e11d8cde4e53b4c05b188",
+                "sha256:965d3b99179ac04aa98e4c4baf4a970ebce77a5e02bb2a0a21cb6304e2bc0955"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==1.37.27"
+            "version": "==1.35.50"
         },
         "brotli": {
             "hashes": [


### PR DESCRIPTION
I'm going to pin our requirements to 1.31.25, for now. We can upgrade to a newer version only after we start using python 3.12

https://github.com/LibraryOfCongress/concordia/actions/runs/14271907765/job/40006831821