### PR TITLE
Added docs for ajax.py and updated other docs to new format

### DIFF
--- a/concordia/models.py
+++ b/concordia/models.py
@@ -735,26 +735,24 @@ class Asset(MetricsModelMixin("asset"), models.Model):
         self,
     ) -> Tuple[bool, Union[str, Transcription], Optional[Transcription]]:
         """
-        Determine whether the latest transcription on this asset can be rolled back.
-
-        This checks the transcription history for the most recent non-rolled-forward
-        transcription that precedes the current latest transcription, excluding any
-        transcriptions that are rollforwards or are sources of rollforwards.
-
-        Returns:
-            tuple:
-                - (True, target, original) if a rollback is possible, where:
-                    * target is the transcription to roll back to.
-                    * original is the current latest transcription.
-                - (False, reason, None) if a rollback is not possible, where:
-                    * reason is a string explaining why.
+        Check whether the latest transcription can be rolled back.
 
         A rollback is only possible if:
-            - There is more than one transcription.
-            - There is a prior transcription that is not a rollforward
-              or a source of one.
+        - There is more than one transcription.
+        - There is a prior transcription that is not a rollforward or source of one.
 
-        This method does not perform the rollback, only checks feasibility.
+        This method does not perform the rollback—only checks feasibility.
+
+        Returns:
+            result (tuple): A (bool, value, latest) tuple describing rollback
+                possibility.
+
+        Return Behavior:
+            - If no transcriptions exist: returns (False, reason_string, None).
+            - If no eligible rollback target exists: returns (False, reason_string,
+              None).
+            - If rollback is possible: returns (True, target_transcription,
+              latest_transcription).
         """
         # original_latest_transcription holds the actual latest transcription
         # latest_transcription starts by holding the actual latest transcription,
@@ -815,26 +813,21 @@ class Asset(MetricsModelMixin("asset"), models.Model):
 
     def rollback_transcription(self, user: User) -> Transcription:
         """
-        Perform a rollback of the latest transcription on this asset.
+        Create a rollback transcription using the most recent eligible prior version.
 
-        This creates a new transcription that copies the text of the most recent
-        eligible prior transcription (as determined by `can_rollback`) and marks it
-        as rolled back. It also updates the original latest transcription to reflect
-        that it has been superseded.
+        If rollback is not possible, raises a `ValueError`. The new transcription will:
+        - Set `rolled_back=True`
+        - Set `source` to the prior eligible transcription
+        - Set `supersedes` to the current latest transcription
 
         Args:
-            user (User): The user initiating the rollback.
+            user (User): The user performing the rollback.
 
         Returns:
-            Transcription: The newly created rollback transcription.
+            transcription (Transcription): The newly created rollback transcription.
 
         Raises:
-            ValueError: If rollback is not possible (e.g. no eligible transcription).
-
-        The new transcription will:
-            - Have `rolled_back=True`.
-            - Set its `source` to the transcription it is rolled back to.
-            - Set `supersedes` to the current latest transcription.
+            ValueError: If rollback is not possible due to invalid or missing history.
         """
         results = self.can_rollback()
         if results[0] is not True:
@@ -873,26 +866,23 @@ class Asset(MetricsModelMixin("asset"), models.Model):
         self,
     ) -> Tuple[bool, Union[str, Transcription], Optional[Transcription]]:
         """
-        Determine whether a previous rollback on this asset can be rolled forward.
-
-        This checks whether the most recent transcription is a rollback transcription
-        and whether the transcription it replaced (its `supersedes`) can be restored.
-
-        Returns:
-            tuple:
-                - (True, target, original) if rollforward is possible, where:
-                    * target is the transcription to roll forward to.
-                    * original is the current latest transcription.
-                - (False, reason, None) if rollforward is not possible, where:
-                    * reason is a string explaining why.
-
-        This method handles cases where multiple rollforwards were applied,
-        walking backward through the transcription chain to find the appropriate
-        rollback origin.
+        Check whether a previous rollback can be rolled forward.
 
         A rollforward is only possible if:
-            - The latest transcription is a rollback.
-            - The rollback's superseded transcription exists and can be restored.
+        - The latest transcription is a rollback.
+        - The rollback’s superseded transcription still exists and can be restored.
+
+        This method does not perform the rollforward—only checks feasibility.
+
+        Returns:
+            result (tuple): A (bool, value, latest) tuple describing rollforward
+                possibility.
+
+        Return Behavior:
+            - If no transcriptions exist: returns (False, reason_string, None).
+            - If the rollback chain is malformed: returns (False, reason_string, None).
+            - If rollforward is possible: returns (True, target_transcription,
+              latest_transcription).
         """
         # original_latest_transcription holds the actual latest transcription
         # latest_transcription starts by holding the actual latest transcription,
@@ -999,23 +989,32 @@ class Asset(MetricsModelMixin("asset"), models.Model):
         """
         Perform a rollforward of the most recent rollback transcription.
 
-        This creates a new transcription that restores the text from the
-        rollback's superseded transcription and marks it as a rollforward.
+        This creates a new transcription that restores the text from the rollback's
+        superseded transcription and marks it as a rollforward. A rollforward is only
+        possible if the latest transcription is a rollback and the replaced
+        transcription still exists.
+
+        Attributes:
+            rolled_forward (bool): Set to `True` for the new transcription.
+            source (Transcription): Set to the transcription being restored.
+            supersedes (Transcription): Set to the current latest transcription.
 
         Args:
             user (User): The user initiating the rollforward.
 
         Returns:
-            Transcription: The newly created rollforward transcription.
+            transcription (Transcription): The newly created rollforward transcription.
 
         Raises:
-            ValueError: If rollforward is not possible (e.g. no valid rollback
-                        history or malformed transcription chain).
+            ValueError: If rollforward is not possible, such as when no rollback
+                exists or the history is malformed.
 
-        The new transcription will:
-            - Have `rolled_forward=True`.
-            - Set its `source` to the transcription being rolled forward to.
-            - Set `supersedes` to the current latest transcription.
+        Return Behavior:
+            - If rollforward is possible:
+                - Creates a new transcription restoring the original text.
+                - Marks it with `rolled_forward=True`.
+            - If rollforward is not possible:
+                - Raises `ValueError` with a descriptive message.
         """
         results = self.can_rollforward()
         if results[0] is not True:

--- a/concordia/views/accounts.py
+++ b/concordia/views/accounts.py
@@ -52,10 +52,10 @@ logger = logging.getLogger(__name__)
 
 class ConcordiaPasswordResetConfirmView(PasswordResetConfirmView):
     """
-    View for confirming a password reset and automatically logging in the user.
+    Confirm a password reset and automatically log in the user.
 
-    Overrides Django's built-in
-    `PasswordResetConfirmView <https://docs.djangoproject.com/en/stable/topics/auth/default/#django.contrib.auth.views.PasswordResetConfirmView>`__
+    Extends Django’s built-in
+    [PasswordResetConfirmView](https://docs.djangoproject.com/en/stable/topics/auth/default/#django.contrib.auth.views.PasswordResetConfirmView)
     to use a custom form and enable automatic login after a successful reset.
 
     Attributes:
@@ -64,12 +64,9 @@ class ConcordiaPasswordResetConfirmView(PasswordResetConfirmView):
         form_class (Form): The form used to set the new password and activate
             the account.
 
-    Args:
-        request (HttpRequest): The HTTP request completing the password reset.
-
     Returns:
-        HttpResponse: Renders the password reset confirmation page or redirects
-        after successful password change and login.
+        response (HttpResponse): Renders the password reset confirmation page or
+            redirects after successful password change and login.
     """
 
     post_reset_login: bool = True
