### PR TITLE
CONCD-985 don't use explicit path for js imports

### DIFF
--- a/concordia/static/js/src/homepage-carousel.js
+++ b/concordia/static/js/src/homepage-carousel.js
@@ -1,6 +1,6 @@
 /* global $ */
 
-import {Carousel} from '/static/bootstrap/dist/js/bootstrap.esm.js';
+import {Carousel} from 'bootstrap';
 
 // initialization
 var carouselElement = document.getElementById('homepage-carousel');


### PR DESCRIPTION
explicit paths can work locally, but will cause issues on the server when whitenoise rewrites static paths