### PR TITLE
Added docstrings and type hints for the rollforward/rollback system parts

### DIFF
--- a/concordia/views/ajax.py
+++ b/concordia/views/ajax.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from time import time
+from typing import Union
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
@@ -8,7 +9,7 @@ from django.contrib.messages import get_messages
 from django.core.exceptions import ValidationError
 from django.db import connection
 from django.db.transaction import atomic
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.timezone import now
@@ -186,7 +187,60 @@ def generate_ocr_transcription(request, *, asset_pk):
 @validate_anonymous_user
 @atomic
 @ratelimit(key="header:cf-connecting-ip", rate="1/m", block=settings.RATELIMIT_BLOCK)
-def rollback_transcription(request, *, asset_pk):
+def rollback_transcription(
+    request: HttpRequest, *, asset_pk: Union[int, str]
+) -> JsonResponse:
+    """
+    Perform a rollback on the latest transcription for the given asset.
+
+    Requires the asset to have at least one earlier transcription that is not
+    a rollforward or the source of a rollforward. If rollback is not possible,
+    returns a 400 response.
+
+    Anonymous users are supported and handled via get_anonymous_user(). They must
+    be validated through validate_anonymous_user (this happens seamlessly if
+    Turnstile validation is included.)
+
+    Args:
+        request (HttpRequest): The incoming HTTP request.
+        asset_pk (int or str): Primary key of the asset to roll back.
+
+    Returns:
+        JsonResponse: A JSON object with the following fields:
+
+        - **id** (int): ID of the created transcription. Example: `123`
+        - **sent** (float): Timestamp (UNIX epoch) when the response was sent.
+          Example: `1715091212.123456`
+        - **submissionUrl** (str): URL where the transcription can be edited.
+          Example: `"/transcriptions/submit/123/"`
+        - **text** (str): Text of the transcription.
+        - **asset** (dict):
+            - **id** (int): ID of the asset. Example: `456`
+            - **status** (str): Current transcription status. Example: `"completed"`
+            - **contributors** (int): Number of distinct contributors. Example: `3`
+        - **message** (str): Status message.
+          Example: `"Successfully rolled back transcription to previous version"`
+        - **undo_available** (bool): Whether a rollback is currently possible.
+        - **redo_available** (bool): Whether a rollforward is currently possible.
+
+        Example:
+            ```json
+            {
+                "id": 123,
+                "sent": 1715091212.123456,
+                "submissionUrl": "/transcriptions/submit/123/",
+                "text": "Transcribed text...",
+                "asset": {
+                    "id": 456,
+                    "status": "completed",
+                    "contributors": 3
+                },
+                "message": "Successfully rolled back transcription to previous version",
+                "undo_available": true,
+                "redo_available": false
+            }
+            ```
+    """
     asset = get_object_or_404(Asset, pk=asset_pk)
 
     if request.user.is_anonymous:
@@ -225,7 +279,60 @@ def rollback_transcription(request, *, asset_pk):
 @validate_anonymous_user
 @atomic
 @ratelimit(key="header:cf-connecting-ip", rate="1/m", block=settings.RATELIMIT_BLOCK)
-def rollforward_transcription(request, *, asset_pk):
+def rollforward_transcription(
+    request: HttpRequest, *, asset_pk: Union[int, str]
+) -> JsonResponse:
+    """
+    Perform a rollforward to the transcription previously replaced by a rollback.
+
+    Requires the most recent transcription to be a rollback, and for the
+    transcription it superseded to exist and be valid. If rollforward is not
+    possible, returns a 400 response.
+
+    Anonymous users are supported and handled via get_anonymous_user(). They must
+    be validated through validate_anonymous_user (this happens seamlessly if
+    Turnstile validation is included.)
+
+    Args:
+        request (HttpRequest): The incoming HTTP request.
+        asset_pk (int or str): Primary key of the asset to roll forward.
+
+    Returns:
+        JsonResponse: A JSON object with the following fields:
+
+        - **id** (int): ID of the created transcription. Example: `123`
+        - **sent** (float): Timestamp (UNIX epoch) when the response was sent.
+          Example: `1715091212.123456`
+        - **submissionUrl** (str): URL where the transcription can be edited.
+          Example: `"/transcriptions/submit/123/"`
+        - **text** (str): Text of the transcription.
+        - **asset** (dict):
+            - **id** (int): ID of the asset. Example: `456`
+            - **status** (str): Current transcription status. Example: `"completed"`
+            - **contributors** (int): Number of distinct contributors. Example: `3`
+        - **message** (str): Status message.
+          Example: `"Successfully restored transcription to next version"`
+        - **undo_available** (bool): Whether a rollback is currently possible.
+        - **redo_available** (bool): Whether a rollforward is currently possible.
+
+        Example:
+            ```json
+            {
+                "id": 123,
+                "sent": 1715091212.123456,
+                "submissionUrl": "/transcriptions/submit/123/",
+                "text": "Transcribed text...",
+                "asset": {
+                    "id": 456,
+                    "status": "completed",
+                    "contributors": 3
+                },
+                "message": "Successfully restored transcription to next version",
+                "undo_available": true,
+                "redo_available": false
+            }
+            ```
+    """
     asset = get_object_or_404(Asset, pk=asset_pk)
 
     if request.user.is_anonymous:


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-1167

These changes are examples of the type of documentation we'll be adding the entire code base.

These are formatted in a way they can be used to produce external documentation using, e.g., Sphinx, though we aren't doing that yet.

from __future__ import annotations is used to reference types that are defined later (in this instance, Transcription) for type hints. The import is required before Python 3.12, and so can be removed once we've fully upgraded to that (it's safe to leave it there after the upgrade, however).

This does include a couple of minor code changes that I decided to make while writing the documentation because the success on the rollback/forward methods returned a 3-tupe, while the failure returned a 2-tuple. Failure now returns a 3-tuple with None as the third value to make it consistent and to enable easier sequence unpacking for future use.