@@ -78,23 +75,20 @@ class ConcordiaPasswordResetConfirmView(PasswordResetConfirmView):
 
 class ConcordiaPasswordResetRequestView(PasswordResetView):
     """
-    View for requesting a password reset, supporting inactive users.
+    Request a password reset, supporting inactive users.
 
-    Overrides Django's built-in
-    `PasswordResetView <https://docs.djangoproject.com/en/stable/topics/auth/default/#django.contrib.auth.views.PasswordResetView>`__
+    Extends Django’s built-in
+    [`PasswordResetView`](https://docs.djangoproject.com/en/stable/topics/auth/default/#django.contrib.auth.views.PasswordResetView)
     to use a custom form that allows inactive users to reset their password
     and activate their account in one step.
 
     Attributes:
         form_class (Form): The form used to validate and process the password
-            reset request. This allows inactive accounts to activate during reset.
-
-    Args:
-        request (HttpRequest): The HTTP request initiating the reset.
+            reset request.
 
     Returns:
-        HttpResponse: Renders the password reset form or redirects after
-        successful submission.
+        response (HttpResponse): Renders the password reset form or redirects
+            after successful submission.
     """
 
     form_class: type[Form] = AllowInactivePasswordResetForm
@@ -102,26 +96,22 @@ class ConcordiaPasswordResetRequestView(PasswordResetView):
 
 def registration_rate(group: str, request: HttpRequest) -> Optional[str]:
     """
-    Determines the throttling rate for registration attempts.
+    Determine the throttling rate for registration attempts.
 
-    Used with the
-    `ratelimit <https://django-ratelimit.readthedocs.io/en/stable/usage.html#ratelimit>`__
-    decorator from django-ratelimit to dynamically adjust the rate based on
-    whether the registration form is valid.
+    Used with the `ratelimit` decorator from `django-ratelimit` to dynamically
+    adjust the request rate based on form validation.
 
-    If the submitted form is invalid, limits requests to 10 per hour. If the
-    form is valid, allows the request without throttling.
+    If the submitted registration form is valid, no throttling is applied.
+    If it is invalid, the rate is limited to 10 requests per hour.
 
     Args:
-        group (str): The rate limit group name. Example: `"registration"`
-        request (HttpRequest): The incoming request containing POST data from
-            the registration form.
+        group (str): The rate limit group name.
+        request (HttpRequest): The request containing registration form data.
 
     Returns:
-        str or None: The rate limit string (e.g., `"10/h"`) if the form is invalid;
-        otherwise, `None` to indicate no throttling.
+        rate (str or None): The rate limit string (e.g., "10/h") if the form is
+            invalid; otherwise `None` to indicate no throttling.
     """
-
     registration_form = UserRegistrationForm(request.POST)
     if registration_form.is_valid():
         return None
@@ -142,22 +132,19 @@ def registration_rate(group: str, request: HttpRequest) -> Optional[str]:
 )
 class ConcordiaRegistrationView(RegistrationView):
     """
-    User registration view with rate limiting.
+    User registration view with POST-specific rate limiting.
 
-    Extends
-    `django_registration.views.RegistrationView <https://django-registration.readthedocs.io/en/stable/views.html#django_registration.views.RegistrationView>`__
-    to apply a POST-specific rate limit using
-    `django-ratelimit <https://django-ratelimit.readthedocs.io/en/stable/usage.html#ratelimit>`__.
-    This protects against registration abuse based on form validation.
+    Extends `django_registration.views.RegistrationView` to apply a POST-specific
+    rate limit using the `django-ratelimit` decorator. This protects against
+    abuse by restricting failed registration attempts while allowing valid
+    submissions to proceed freely.
 
     Attributes:
-        form_class (Form): The form used to collect and validate user registration data.
-
-    Args:
-        request (HttpRequest): The registration request from the client.
+        form_class (Form): The form used to collect and validate user registration
+            data. Example: `UserRegistrationForm`.
 
     Returns:
-        HttpResponse: Renders the registration form or redirects after
+        response (HttpResponse): Renders the registration form or redirects after
             successful registration.
     """
 
@@ -170,22 +157,22 @@ class ConcordiaLoginView(LoginView):
     Login view with Turnstile validation.
 
     Extends Django's
