### PR TITLE
CONCD-1139 pin sass to 1.78.0 (at least until Bootstrap 6 is released)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "openseadragon-filtering": "^1.0.0",
                 "prettier": "^2.8.8",
                 "remarkable": "^2.0.1",
-                "sass": "^1.86.3",
+                "sass": "^1.78.0",
                 "screenfull": "^5.1.0",
                 "split.js": "^1.6.2",
                 "urijs": "^1.19.11"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "openseadragon-filtering": "^1.0.0",
         "prettier": "^2.8.8",
         "remarkable": "^2.0.1",
-        "sass": "^1.86.3",
+        "sass": "^1.78.0",
         "screenfull": "^5.1.0",
         "split.js": "^1.6.2",
         "urijs": "^1.19.11"


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-1139