### PR TITLE
Updated asset_id regex in exporter to handle all Paprika URLs - main

### DIFF
--- a/exporter/views.py
+++ b/exporter/views.py
@@ -72,7 +72,7 @@ def get_original_asset_id(download_url):
         pattern = (
             r"/service:([A-Za-z0-9:.\-\_]+)/"
             + r"|/master/([A-Za-z0-9/]+)([0-9.]+)"
-            + r"|/public:music:([A-Za-z0-9:.\-\_]+)/"
+            + r"|/public:[A-Za-z0-9]+:([A-Za-z0-9:.\-_]+?)/"
         )
         asset_id = re.search(pattern, download_url)
         if not asset_id:


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-1176

This is the merge into main.

I failed to merge one of my hotfixes into main before the last release. That hotfix dealt with asset.media_url, which has been removed altogether in main. The merge from release here wanted to add those back in, which, among other things, caused tests to fail. I've removed the media_url-related changes during this merge as well.

The pip-audit failure is legitimate, but unrelated to these changes. I've added a ticket to upgrade Django to resolve that: https://staff.loc.gov/tasks/browse/CONCD-1181