### PR TITLE
CONCD-985

### DIFF
--- a/concordia/templates/fragments/common-scripts.html
+++ b/concordia/templates/fragments/common-scripts.html
@@ -2,7 +2,7 @@
 
 <script src="{% static 'jquery/dist/jquery.min.js' %}"></script>
 <script src="{% static 'js-cookie/src/js.cookie.js' %}"></script>
-<script src="{% static '@popperjs/core/dist/umd/popper.min.js' %}"></script>
+<script src="{% static '@popperjs/core/dist/esm/popper.js' %}" type="module"></script>
 <script src="{% static 'bootstrap/dist/js/bootstrap.esm.js' %}" type="module"></script>
 <script src="{% static 'screenfull/dist/screenfull.js' %}"></script>
 <script src="{% static 'js/base.js' %}"></script>


### PR DESCRIPTION
- popper 2 needs to be included as a module (not umd)
- updating common-scripts.html will make it consistent with the importmaps in our .js files