-    `LoginView <https://docs.djangoproject.com/en/stable/topics/auth/default/#django.contrib.auth.views.LoginView>`__
-    to integrate Turnstile CAPTCHA validation during POST requests.
+    [LoginView](https://docs.djangoproject.com/en/stable/topics/auth/default/#django.contrib.auth.views.LoginView)
+    to integrate Turnstile validation during POST requests.
 
     Attributes:
         form_class (Form): The login form used to authenticate users.
 
-    Args:
-        request (HttpRequest): The login request from the client.
-
     Returns:
-        HttpResponse:
-            - On GET: Renders the login form with embedded Turnstile widget.
-            - On POST:
-                - If both login and Turnstile succeed: Redirects to the next page.
-                - If Turnstile fails: Returns the login form with an error message.
-                - If login form is invalid: Returns the form with validation errors.
+        response (HttpResponse): The rendered login form or redirect response,
+            depending on the validation outcome.
+
+    Return Behavior:
+        - On GET: Renders the login form with the embedded Turnstile widget.
+        - On POST:
+            - If both login and Turnstile succeed: redirects to the next page.
+            - If Turnstile fails: returns the login form with an error message.
+            - If the login form is invalid: returns the form with validation errors.
     """
 
     form_class = UserLoginForm
@@ -219,24 +206,22 @@ def account_letter(request: HttpRequest) -> HttpResponse:
     """
     Generate and return a PDF letter summarizing a user's contributions.
 
-    This view creates a service letter for the logged-in user, summarizing
-    their transcription and review activity. It uses an HTML template rendered
-    with contribution data and converts it to a PDF using WeasyPrint.
+    This view creates a service letter for the logged-in user, summarizing their
+    transcription and review activity. It uses an HTML template rendered with
+    contribution data and converts it to a PDF using WeasyPrint.
 
     Requires the user to be authenticated.
 
-    Args:
-        request (HttpRequest): The request from the authenticated user.
-
     Returns:
-        HttpResponse: A PDF response with content type `application/pdf` and
-        a `Content-Disposition` set to download as `letter.pdf`.
+        response (HttpResponse): A PDF response with content type
+            `application/pdf` and a `Content-Disposition` header set to download
+            as `letter.pdf`.
 
-    Example:
-        The generated PDF includes:
-        - User's name and join date
-        - Total transcriptions and reviews
-        - List of assets they contributed to
+    Return Behavior:
+        - The generated PDF includes:
+            - User's name and join date.
+            - Total transcriptions and reviews.
+            - List of assets the user contributed to.
     """
     image_url = "file://{0}/{1}/img/logo.jpg".format(
         settings.SITE_ROOT_DIR, settings.STATIC_ROOT
@@ -271,35 +256,37 @@ def get_pages(request: HttpRequest) -> JsonResponse:
     Return a paginated and filtered list of the user's contributed assets as HTML.
 
     Retrieves assets the current user has worked on, applies pagination, and
-    optionally filters by campaign, activity type, status, and date range.
-    Renders the results into a fragment of HTML for use in dynamic page updates.
+    optionally filters by campaign, activity type, status, and date range. Renders
+    the results into a fragment of HTML for use in dynamic page updates.
 
     Requires the user to be authenticated.
 
     Args:
         request (HttpRequest): The request from the authenticated user.
-            The following GET query parameters are supported:
 
-            - page (int): Page number to display. Example: `2`
-            - campaign (int): Filter by campaign ID. Example: `17`
-            - status (list[str]): Filter by asset statuses.
-              Example: `["in_progress", "submitted"]`
-            - activity (str): Filter by activity type. Example: `"transcribe"`
-            - order_by (str): Sort order. Example: `"date-descending"`
-            - start (str): Start date in YYYY-MM-DD format. Example: `"2023-01-01"`
-            - end (str): End date in YYYY-MM-DD format. Example: `"2023-12-31"`
+    Request Parameters:
+        - `page` (int): Page number to display. Example: `2`
+        - `campaign` (int): Filter by campaign ID. Example: `17`
+        - `status` (list[str]): Filter by asset statuses. Example:
+          `["in_progress", "submitted"]`
+        - `activity` (str): Filter by activity type. Example: `"transcribe"`
+        - `order_by` (str): Sort order. Example: `"date-descending"`
+        - `start` (str): Start date in YYYY-MM-DD format. Example: `"2023-01-01"`
+        - `end` (str): End date in YYYY-MM-DD format. Example: `"2023-12-31"`
 
     Returns:
-        JsonResponse: A JSON object with the following field:
+        response (JsonResponse): A JSON object containing rendered HTML for recent
+            contributed pages.
 
-        - **content** (str): Rendered HTML fragment for recent pages.
+    Response Format - Success:
+        - `content` (str): Rendered HTML for recent pages.
 
     Example:
-        ::
-
-            {
-                "content": "<div class='page-results'>...</div>"
-            }
+        ```json
+        {
+            "content": "<div class='page-results'>...</div>"
+        }
+        ```
     """
     asset_list = _get_pages(request)
     paginator = Paginator(asset_list, 30)  # Show 30 assets per page.
@@ -335,53 +322,46 @@ class AccountProfileView(LoginRequiredMixin, FormView, ListView):
     Display and update user account profile and contribution history.
 
     Combines functionality from:
-    - `LoginRequiredMixin <https://docs.djangoproject.com/en/stable/topics/auth/default/#the-loginrequiredmixin-mixin>`__
-    - `FormView <https://docs.djangoproject.com/en/stable/ref/class-based-views/generic-editing/#formview>`__
-    - `ListView <https://docs.djangoproject.com/en/stable/ref/class-based-views/generic-display/#listview>`__
+    - [LoginRequiredMixin](https://docs.djangoproject.com/en/stable/topics/auth/default/#the-loginrequiredmixin-mixin)
+    - [FormView](https://docs.djangoproject.com/en/stable/ref/class-based-views/generic-editing/#formview)
+    - [ListView](https://docs.djangoproject.com/en/stable/ref/class-based-views/generic-display/#listview)
 
-    to allow authenticated users to:
-    - Update their email address and name.
-    - View a paginated list of assets they have contributed to.
-    - See aggregate statistics on their transcription and review activity.
+    Allows authenticated users to:
+    - Update their email address and name
+    - View a paginated list of assets they have contributed to
+    - See aggregate statistics on their transcription and review activity
 
-    Email changes may require reconfirmation if `REQUIRE_EMAIL_RECONFIRMATION` is set.
+    Email changes require confirmation unless the setting
+    `REQUIRE_EMAIL_RECONFIRMATION` is False.
 
     Attributes:
         template_name (str): Template used to render the profile page.
-            Example: `"account/profile.html"`
         form_class (Form): Form used to update the user's email address.
-            Example: `UserProfileForm`
         success_url (str): Redirect URL after successful form submission.
-            Example: `"/accounts/profile/"`
-        allow_empty (bool): Whether to render the page if the user has no contributions.
-            Default is `True`.
+        allow_empty (bool): Whether to render the page if the user has no
+            contributions.
         paginate_by (int): Number of contributed assets to show per page.
-            Default is `30`.
         reconfirmation_email_body_template (str): Path to the plain text email
             body template.
-            Example: `"emails/email_reconfirmation_body.txt"`
-        reconfirmation_email_subject_template (str): Path to the email subject template.
-            Example: `"emails/email_reconfirmation_subject.txt"`
-
-    Args:
-        request (HttpRequest): The request from the authenticated user, with
-            optional GET or POST data including:
-
-            - page (int): Page number to display. Example: `1`
-            - campaign (int): Campaign filter. Example: `42`
-            - activity (str): Activity type filter. Example: `"transcribe"`
-            - status (list[str]): Asset statuses. Example: `["completed"]`
-            - start (str): Start date in YYYY-MM-DD format. Example: `"2023-01-01"`
-            - end (str): End date in YYYY-MM-DD format. Example: `"2023-12-31"`
-            - order_by (str): Sort field. Example: `"date-descending"`
-            - tab (str): Selected tab to display. Example: `"account"`
+        reconfirmation_email_subject_template (str): Path to the email subject
+            template.
 
     Returns:
-        HttpResponse: The rendered profile page with contribution data, or a redirect
-        to `#account` after successful form submission.
+        response (HttpResponse): The rendered profile page with contribution data
+            or a redirect to `#account` after successful form submission.
+
+    Request Parameters:
+        - `page` (int): Page number. Example: `1`
+        - `campaign` (int): Campaign filter. Example: `42`
+        - `activity` (str): Activity type filter. Example: `"transcribe"`
+        - `status` (list[str]): Asset statuses. Example: `["completed"]`
+        - `start` (str): Start date in YYYY-MM-DD format. Example: `"2023-01-01"`
+        - `end` (str): End date in YYYY-MM-DD format. Example: `"2023-12-31"`
+        - `order_by` (str): Sort field. Example: `"date-descending"`
+        - `tab` (str): Selected tab. Example: `"account"`
     """
 
-    template_name = "account/profile.html"
+    template_name: str = "account/profile.html"
     form_class: Type[Form] = UserProfileForm
     success_url = reverse_lazy("user-profile")
     reconfirmation_email_body_template: str = "emails/email_reconfirmation_body.txt"
@@ -544,41 +524,42 @@ class AccountProfileView(LoginRequiredMixin, FormView, ListView):
 @method_decorator(never_cache, name="dispatch")
 class AccountDeletionView(LoginRequiredMixin, FormView):
     """
-    View for handling user-initiated account deletion.
+    Handle user-initiated account deletion.
 
-    Extends:
-    - `LoginRequiredMixin <https://docs.djangoproject.com/en/stable/topics/auth/default/#the-loginrequiredmixin-mixin>`__
-    - `FormView <https://docs.djangoproject.com/en/stable/ref/class-based-views/generic-editing/#formview>`__
+    Provides a confirmation form for deleting the user's account. If the user has
+    contributed transcriptions, their data is anonymized instead of being deleted.
+    Otherwise, the account is fully removed. A confirmation email is sent to the
+    user's address before deletion. After deletion, the user is logged out.
 
-    Provides a confirmation form and, upon validation, either deletes or anonymizes
-    the user account based on whether they have existing transcriptions.
-
-    After account deletion, logs the user out and sends a confirmation email to the
-    address associated with the account before deletion.
+    Requires the user to be authenticated.
 
     Attributes:
-        template_name (str): Path to the template used for rendering the confirmation
-            page. Example: `"account/account_deletion.html"`
+        template_name (str): Template used to render the confirmation form.
+            Example: `"account/account_deletion.html"`
         form_class (Form): Form used to confirm account deletion.
             Example: `AccountDeletionForm`
-        success_url (str): Redirect URL after account deletion.
+        success_url (str): URL to redirect to after deletion.
             Example: `"/"`
-        email_body_template (str): Template for the body of the deletion confirmation
-            email. Example: `"emails/delete_account_body.txt"`
-        email_subject_template (str): Template for the subject of the deletion
-            confirmation email. Example: `"emails/delete_account_subject.txt"`
-
-    Args:
-        request (HttpRequest): The deletion request from the authenticated user.
+        email_body_template (str): Template for the body of the confirmation email.
+            Example: `"emails/delete_account_body.txt"`
+        email_subject_template (str): Template for the subject of the confirmation
+            email. Example: `"emails/delete_account_subject.txt"`
 
     Returns:
-        HttpResponse: A redirect to the homepage after account deletion, or re-renders
-        the form with validation errors.
+        response (HttpResponse): A redirect to the homepage after deletion, or a
+            rendered form with errors if validation fails.
+
+    Return Behavior:
+        - If the user confirms deletion and has transcriptions: anonymizes their
+          account and logs them out.
+        - If the user has no transcriptions: deletes the account entirely and logs
+          them out.
+        - If the form is invalid: re-renders the confirmation form with errors.
     """
 
-    template_name = "account/account_deletion.html"
+    template_name: str = "account/account_deletion.html"
     form_class: Type[Form] = AccountDeletionForm
-    success_url = reverse_lazy("homepage")
+    success_url: str = reverse_lazy("homepage")
     email_body_template: str = "emails/delete_account_body.txt"
     email_subject_template: str = "emails/delete_account_subject.txt"
 
@@ -649,37 +630,27 @@ class EmailReconfirmationView(TemplateView):
     """
     Handle email reconfirmation via a signed URL token.
 
-    Extends:
-    - `TemplateView <https://docs.djangoproject.com/en/stable/ref/class-based-views/base/#templateview>`__
-
-    This view validates a signed confirmation key sent to the user's email during an
-    address change. If valid and not expired, the email update is applied. If invalid
-    or expired, an error message is rendered on a failure page.
+    Validates a confirmation key sent to the user's new email address during
+    an address change. If valid and not expired, applies the email update. If
+    invalid, expired, or mismatched, renders an error message.
 
     Attributes:
-        template_name (str): Template rendered when confirmation fails.
+        template_name (str): Template rendered if the confirmation fails.
             Example: `"account/email_reconfirmation_failed.html"`
-        success_url (str): URL to redirect to on successful confirmation.
+        success_url (str): URL to redirect to on success.
             Example: `"/accounts/profile/#account"`
-        BAD_USERNAME_MESSAGE (str): Error message when the user account cannot be found.
-        BAD_EMAIL_MESSAGE (str): Error message when the email does not match.
-        EXPIRED_MESSAGE (str): Error message when the token is expired.
-        INVALID_KEY_MESSAGE (str): Error message when the token signature is invalid.
-
-    Args:
-        request (HttpRequest): A GET request with `confirmation_key` in the URL.
+        BAD_USERNAME_MESSAGE (str): Error if the user account cannot be found.
+        BAD_EMAIL_MESSAGE (str): Error if the email does not match expectations.
+        EXPIRED_MESSAGE (str): Error if the key is expired.
+        INVALID_KEY_MESSAGE (str): Error if the key signature is invalid.
 
     Returns:
-        HttpResponse:
-            - Redirect to `#account` on success.
-            - Rendered failure template with error context on validation failure.
+        response (HttpResponse): Redirects to the profile page with `#account`
+            on success, or renders the failure template with error details.
 
     URL Parameters:
-        confirmation_key (str): A signed token containing the username and new email.
-            Example: `"ZHVtbXl1c2VyOnNvbWVvbmVAZXhhbXBsZS5jb20="`
-
-    Raises:
-        ValidationError: If the token is invalid, expired, or does not match the user.
+        confirmation_key (str): A signed token containing the username and new
+            email. Example: `"ZHVtbXl1c2VyOnNvbWVvbmVAZXhhbXBsZS5jb20="`
     """
 
     success_url = reverse_lazy("user-profile")

--- a/concordia/views/ajax.py
+++ b/concordia/views/ajax.py
@@ -232,15 +232,16 @@ def generate_ocr_transcription(
     """
     Create and save a new OCR-generated transcription for an asset.
 
-    If no prior transcription exists, creates a blank transcription to serve
-    as the superseded record. Otherwise, the specified previous transcription
-    is superseded by the new OCR transcription.
+    If no prior transcription exists, creates a blank transcription to serve as
+    the superseded record. Otherwise, the specified previous transcription is
+    superseded by the new OCR transcription.
 
     Requires the user to be authenticated.
 
-    Args:
-        request (HttpRequest): The POST request initiating OCR transcription.
-        asset_pk (int or str): The primary key of the asset to transcribe.
+    Request Parameters:
+        - `supersedes` (int or str, optional): The ID of the transcription being
+          superseded.
+        - `language` (str, optional): The language code to influence OCR output.
 
     Returns:
         response (JsonResponse): A dictionary describing the new transcription
@@ -554,9 +555,10 @@ def save_transcription(
     checks for supersession rules. If valid, creates and saves a new transcription
     associated with the current or anonymous user.
 
-    Args:
-        request (HttpRequest): The POST request containing transcription text.
-        asset_pk (int or str): The primary key of the asset being transcribed.
+    Request Parameters:
+        - `text` (str): The transcription text.
+        - `supersedes` (int or str, optional): The ID of the transcription being
+          superseded. Example: `"123"`
 
     Returns:
         response (JsonResponse): A dictionary describing the saved transcription
@@ -954,16 +956,16 @@ def reserve_asset(request: HttpRequest, *, asset_pk: Union[int, str]) -> JsonRes
     If no active reservation exists, creates a new one using the session's
     reservation token. If a reservation exists for this session, updates it.
     If the asset is reserved by another session, returns a conflict response.
-    Handles reservation release if `release` is set in the POST body.
+    Handles reservation release if `release` is set in the request body.
 
-    Args:
-        request (HttpRequest): The POST request to reserve or release the asset.
-        asset_pk (int or str): The primary key of the asset to reserve.
+    Request Parameters:
+        - `release` (bool, optional): If present and true, releases the current
+          reservation instead of acquiring or updating it. Example: `"true"`
 
     Returns:
         response (JsonResponse or HttpResponse): A dictionary indicating the
-            reservation status and token, or an HTTP 408/409 response for timeout
-            or conflict.
+        reservation status and token, or an HTTP 408/409 response for timeout
+        or conflict.
 
     Response Format - Success:
         - `asset_pk` (int): The ID of the reserved asset.
@@ -981,6 +983,7 @@ def reserve_asset(request: HttpRequest, *, asset_pk: Union[int, str]) -> JsonRes
         }
         ```
     """
+
     reservation_token = get_or_create_reservation_token(request)
 
     if request.POST.get("release"):

--- a/concordia/views/ajax.py
+++ b/concordia/views/ajax.py
@@ -47,12 +47,42 @@ structured_logger = structlog.get_logger(f"structlog.{__name__}")
 
 @cache_control(private=True, max_age=settings.DEFAULT_PAGE_TTL)
 @csrf_exempt
-def ajax_session_status(request):
+def ajax_session_status(request: HttpRequest) -> JsonResponse:
     """
-    Returns the user-specific information which would otherwise make many pages
-    uncacheable
-    """
+    Return a JSON object describing the authenticated session state.
 
+    If the user is authenticated, this includes a truncated username and
+    navigational links to profile, logout, and admin pages (if staff or superuser).
+    If the user is anonymous, returns an empty dictionary.
+
+    Args:
+        request (HttpRequest): The HTTP request initiating the session status check.
+
+    Returns:
+        response (JsonResponse): A dictionary containing either session information
+            or empty data.
+
+    Response Format - Success:
+        - `username` (str): The first 15 characters of the user's username.
+        - `links` (list[dict]): A list of links relevant to the user's session.
+            - `title` (str): The label for the link (e.g., "Profile", "Logout").
+            - `url` (str): The absolute URL for the link.
+
+    Example:
+        ```json
+        // If the user is authenticated:
+        {
+            "username": "johndoe",
+            "links": [
+                {"title": "Profile", "url": "https://example.com/accounts/profile/"},
+                {"title": "Logout", "url": "https://example.com/accounts/logout/"}
+            ]
+        }
+
+        // If the user is anonymous:
+        {}
+        ```
+    """
     user = request.user
     if user.is_anonymous:
         res = {}
@@ -85,11 +115,39 @@ def ajax_session_status(request):
 @never_cache
 @login_required
 @csrf_exempt
-def ajax_messages(request):
+def ajax_messages(request: HttpRequest) -> JsonResponse:
     """
-    Returns any messages queued for the current user
-    """
+    Return a JSON object containing the user's queued messages.
 
+    Retrieves Django messages for the current request and formats them
+    as a list of dictionaries, each containing the message text and its
+    severity level.
+
+    Requires the user to be authenticated.
+
+    Args:
+        request (HttpRequest): The request from the authenticated user.
+
+    Returns:
+        response (JsonResponse): A dictionary with a `messages` field containing
+            a list of message entries.
+
+    Response Format - Success:
+        - `messages` (list[dict]): A list of user-visible messages.
+            - `level` (str): The severity level of the message
+              (e.g., "info", "warning", "error").
+            - `message` (str): The text content of the message.
+
+    Example:
+        ```json
+        {
+            "messages": [
+                {"level": "info", "message": "You have been logged out."},
+                {"level": "warning", "message": "Your session is about to expire."}
+            ]
+        }
+        ```
+    """
     return JsonResponse(
         {
             "messages": [
@@ -100,7 +158,47 @@ def ajax_messages(request):
     )
 
 
-def get_transcription_superseded(asset, supersedes_pk):
+def get_transcription_superseded(
+    asset: Asset, supersedes_pk: Union[int, str, None]
+) -> Union[Transcription, JsonResponse, None]:
+    """
+    Determine the superseded transcription, if any, for a new transcription.
+
+    If a valid `supersedes_pk` is provided, returns the corresponding transcription
+    unless it has already been superseded. If no `supersedes_pk` is provided,
+    checks whether the asset already has an open transcription.
+
+    This helper may return an error response to be passed directly to the client,
+    or a transcription object used when saving a new one.
+
+    Args:
+        asset (Asset): The asset the transcription is associated with.
+        supersedes_pk (int or str or None): The primary key of the transcription
+            being superseded, or `None` if this is the first transcription.
+
+    Returns:
+        response (Transcription or JsonResponse or None): A valid transcription,
+            an error response, or `None`.
+
+    Return Behavior:
+        - If a valid transcription is found, a `Transcription` object is returned.
+        - If the request is invalid or the transcription has already been superseded,
+          a `JsonResponse` with an error is returned.
+        - If there is no previous transcription to supersede, `None` is returned.
+
+    Response Format - Error:
+        - `error` (str): Explanation of why the transcription cannot be created.
+            - "An open transcription already exists"
+            - "This transcription has been superseded"
+            - "Invalid supersedes value"
+
+    Example:
+        ```json
+        {
+            "error": "An open transcription already exists"
+        }
+        ```
+    """
     if not supersedes_pk:
         if asset.transcription_set.filter(supersedes=None).exists():
             return JsonResponse(
@@ -128,7 +226,55 @@ def get_transcription_superseded(asset, supersedes_pk):
 @login_required
 @atomic
 @ratelimit(key="header:cf-connecting-ip", rate="1/m", block=settings.RATELIMIT_BLOCK)
-def generate_ocr_transcription(request, *, asset_pk):
+def generate_ocr_transcription(
+    request: HttpRequest, *, asset_pk: Union[int, str]
+) -> JsonResponse:
+    """
+    Create and save a new OCR-generated transcription for an asset.
+
+    If no prior transcription exists, creates a blank transcription to serve
+    as the superseded record. Otherwise, the specified previous transcription
+    is superseded by the new OCR transcription.
+
+    Requires the user to be authenticated.
+
+    Args:
+        request (HttpRequest): The POST request initiating OCR transcription.
+        asset_pk (int or str): The primary key of the asset to transcribe.
+
+    Returns:
+        response (JsonResponse): A dictionary describing the new transcription
+            and asset status.
+
+    Response Format - Success:
+        - `id` (int): ID of the new transcription.
+        - `sent` (float): UNIX timestamp when the transcription was created.
+        - `submissionUrl` (str): URL to submit the transcription.
+        - `text` (str): The OCR-generated transcription content.
+        - `asset` (dict):
+            - `id` (int): ID of the associated asset.
+            - `status` (str): Current transcription status.
+            - `contributors` (int): Number of users who have contributed.
+        - `undo_available` (bool): Whether the user can roll back this transcription.
+        - `redo_available` (bool): Whether the user can roll forward to another version.
+
+    Example:
+        ```json
+        {
+            "id": 123,
+            "sent": 1716294920.927134,
+            "submissionUrl": "/transcriptions/123/submit/",
+            "text": "Detected OCR content...",
+            "asset": {
+                "id": 456,
+                "status": "in_progress",
+                "contributors": 2
+            },
+            "undo_available": true,
+            "redo_available": false
+        }
+        ```
+    """
     asset = get_object_or_404(Asset, pk=asset_pk)
     user = request.user
 
@@ -136,17 +282,9 @@ def generate_ocr_transcription(request, *, asset_pk):
     language = request.POST.get("language", None)
     superseded = get_transcription_superseded(asset, supersedes_pk)
     if superseded:
-        # If superseded is an HttpResponse, that means
-        # this transcription has already been superseded, so
-        # we won't run OCR and instead send back an error
-        # Otherwise, we just have thr transcription the OCR
-        # is gong to supersede, so we can continue
         if isinstance(superseded, HttpResponse):
             return superseded
     else:
-        # This means this is the first transcription on this asset.
-        # To enable undoing of the OCR transcription, we create
-        # an empty transcription for the OCR transcription to supersede
         superseded = Transcription(
             asset=asset,
             user=get_anonymous_user(),
@@ -195,53 +333,54 @@ def rollback_transcription(
     """
     Perform a rollback on the latest transcription for the given asset.
 
-    Requires the asset to have at least one earlier transcription that is not
-    a rollforward or the source of a rollforward. If rollback is not possible,
-    returns a 400 response.
+    Restores the asset's transcription to the previous version in its history.
+    If rollback is not possible (e.g., no prior version exists), returns an error.
 
-    Anonymous users are supported and handled via get_anonymous_user(). They must
-    be validated through validate_anonymous_user (this happens seamlessly if
-    Turnstile validation is included.)
+    Anonymous users are supported and handled via `get_anonymous_user()`. The caller
+    must be validated via `validate_anonymous_user`.
 
     Args:
-        request (HttpRequest): The incoming HTTP request.
-        asset_pk (int or str): Primary key of the asset to roll back.
+        request (HttpRequest): The POST request to initiate rollback.
+        asset_pk (int or str): The primary key of the asset being rolled back.
 
     Returns:
-        JsonResponse: A JSON object with the following fields:
+        response (JsonResponse): A dictionary containing the restored transcription
+            and asset status, or an error response if rollback fails.
 
-        - **id** (int): ID of the created transcription. Example: `123`
-        - **sent** (float): Timestamp (UNIX epoch) when the response was sent.
-          Example: `1715091212.123456`
-        - **submissionUrl** (str): URL where the transcription can be edited.
-          Example: `"/transcriptions/submit/123/"`
-        - **text** (str): Text of the transcription.
-        - **asset** (dict):
-            - **id** (int): ID of the asset. Example: `456`
-            - **status** (str): Current transcription status. Example: `"completed"`
-            - **contributors** (int): Number of distinct contributors. Example: `3`
-        - **message** (str): Status message.
-          Example: `"Successfully rolled back transcription to previous version"`
-        - **undo_available** (bool): Whether a rollback is currently possible.
-        - **redo_available** (bool): Whether a rollforward is currently possible.
+    Response Format - Success:
+        - `id` (int): ID of the restored transcription.
+        - `sent` (float): UNIX timestamp of the response.
+        - `submissionUrl` (str): URL to submit the transcription.
+        - `text` (str): The restored transcription text.
+        - `asset` (dict):
+            - `id` (int): ID of the asset.
+            - `status` (str): Current transcription status.
+            - `contributors` (int): Number of users who contributed.
+        - `message` (str): Confirmation message.
+        - `undo_available` (bool): Whether rollback is possible again.
+        - `redo_available` (bool): Whether rollforward is now available.
 
-        Example:
-            ```json
-            {
-                "id": 123,
-                "sent": 1715091212.123456,
-                "submissionUrl": "/transcriptions/submit/123/",
-                "text": "Transcribed text...",
-                "asset": {
-                    "id": 456,
-                    "status": "completed",
-                    "contributors": 3
-                },
-                "message": "Successfully rolled back transcription to previous version",
-                "undo_available": true,
-                "redo_available": false
-            }
-            ```
+    Response Format - Error:
+        - `error` (str): Explanation of the failure.
+            - "No previous transcription available"
+
+    Example:
+        ```json
+        {
+            "id": 123,
+            "sent": 1716295121.113204,
+            "submissionUrl": "/transcriptions/123/submit/",
+            "text": "Previous transcription text",
+            "asset": {
+                "id": 456,
+                "status": "in_progress",
+                "contributors": 1
+            },
+            "message": "Successfully rolled back transcription to previous version",
+            "undo_available": false,
+            "redo_available": true
+        }
+        ```
     """
     asset = get_object_or_404(Asset, pk=asset_pk)
 
@@ -304,53 +443,54 @@ def rollforward_transcription(
     """
     Perform a rollforward to the transcription previously replaced by a rollback.
 
-    Requires the most recent transcription to be a rollback, and for the
-    transcription it superseded to exist and be valid. If rollforward is not
-    possible, returns a 400 response.
+    Restores the asset's transcription to the next version in its history,
+    if a valid rollforward target exists. If not, returns an error response.
 
-    Anonymous users are supported and handled via get_anonymous_user(). They must
-    be validated through validate_anonymous_user (this happens seamlessly if
-    Turnstile validation is included.)
+    Anonymous users are supported and handled via `get_anonymous_user()`. The caller
+    must be validated via `validate_anonymous_user`.
 
     Args:
-        request (HttpRequest): The incoming HTTP request.
-        asset_pk (int or str): Primary key of the asset to roll forward.
+        request (HttpRequest): The POST request to initiate rollforward.
+        asset_pk (int or str): The primary key of the asset being rolled forward.
 
     Returns:
-        JsonResponse: A JSON object with the following fields:
+        response (JsonResponse): A dictionary containing the restored transcription
+            and asset status, or an error response if rollforward fails.
 
-        - **id** (int): ID of the created transcription. Example: `123`
-        - **sent** (float): Timestamp (UNIX epoch) when the response was sent.
-          Example: `1715091212.123456`
-        - **submissionUrl** (str): URL where the transcription can be edited.
-          Example: `"/transcriptions/submit/123/"`
-        - **text** (str): Text of the transcription.
-        - **asset** (dict):
-            - **id** (int): ID of the asset. Example: `456`
-            - **status** (str): Current transcription status. Example: `"completed"`
-            - **contributors** (int): Number of distinct contributors. Example: `3`
-        - **message** (str): Status message.
-          Example: `"Successfully restored transcription to next version"`
-        - **undo_available** (bool): Whether a rollback is currently possible.
-        - **redo_available** (bool): Whether a rollforward is currently possible.
+    Response Format - Success:
+        - `id` (int): ID of the restored transcription.
+        - `sent` (float): UNIX timestamp of the response.
+        - `submissionUrl` (str): URL to submit the transcription.
+        - `text` (str): The restored transcription text.
+        - `asset` (dict):
+            - `id` (int): ID of the asset.
+            - `status` (str): Current transcription status.
+            - `contributors` (int): Number of users who contributed.
+        - `message` (str): Confirmation message.
+        - `undo_available` (bool): Whether rollback is now possible.
+        - `redo_available` (bool): Whether another rollforward is possible.
 
-        Example:
-            ```json
-            {
-                "id": 123,
-                "sent": 1715091212.123456,
-                "submissionUrl": "/transcriptions/submit/123/",
-                "text": "Transcribed text...",
-                "asset": {
-                    "id": 456,
-                    "status": "completed",
-                    "contributors": 3
-                },
-                "message": "Successfully restored transcription to next version",
-                "undo_available": true,
-                "redo_available": false
-            }
-            ```
+    Response Format - Error:
+        - `error` (str): Explanation of the failure.
+            - "No transcription to restore"
+
+    Example:
+        ```json
+        {
+            "id": 124,
+            "sent": 1716295243.029184,
+            "submissionUrl": "/transcriptions/124/submit/",
+            "text": "Next transcription text",
+            "asset": {
+                "id": 456,
+                "status": "in_progress",
+                "contributors": 1
+            },
+            "message": "Successfully restored transcription to next version",
+            "undo_available": true,
+            "redo_available": false
+        }
+        ```
     """
     asset = get_object_or_404(Asset, pk=asset_pk)
 
@@ -404,7 +544,58 @@ def rollforward_transcription(
 @require_POST
 @validate_anonymous_user
 @atomic
-def save_transcription(request, *, asset_pk):
+def save_transcription(
+    request: HttpRequest, *, asset_pk: Union[int, str]
+) -> JsonResponse:
+    """
+    Save a transcription draft for a given asset.
+
+    Validates the transcription text for disallowed content (e.g., URLs) and
+    checks for supersession rules. If valid, creates and saves a new transcription
+    associated with the current or anonymous user.
+
+    Args:
+        request (HttpRequest): The POST request containing transcription text.
+        asset_pk (int or str): The primary key of the asset being transcribed.
+
+    Returns:
+        response (JsonResponse): A dictionary describing the saved transcription
+            and asset status, or an error response if validation fails.
+
+    Response Format - Success:
+        - `id` (int): ID of the saved transcription.
+        - `sent` (float): UNIX timestamp of the response.
+        - `submissionUrl` (str): URL to submit the transcription.
+        - `asset` (dict):
+            - `id` (int): ID of the associated asset.
+            - `status` (str): Current transcription status.
+            - `contributors` (int): Number of users who contributed.
+        - `undo_available` (bool): Whether rollback is currently possible.
+        - `redo_available` (bool): Whether rollforward is currently possible.
+
+    Response Format - Error:
+        - `error` (str): Explanation of the validation failure.
+            - "It looks like your text contains URLs."
+            - "An open transcription already exists"
+            - "This transcription has been superseded"
+            - "Invalid supersedes value"
+
+    Example:
+        ```json
+        {
+            "id": 125,
+            "sent": 1716295310.743182,
+            "submissionUrl": "/transcriptions/125/submit/",
+            "asset": {
+                "id": 456,
+                "status": "in_progress",
+                "contributors": 1
+            },
+            "undo_available": true,
+            "redo_available": false
+        }
+        ```
+    """
     asset = get_object_or_404(Asset, pk=asset_pk)
     logger.info("Saving transcription for %s (%s)", asset, asset.id)
 
@@ -413,8 +604,6 @@ def save_transcription(request, *, asset_pk):
     else:
         user = request.user
 
-    # Check whether this transcription text contains any URLs
-    # If so, ask the user to correct the transcription by removing the URLs
     transcription_text = request.POST["text"]
     url_match = re.search(URL_REGEX, transcription_text)
     if url_match:
@@ -467,7 +656,54 @@ def save_transcription(request, *, asset_pk):
 
 @require_POST
 @validate_anonymous_user
-def submit_transcription(request, *, pk):
+def submit_transcription(request: HttpRequest, *, pk: Union[int, str]) -> JsonResponse:
+    """
+    Submit a transcription for review.
+
+    Marks the transcription as submitted and clears any rejection state.
+    Prevents submission if the transcription has already been accepted or
+    superseded.
+
+    Anonymous users are supported and handled via `get_anonymous_user()`. The caller
+    must be validated via `validate_anonymous_user`.
+
+    Args:
+        request (HttpRequest): The POST request to submit the transcription.
+        pk (int or str): The primary key of the transcription to submit.
+
+    Returns:
+        response (JsonResponse): A dictionary with the asset status and submission
+            metadata, or an error response if submission is not allowed.
+
+    Response Format - Success:
+        - `id` (int): ID of the submitted transcription.
+        - `sent` (float): UNIX timestamp of the response.
+        - `asset` (dict):
+            - `id` (int): ID of the associated asset.
+            - `status` (str): Current transcription status.
+            - `contributors` (int): Number of users who contributed.
+        - `undo_available` (bool): Always `false` after submission.
+        - `redo_available` (bool): Always `false` after submission.
+
+    Response Format - Error:
+        - `error` (str): Explanation of the submission failure.
+            - "This transcription has already been updated."
+
+    Example:
+        ```json
+        {
+            "id": 126,
+            "sent": 1716295421.019122,
+            "asset": {
+                "id": 456,
+                "status": "submitted",
+                "contributors": 1
+            },
+            "undo_available": false,
+            "redo_available": false
+        }
+        ```
+    """
     transcription = get_object_or_404(Transcription, pk=pk)
     asset = transcription.asset
 
@@ -521,7 +757,50 @@ def submit_transcription(request, *, pk):
 @require_POST
 @login_required
 @never_cache
-def review_transcription(request, *, pk):
+def review_transcription(request: HttpRequest, *, pk: Union[int, str]) -> JsonResponse:
+    """
+    Review and accept or reject a submitted transcription.
+
+    Only non-authors may accept a transcription. Users are limited by a
+    rate limit when accepting transcriptions. Review actions are rejected
+    if the transcription has already been reviewed or is invalid.
+
+    Args:
+        request (HttpRequest): The POST request containing the review action.
+        pk (int or str): The primary key of the transcription to review.
+
+    Returns:
+        response (JsonResponse): A dictionary with updated asset status and
+            metadata, or an error response if the review fails.
+
+    Response Format - Success:
+        - `id` (int): ID of the reviewed transcription.
+        - `sent` (float): UNIX timestamp of the response.
+        - `asset` (dict):
+            - `id` (int): ID of the associated asset.
+            - `status` (str): Updated transcription status.
+            - `contributors` (int): Number of users who contributed.
+
+    Response Format - Error:
+        - `error` (str): Explanation of the review failure.
+            - "Invalid action"
+            - "This transcription has already been reviewed"
+            - "You cannot accept your own transcription"
+            - Configuration-based rate limit messages
+
+    Example:
+        ```json
+        {
+            "id": 127,
+            "sent": 1716295502.642184,
+            "asset": {
+                "id": 456,
+                "status": "completed",
+                "contributors": 2
+            }
+        }
+        ```
+    """
     action = request.POST.get("action")
 
     if action not in ("accept", "reject"):
@@ -592,7 +871,36 @@ def review_transcription(request, *, pk):
 @require_POST
 @login_required
 @atomic
-def submit_tags(request, *, asset_pk):
+def submit_tags(request: HttpRequest, *, asset_pk: Union[int, str]) -> JsonResponse:
+    """
+    Submit a new set of tags for an asset from the current user.
+
+    Creates any new tags as needed and updates the user's tag collection
+    for the asset. Removes tags that are no longer present in the submission.
+
+    Args:
+        request (HttpRequest): The POST request containing tag values.
+        asset_pk (int or str): The primary key of the asset to tag.
+
+    Returns:
+        response (JsonResponse): A dictionary containing the updated user-specific
+            and global tag lists for the asset.
+
+    Response Format - Success:
+        - `user_tags` (list[str]): Tags currently assigned to the asset by this user.
+        - `all_tags` (list[str]): All tags currently applied to the asset by any user.
+
+    Response Format - Error:
+        - `error` (list[str]): Validation error messages for malformed/duplicate tags.
+
+    Example:
+        ```json
+        {
+            "user_tags": ["map", "handwritten"],
+            "all_tags": ["handwritten", "map", "note"]
+        }
+        ```
+    """
     asset = get_object_or_404(Asset, pk=asset_pk)
 
     user_tags, created = UserAssetTagCollection.objects.get_or_create(
@@ -611,12 +919,7 @@ def submit_tags(request, *, asset_pk):
 
     Tag.objects.bulk_create(new_tags)
 
-    # At this point we now have Tag objects for everything in the POSTed
-    # request. We'll add anything which wasn't previously in this user's tag
-    # collection and remove anything which is no longer present.
-
     all_submitted_tags = list(existing_tags) + new_tags
-
     existing_user_tags = user_tags.tags.all()
 
     for tag in all_submitted_tags:
@@ -631,7 +934,6 @@ def submit_tags(request, *, asset_pk):
                 collection.tags.remove(tag)
 
     all_tags = all_tags_qs.order_by("value")
-
     final_user_tags = user_tags.tags.order_by("value").values_list("value", flat=True)
     all_tags = all_tags.values_list("value", flat=True).distinct()
 
@@ -645,19 +947,42 @@ def submit_tags(request, *, asset_pk):
 )
 @require_POST
 @never_cache
-def reserve_asset(request, *, asset_pk):
+def reserve_asset(request: HttpRequest, *, asset_pk: Union[int, str]) -> JsonResponse:
     """
-    Receives an asset PK and attempts to create/update a reservation for it
+    Attempt to reserve an asset for transcription by the current session.
 
-    Returns JSON message with reservation token on success
+    If no active reservation exists, creates a new one using the session's
+    reservation token. If a reservation exists for this session, updates it.
+    If the asset is reserved by another session, returns a conflict response.
+    Handles reservation release if `release` is set in the POST body.
 
-    Returns HTTP 409 when the record is in use
+    Args:
+        request (HttpRequest): The POST request to reserve or release the asset.
+        asset_pk (int or str): The primary key of the asset to reserve.
+
+    Returns:
+        response (JsonResponse or HttpResponse): A dictionary indicating the
+            reservation status and token, or an HTTP 408/409 response for timeout
+            or conflict.
+
+    Response Format - Success:
+        - `asset_pk` (int): The ID of the reserved asset.
+        - `reservation_token` (str): A unique identifier for the reservation session.
+
+    Response Format - Error:
+        - `408 Request Timeout`: The current session's reservation is tombstoned.
+        - `409 Conflict`: The asset is actively reserved by another session.
+
+    Example:
+        ```json
+        {
+            "asset_pk": 789,
+            "reservation_token": "abc123xyz"
+        }
+        ```
     """
-
     reservation_token = get_or_create_reservation_token(request)
 
-    # If the browser is letting us know of a specific reservation release,
-    # let it go even if it's within the grace period.
     if request.POST.get("release"):
         with connection.cursor() as cursor:
             cursor.execute(
@@ -668,21 +993,15 @@ def reserve_asset(request, *, asset_pk):
                 [asset_pk, reservation_token],
             )
 
-        # We'll pass the message to the WebSocket listeners before returning it:
         msg = {"asset_pk": asset_pk, "reservation_token": reservation_token}
         logger.info("Releasing reservation with token %s", reservation_token)
         reservation_released.send(sender="reserve_asset", **msg)
         return JsonResponse(msg)
 
-    # We're relying on the database to meet our integrity requirements and since
-    # this is called periodically we want to be fairly fast until we switch to
-    # something like Redis.
-
     reservations = AssetTranscriptionReservation.objects.filter(
         asset_id__exact=asset_pk
     )
 
-    # Default: pretend there is no activity on the asset
     is_it_already_mine = False
     am_i_tombstoned = False
     is_someone_else_tombstoned = False
@@ -713,13 +1032,12 @@ def reserve_asset(request, *, asset_pk):
                     )
 
         if am_i_tombstoned:
-            return HttpResponse(status=408)  # Request Timed Out
+            return HttpResponse(status=408)
 
         if is_someone_else_active:
-            return HttpResponse(status=409)  # Conflict
+            return HttpResponse(status=409)
 
         if is_it_already_mine:
-            # This user already has the reservation and it's not tombstoned
             msg = update_reservation(asset_pk, reservation_token)
             logger.debug("Updating reservation %s", reservation_token)
 
@@ -730,14 +1048,40 @@ def reserve_asset(request, *, asset_pk):
             )
 
     else:
-        # No reservations = no activity = go ahead and do an insert
         msg = obtain_reservation(asset_pk, reservation_token)
         logger.debug("No activity, just get the reservation %s", reservation_token)
 
     return JsonResponse(msg)
 
 
-def update_reservation(asset_pk, reservation_token):
+def update_reservation(
+    asset_pk: Union[int, str], reservation_token: str
+) -> dict[str, Union[int, str]]:
+    """
+    Update the timestamp on an existing active reservation for an asset.
+
+    Refreshes the reservation's `updated_on` field to extend its validity
+    and emits the `reservation_obtained` signal.
+
+    Args:
+        asset_pk (int or str): The primary key of the reserved asset.
+        reservation_token (str): The session's reservation token.
+
+    Returns:
+        response (dict): A dictionary confirming the updated reservation state.
+
+    Response Format - Success:
+        - `asset_pk` (int): The ID of the reserved asset.
+        - `reservation_token` (str): The reservation token used by the session.
+
+    Example:
+        ```json
+        {
+            "asset_pk": 789,
+            "reservation_token": "abc123xyz"
+        }
+        ```
+    """
     with connection.cursor() as cursor:
         cursor.execute(
             """
@@ -751,13 +1095,39 @@ def update_reservation(asset_pk, reservation_token):
         """.strip(),
             [asset_pk, reservation_token],
         )
-    # We'll pass the message to the WebSocket listeners before returning it:
     msg = {"asset_pk": asset_pk, "reservation_token": reservation_token}
     reservation_obtained.send(sender="reserve_asset", **msg)
     return msg
 
 
-def obtain_reservation(asset_pk, reservation_token):
+def obtain_reservation(
+    asset_pk: Union[int, str], reservation_token: str
+) -> dict[str, Union[int, str]]:
+    """
+    Create a new reservation entry for an asset.
+
+    Inserts a new reservation row in the database for the given asset and
+    session token. Emits the `reservation_obtained` signal to notify listeners.
+
+    Args:
+        asset_pk (int or str): The primary key of the asset to reserve.
+        reservation_token (str): The session's reservation token.
+
+    Returns:
+        response (dict): A dictionary confirming the newly obtained reservation.
+
+    Response Format - Success:
+        - `asset_pk` (int): The ID of the reserved asset.
+        - `reservation_token` (str): The reservation token used by the session.
+
+    Example:
+        ```json
+        {
+            "asset_pk": 789,
+            "reservation_token": "abc123xyz"
+        }
+        ```
+    """
     with connection.cursor() as cursor:
         cursor.execute(
             """
@@ -769,7 +1139,6 @@ def obtain_reservation(asset_pk, reservation_token):
         """.strip(),
             [asset_pk, reservation_token],
         )
-    # We'll pass the message to the WebSocket listeners before returning it:
     msg = {"asset_pk": asset_pk, "reservation_token": reservation_token}
     reservation_obtained.send(sender="reserve_asset", **msg)
     return msg


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-1185

As part of this, I tested libraries to generate the documentation, and found that Sphinx, which I was planning on using, required too much in the way of essentially boilerplate documentation files that have to be constantly manually updated to really be usable (I also hate how rst formats links).

I pivoted to using mkdocs instead, which avoids having to create a lot of boilerplate or maintain it after creating it--it creates the structure of the files based on the code, including things like tables of contents, which are impossible (as far as I can tell) with Sphinx without you manually adding sections for each class, function, method, etc., meaning you'd need to update two places when you add something new. Also mkdocs uses Markdown, which is preferable to rst in anycase.

I've gone back and reformatted all the existing docstrings (accounts.py and the rollback methods on models.Asset) to use this new format.