### PR TITLE
Added a logging wrapper class and added logging to the utils.next_asset code

### DIFF
--- a/concordia/logging.py
+++ b/concordia/logging.py
@@ -1,0 +1,267 @@
+from typing import Any, Optional
+
+import structlog
+
+from concordia.utils.logging import get_logging_user_id
+
+
+class ConcordiaLogger:
+    """
+    A structured logging wrapper around structlog that enforces consistent logging
+    conventions across the Concordia application.
+
+    Features:
+        - Requires 'event' for all logs, and 'reason'/'reason_code' for warnings/errors.
+        - Automatically extracts common context from objects like Asset, User
+            and Transcription.
+        - Allows semantic binding of objects (e.g., asset=self) which are expanded
+            at log time.
+        - Supports binding persistent fields via structlog's context mechanism.
+
+    Usage:
+    -----
+
+    Create a logger:
+        ```python
+        structured_logger = ConcordiaLogger.get_logger(f"{__name__}")
+        ```
+
+
+    Log an info-level event:
+        ```python
+        structured_logger.info(
+            "Started OCR processing.",
+            event="asset_ocr_started",
+            asset=my_asset,
+            user=request.user,
+        )
+        ```
+
+    Log a warning with reason:
+        ```python
+        structured_logger.warning(
+            "Rollback failed.",
+            event="rollback_attempt_failed",
+            reason="No eligible transcription found.",
+            reason_code="no_valid_target",
+            asset=my_asset,
+            user=request.user,
+        )
+        ```
+
+    Bind a logger for repeated use:
+        ```python
+        logger = ConcordiaLogger.get_logger(f"{__name__}")
+        my_logger = logger.bind(asset=asset)
+        my_logger.info("Transcription updated.", event="transcription_updated")
+        ```
+
+        This is the equivalent of:
+        ```python
+        logger = ConcordiaLogger.get_logger(f"{__name__}")
+        logger.info(
+            "Transcription updated.",
+            event="transcription_updated",
+            asset=asset
+        )
+        ```
+
+        This can save you from having to repeatedly pass in the same data to every
+        logging call. For instance, if you bind a logger to a particular model
+        instance like `.bind(asset=self)`, that bound logger will automatically
+        include the instance as context for all the logging statements done by it.
+
+    Special Context Expansion:
+    --------------------------
+
+    The logger recognizes certain context object names and extracts fields from them
+    automatically. These include:
+
+    - `user` → `user_id`
+    - `asset` → `asset_id`, `campaign_slug`, `item_id`
+    - `transcription` → `transcription_id`
+    - `campaign` → `campaign_slug`
+    - `item` → `item_id`
+
+    If these objects are passed directly (e.g., as `user=request.user`), their relevant
+    fields will be included automatically in the log entry.
+
+    Explicit values passed (e.g., `item_id=...`) override extracted ones. Fields with
+    `None` values are omitted from the final log output.
+    """
+
+    def __init__(self, logger, context: Optional[dict[str, Any]] = None):
+        """
+        Initialize the ConcordiaLogger with an underlying structlog logger.
+
+        Args:
+            logger (structlog.BoundLogger): A structlog logger instance.
+        """
+        self._logger = logger
+        self._context = context or {}
+
+    @classmethod
+    def get_logger(cls, name: str) -> "ConcordiaLogger":
+        """
+        Factory method to create a ConcordiaLogger from a given logger name.
+
+        Args:
+            name (str): The logger name (typically f"structlog.{__name__}").
+
+        Returns:
+            ConcordiaLogger: A logger instance with enriched behavior.
+        """
+        return cls(structlog.get_logger(f"structlog.{__name__}"))
+
+    def log(
+        self,
+        level: str,
+        message: str,
+        *,
+        event: str,
+        reason: Optional[str] = None,
+        reason_code: Optional[str] = None,
+        **context: Any,
+    ) -> None:
+        """
+        Emit structured logs with standardized context.
+
+        Args:
+            level (str): Logging level ('debug', 'info', 'warning', 'error').
+            message (str): Human-readable log message.
+            event (str): Required short machine-readable identifier.
+            reason (str, optional): Human-readable reason for failure (required for
+                warnings/errors).
+            reason_code (str, optional): Short identifier for reason (required for
+                warnings/errors).
+            context (Any): Additional structured context for the log. See the
+                **Special Context Handling** section below for recognized keys.
+
+                - `user` (User): Extracts `user_id` using `get_logging_user_id()`.
+                - `asset` (Asset): Extracts `asset_id`, `campaign_slug`, and `item_id`.
+                - `transcription` (Transcription): Extracts `transcription_id`.
+                - `campaign` (Campaign): Extracts `campaign_slug`.
+                - `item` (Item): Extracts `item_id`.
+
+                Any other key-value pairs are included as-is, unless their value is
+                `None`, in which case they are omitted.
+
+        Raises:
+            ValueError: If required fields are missing for the given log level.
+        """
+        if not message:
+            raise ValueError("Log message is required.")
+        if not event:
+            raise ValueError("Structured logs must include an 'event' field.")
+        if level in ("warning", "error") and (not reason or not reason_code):
+            raise ValueError(
+                "Warnings and errors must include both 'reason' and 'reason_code'."
+            )
+
+        ctx = {"event": event}
+        if reason:
+            ctx["reason"] = reason
+        if reason_code:
+            ctx["reason_code"] = reason_code
+
+        bound = self._context
+
+        # Extract known context objects
+        user = context.pop("user", bound.get("user"))
+        asset = context.pop("asset", bound.get("asset"))
+        transcription = context.pop("transcription", bound.get("transcription"))
+        campaign = context.pop("campaign", bound.get("campaign"))
+        item = context.pop("item", bound.get("item"))
+
+        if user:
+            user_id = get_logging_user_id(user)
+            if user_id is not None:
+                ctx["user_id"] = user_id
+
+        if asset:
+            asset_id = getattr(asset, "pk", None)
+            campaign_slug = getattr(getattr(asset, "campaign", None), "slug", None)
+            item_id = getattr(getattr(asset, "item", None), "item_id", None)
+
+            if asset_id is not None:
+                ctx["asset_id"] = asset_id
+            if campaign_slug is not None:
+                ctx["campaign_slug"] = campaign_slug
+            if item_id is not None:
+                ctx["item_id"] = item_id
+
+        if transcription:
+            transcription_id = getattr(transcription, "pk", None)
+            if transcription_id is not None:
+                ctx["transcription_id"] = transcription_id
+
+        if campaign:
+            slug = getattr(campaign, "slug", None)
+            if slug is not None:
+                ctx["campaign_slug"] = slug
+
+        if item:
+            item_id = getattr(item, "item_id", None)
+            if item_id is not None:
+                ctx["item_id"] = item_id
+
+        # Add remaining values in context (which may include user-defined fields)
+        for key, value in context.items():
+            if value is not None:
+                ctx[key] = value
+
+        getattr(self._logger, level)(message, **ctx)
+
+    def debug(self, message: str, *, event: str, **kwargs):
+        """Emit a debug-level structured log."""
+        self.log("debug", message, event=event, **kwargs)
+
+    def info(self, message: str, *, event: str, **kwargs):
+        """Emit an info-level structured log."""
+        self.log("info", message, event=event, **kwargs)
+
+    def warning(
+        self, message: str, *, event: str, reason: str, reason_code: str, **kwargs
+    ):
+        """Emit a warning-level structured log. Requires reason and reason_code."""
+        self.log(
+            "warning",
+            message,
+            event=event,
+            reason=reason,
+            reason_code=reason_code,
+            **kwargs,
+        )
+
+    def error(
+        self, message: str, *, event: str, reason: str, reason_code: str, **kwargs
+    ):
+        """Emit an error-level structured log. Requires reason and reason_code."""
+        self.log(
+            "error",
+            message,
+            event=event,
+            reason=reason,
+            reason_code=reason_code,
+            **kwargs,
+        )
+
+    def bind(self, **kwargs: Any) -> "ConcordiaLogger":
+        """
+        Return a new ConcordiaLogger with additional context permanently bound.
+
+        Bound context can include semantic objects like asset, user, or transcription.
+        These will be expanded into structured fields at log time.
+
+        Args:
+            **kwargs: Context to bind.
+
+        Returns:
+            ConcordiaLogger: A logger with the provided context bound.
+        """
+
+        # We make our own bound context rather than using structlog's
+        # .bind so we can safely access it
+        new_context = self._context.copy()
+        new_context.update(kwargs)
+        return ConcordiaLogger(self._logger, context=new_context)

--- a/concordia/logging.py
+++ b/concordia/logging.py
@@ -1,5 +1,4 @@
 import warnings
-from copy import deepcopy
 from types import MappingProxyType
 from typing import Any, Callable, Optional
 
@@ -191,7 +190,7 @@ class ConcordiaLogger:
     def __init__(self, logger, context: Optional[dict[str, Any]] = None):
         self._logger = logger
         self._context = context or {}
-        self._extractors = deepcopy(_DEFAULT_EXTRACTORS)
+        self._extractors = _DEFAULT_EXTRACTORS.copy()
 
     @classmethod
     def get_logger(cls, name: str) -> "ConcordiaLogger":
@@ -217,14 +216,11 @@ class ConcordiaLogger:
             extractor (Callable): A function that returns a dict of fields to log.
         """
         self._extractors[key] = extractor
-        if any(
-            key in extractor.__code__.co_names
-            for extractor in _DEFAULT_EXTRACTORS.values()
-            if callable(extractor)
-        ):
+        if key in _DEFAULT_EXTRACTORS:
             warnings.warn(
-                f"Extractor for '{key}' registered but will not override chained "
-                f"extractor behavior, which uses global defaults.",
+                f"Extractor for '{key}' registered but default extractors may still "
+                f"reference the original implementation via chaining. Overriding it "
+                f"here will not affect those chained uses.",
                 UserWarning,
                 stacklevel=2,
             )

--- a/concordia/logging.py
+++ b/concordia/logging.py
@@ -69,7 +69,8 @@ class ConcordiaLogger:
     conventions across the Concordia application.
 
     Features:
-        - Requires 'event' for all logs, and 'reason'/'reason_code' for warnings/errors.
+        - Requires 'message' and 'event_code' for all logs, and 'reason'/'reason_code'
+          for warnings/errors.
         - Automatically extracts common context from objects like Asset, User
           and Transcription.
         - Allows semantic binding of objects (e.g., asset=self) which are expanded
@@ -88,7 +89,7 @@ class ConcordiaLogger:
         ```python
         structured_logger.info(
             "Started OCR processing.",
-            event="asset_ocr_started",
+            event_code="asset_ocr_started",
             asset=my_asset,
             user=request.user,
         )
@@ -98,7 +99,7 @@ class ConcordiaLogger:
         ```python
         structured_logger.warning(
             "Rollback failed.",
-            event="rollback_attempt_failed",
+            event_code="rollback_attempt_failed",
             reason="No eligible transcription found.",
             reason_code="no_valid_target",
             asset=my_asset,
@@ -110,7 +111,7 @@ class ConcordiaLogger:
         ```python
         logger = ConcordiaLogger.get_logger(f"{__name__}")
         my_logger = logger.bind(asset=asset)
-        my_logger.info("Transcription updated.", event="transcription_updated")
+        my_logger.info("Transcription updated.", event_code="transcription_updated")
         ```
 
         This is the equivalent of:
@@ -118,7 +119,7 @@ class ConcordiaLogger:
         logger = ConcordiaLogger.get_logger(f"{__name__}")
         logger.info(
             "Transcription updated.",
-            event="transcription_updated",
+            event_code="transcription_updated",
             asset=asset
         )
         ```

--- a/concordia/logging.py
+++ b/concordia/logging.py
@@ -185,7 +185,7 @@ class ConcordiaLogger:
         use the default global extractors. If you override an extractor on a logger,
         chained calls will not reflect that override. So, if you override the "asset"
         extractor, if you pass in "transcription", that extractor will use the default
-        `asset` extractor, rather than you're newly registered one.
+        `asset` extractor, rather than your newly registered one.
     """
 
     def __init__(self, logger, context: Optional[dict[str, Any]] = None):

--- a/concordia/logging.py
+++ b/concordia/logging.py
@@ -239,7 +239,7 @@ class ConcordiaLogger:
         level: str,
         message: str,
         *,
-        event: str,
+        event_code: str,
         reason: Optional[str] = None,
         reason_code: Optional[str] = None,
         **context: Any,
@@ -252,7 +252,7 @@ class ConcordiaLogger:
         Args:
             level (str): Logging level ('debug', 'info', 'warning', 'error').
             message (str): Human-readable log message.
-            event (str): Required short machine-readable identifier.
+            event_code (str): Required short machine-readable identifier.
             reason (str, optional): Human-readable reason for failure (required for
                 warnings/errors).
             reason_code (str, optional): Short identifier for reason (required for
@@ -264,14 +264,14 @@ class ConcordiaLogger:
         """
         if not message:
             raise ValueError("Log message is required.")
-        if not event:
-            raise ValueError("Structured logs must include an 'event' field.")
+        if not event_code:
+            raise ValueError("Structured logs must include an 'event_code' field.")
         if level in ("warning", "error") and (not reason or not reason_code):
             raise ValueError(
                 "Warnings and errors must include both 'reason' and 'reason_code'."
             )
 
-        context_data = {"event": event}
+        context_data = {"event_code": event_code}
         if reason:
             context_data["reason"] = reason
         if reason_code:
@@ -306,35 +306,35 @@ class ConcordiaLogger:
 
         getattr(self._logger, level)(message, **context_data)
 
-    def debug(self, message: str, *, event: str, **kwargs):
+    def debug(self, message: str, *, event_code: str, **kwargs):
         """Emit a debug-level structured log."""
-        self.log("debug", message, event=event, **kwargs)
+        self.log("debug", message, event_code=event_code, **kwargs)
 
-    def info(self, message: str, *, event: str, **kwargs):
+    def info(self, message: str, *, event_code: str, **kwargs):
         """Emit an info-level structured log."""
-        self.log("info", message, event=event, **kwargs)
+        self.log("info", message, event_code=event_code, **kwargs)
 
     def warning(
-        self, message: str, *, event: str, reason: str, reason_code: str, **kwargs
+        self, message: str, *, event_code: str, reason: str, reason_code: str, **kwargs
     ):
         """Emit a warning-level structured log. Requires reason and reason_code."""
         self.log(
             "warning",
             message,
-            event=event,
+            event_code=event_code,
             reason=reason,
             reason_code=reason_code,
             **kwargs,
         )
 
     def error(
-        self, message: str, *, event: str, reason: str, reason_code: str, **kwargs
+        self, message: str, *, event_code: str, reason: str, reason_code: str, **kwargs
     ):
         """Emit an error-level structured log. Requires reason and reason_code."""
         self.log(
             "error",
             message,
-            event=event,
+            event_code=event_code,
             reason=reason,
             reason_code=reason_code,
             **kwargs,

--- a/concordia/tests/test_logging.py
+++ b/concordia/tests/test_logging.py
@@ -1,0 +1,190 @@
+import warnings
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from concordia.logging import ConcordiaLogger
+
+
+class ConcordiaLoggerTests(TestCase):
+    def setUp(self):
+        self.mock_structlog_logger = MagicMock()
+        self.logger = ConcordiaLogger(self.mock_structlog_logger)
+
+    def test_debug_logs_with_event(self):
+        self.logger.debug("debug msg", event="debug_event", key1="value1")
+        self.mock_structlog_logger.debug.assert_called_once()
+        args, kwargs = self.mock_structlog_logger.debug.call_args
+        self.assertEqual(args[0], "debug msg")
+        self.assertEqual(kwargs["event"], "debug_event")
+        self.assertEqual(kwargs["key1"], "value1")
+
+    def test_info_logs_with_event(self):
+        self.logger.info("info msg", event="info_event", key2="value2")
+        self.mock_structlog_logger.info.assert_called_once()
+        args, kwargs = self.mock_structlog_logger.info.call_args
+        self.assertEqual(args[0], "info msg")
+        self.assertEqual(kwargs["event"], "info_event")
+        self.assertEqual(kwargs["key2"], "value2")
+
+    def test_warning_requires_reason_and_reason_code(self):
+        with self.assertRaises(TypeError):
+            self.logger.warning("warning msg", event="warn_event", reason="only_reason")
+
+        self.logger.warning(
+            "warning msg",
+            event="warn_event",
+            reason="test reason",
+            reason_code="warn_code",
+            key3="value3",
+        )
+        self.mock_structlog_logger.warning.assert_called_once()
+        args, kwargs = self.mock_structlog_logger.warning.call_args
+        self.assertEqual(kwargs["event"], "warn_event")
+        self.assertEqual(kwargs["reason"], "test reason")
+        self.assertEqual(kwargs["reason_code"], "warn_code")
+        self.assertEqual(kwargs["key3"], "value3")
+
+    def test_error_requires_reason_and_reason_code(self):
+        with self.assertRaises(TypeError):
+            self.logger.error("error msg", event="error_event", reason_code="only_code")
+
+        self.logger.error(
+            "error msg",
+            event="error_event",
+            reason="error reason",
+            reason_code="error_code",
+        )
+        self.mock_structlog_logger.error.assert_called_once()
+        args, kwargs = self.mock_structlog_logger.error.call_args
+        self.assertEqual(kwargs["event"], "error_event")
+        self.assertEqual(kwargs["reason"], "error reason")
+        self.assertEqual(kwargs["reason_code"], "error_code")
+
+    def test_missing_event_raises(self):
+        with self.assertRaises(ValueError):
+            self.logger.info("msg", event=None)
+
+    def test_log_merges_context_correctly(self):
+        mock_obj = SimpleNamespace(id=42)
+        self.logger.register_extractor("thing", lambda o: {"thing_id": o.id})
+        self.logger.info("msg", event="test_event", thing=mock_obj)
+        args, kwargs = self.mock_structlog_logger.info.call_args
+        self.assertEqual(kwargs["thing_id"], 42)
+
+    def test_log_explicit_key_overrides_extracted(self):
+        mock_obj = SimpleNamespace(id=42)
+        self.logger.register_extractor("thing", lambda o: {"thing_id": 123})
+        self.logger.info("msg", event="test_event", thing=mock_obj, thing_id=999)
+        args, kwargs = self.mock_structlog_logger.info.call_args
+        self.assertEqual(kwargs["thing_id"], 999)
+
+    def test_bind_merges_context(self):
+        bound = self.logger.bind(foo="bar")
+        self.assertIsInstance(bound, ConcordiaLogger)
+        self.assertIn("foo", bound._context)
+        self.assertEqual(bound._context["foo"], "bar")
+
+    def test_bind_merges_context_into_logging(self):
+        bound = self.logger.bind(user="uval")
+        bound.register_extractor("user", lambda o: {"user_id": o})
+        bound.info("msg", event="bound_event")
+        args, kwargs = self.mock_structlog_logger.info.call_args
+        self.assertEqual(kwargs["user_id"], "uval")
+
+    def test_unregister_extractor_removes_extractor(self):
+        self.logger.register_extractor("foo", lambda o: {"foo_id": 1})
+        self.logger.unregister_extractor("foo")
+        self.assertNotIn("foo", self.logger._extractors)
+
+    def test_register_extractor_warns_on_chained_override(self):
+        def fake_asset_extractor(x):
+            return {"asset_id": 1, "item_id": 2}
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.logger.register_extractor("asset", fake_asset_extractor)
+            self.assertTrue(
+                any(
+                    "default extractors may still reference" in str(warn.message)
+                    for warn in w
+                )
+            )
+
+    def test_log_raises_when_message_is_none(self):
+        with self.assertRaises(ValueError):
+            self.logger.info(None, event="event")
+
+    def test_log_raises_when_message_is_none_direct(self):
+        with self.assertRaises(ValueError):
+            self.logger.log("info", None, event="event")
+
+    def test_log_raises_when_message_is_empty(self):
+        with self.assertRaises(ValueError):
+            self.logger.info("", event="event")
+
+    def test_log_raises_when_message_is_empty_direct(self):
+        with self.assertRaises(ValueError):
+            self.logger.log("info", "", event="event")
+
+    def test_log_skips_none_values_from_extractor(self):
+        class Dummy:
+            def __init__(self):
+                self.id = None
+
+        self.logger.register_extractor("thing", lambda o: {"thing_id": o.id})
+        self.logger.info("msg", event="event", thing=Dummy())
+        args, kwargs = self.mock_structlog_logger.info.call_args
+        self.assertNotIn("thing_id", kwargs)
+
+    def test_log_includes_nonextractor_bound_context(self):
+        bound = self.logger.bind(extra1="foo", extra2="bar")
+        bound.info("msg", event="event")
+        args, kwargs = self.mock_structlog_logger.info.call_args
+        self.assertEqual(kwargs["extra1"], "foo")
+        self.assertEqual(kwargs["extra2"], "bar")
+
+    def test_log_skips_none_values_in_context(self):
+        self.logger.info("msg", event="event", explicit=None)
+        args, kwargs = self.mock_structlog_logger.info.call_args
+        self.assertNotIn("explicit", kwargs)
+
+    def test_log_overrides_bound_and_extracted_context(self):
+        obj = SimpleNamespace(id=123)
+        base = self.logger.bind(thing=obj, value="a")
+        base.register_extractor("thing", lambda o: {"thing_id": o.id, "value": "b"})
+        base.info("msg", event="event", value="c")
+        args, kwargs = self.mock_structlog_logger.info.call_args
+        # Extracted value ("b") overridden by explicit context ("c")
+        self.assertEqual(kwargs["value"], "c")
+        self.assertEqual(kwargs["thing_id"], 123)
+
+    def test_extractor_returns_none_value_skipped(self):
+        obj = SimpleNamespace()
+        self.logger.register_extractor("thing", lambda o: {"thing_id": None})
+        self.logger.info("msg", event="event", thing=obj)
+        args, kwargs = self.mock_structlog_logger.info.call_args
+        self.assertNotIn("thing_id", kwargs)
+
+    def test_get_logger_uses_structlog(self):
+        with patch("concordia.logging.structlog.get_logger") as mock_get_logger:
+            mock_logger_instance = MagicMock()
+            mock_get_logger.return_value = mock_logger_instance
+
+            logger = ConcordiaLogger.get_logger("concordia.tests")
+
+            mock_get_logger.assert_called_once_with("structlog.concordia.tests")
+            self.assertIsInstance(logger, ConcordiaLogger)
+            self.assertEqual(logger._logger, mock_logger_instance)
+
+    def test_log_raises_valueerror_for_empty_reason_and_code(self):
+        with self.assertRaises(ValueError):
+            self.logger.log(
+                "warning", "bad", event="something", reason="", reason_code="fail"
+            )
+
+        with self.assertRaises(ValueError):
+            self.logger.log(
+                "error", "bad", event="something", reason="fail", reason_code=None
+            )

--- a/concordia/tests/test_utils.py
+++ b/concordia/tests/test_utils.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
@@ -432,7 +433,7 @@ class NextTranscribableTopicAssetTests(CreateTestUsers, TestCase):
 class LoggingTests(CreateTestUsers, TestCase):
     def test_get_logging_user_id_authenticated_user(self):
         user = self.create_test_user()
-        self.assertEqual(get_logging_user_id(user), user.id)
+        self.assertEqual(get_logging_user_id(user), str(user.id))
 
     def test_get_logging_user_id_anonymous_user(self):
         anon = get_anonymous_user()
@@ -443,3 +444,8 @@ class LoggingTests(CreateTestUsers, TestCase):
         mock_user = object()
         # Should fallback to "anonymous" since getattr will not find .is_authenticated
         self.assertEqual(get_logging_user_id(mock_user), "anonymous")
+
+    def test_get_logging_user_id_authenticated_no_id(self):
+        user = SimpleNamespace(is_authenticated=True, username="someuser")
+        # Intentionally omit 'id' to trigger the final check
+        self.assertEqual(get_logging_user_id(user), "anonymous")

--- a/concordia/tests/test_utils.py
+++ b/concordia/tests/test_utils.py
@@ -429,7 +429,7 @@ class NextTranscribableTopicAssetTests(CreateTestUsers, TestCase):
         self.assertFalse(mock_task.delay.called)
 
 
-class LoggingsTest(CreateTestUsers, TestCase):
+class LoggingTests(CreateTestUsers, TestCase):
     def test_get_logging_user_id_authenticated_user(self):
         user = self.create_test_user()
         self.assertEqual(get_logging_user_id(user), user.id)

--- a/concordia/tests/test_utils.py
+++ b/concordia/tests/test_utils.py
@@ -11,6 +11,7 @@ from concordia.models import (
     TranscriptionStatus,
 )
 from concordia.utils import get_anonymous_user
+from concordia.utils.logging import get_logging_user_id
 from concordia.utils.next_asset import (
     find_new_reviewable_campaign_assets,
     find_new_reviewable_topic_assets,
@@ -426,3 +427,19 @@ class NextTranscribableTopicAssetTests(CreateTestUsers, TestCase):
         self.assertEqual(asset, self.asset2)
         self.assertFalse(mock_get_task.called)
         self.assertFalse(mock_task.delay.called)
+
+
+class LoggingsTest(CreateTestUsers, TestCase):
+    def test_get_logging_user_id_authenticated_user(self):
+        user = self.create_test_user()
+        self.assertEqual(get_logging_user_id(user), user.id)
+
+    def test_get_logging_user_id_anonymous_user(self):
+        anon = get_anonymous_user()
+        self.assertEqual(get_logging_user_id(anon), "anonymous")
+
+    def test_get_logging_user_id_missing_auth_attribute(self):
+        # Simulate a user-like object with no is_authenticated attribute
+        mock_user = object()
+        # Should fallback to "anonymous" since getattr will not find .is_authenticated
+        self.assertEqual(get_logging_user_id(mock_user), "anonymous")

--- a/concordia/utils/logging.py
+++ b/concordia/utils/logging.py
@@ -1,14 +1,25 @@
-from typing import Union
+from typing import Any
 
 
-def get_logging_user_id(user) -> Union[int, str]:
+def get_logging_user_id(user: Any) -> str:
     """
     Return a consistent identifier for logging purposes.
 
     Args:
-        user (User): A Django user object (possibly anonymous).
+        user (Any): A Django user object (possibly anonymous).
 
     Returns:
-        Union[int, str]: User's ID or "anonymous" if unauthenticated.
+        user_id (str): User's ID or "anonymous" if unauthenticated, represents
+                         the Concordia anonymous user, or has no ID.
     """
-    return getattr(user, "id", None) if user.is_authenticated else "anonymous"
+    if not getattr(user, "is_authenticated", False):
+        return "anonymous"
+
+    if getattr(user, "username", None) == "anonymous":
+        return "anonymous"
+
+    user_id = getattr(user, "id", None)
+    if user_id is None:
+        return "anonymous"
+
+    return str(user_id)

--- a/concordia/utils/logging.py
+++ b/concordia/utils/logging.py
@@ -1,0 +1,14 @@
+from typing import Union
+
+
+def get_logging_user_id(user) -> Union[int, str]:
+    """
+    Return a consistent identifier for logging purposes.
+
+    Args:
+        user (User): A Django user object (possibly anonymous).
+
+    Returns:
+        Union[int, str]: User's ID or "anonymous" if unauthenticated.
+    """
+    return getattr(user, "id", None) if user.is_authenticated else "anonymous"

--- a/concordia/utils/next_asset/__init__.py
+++ b/concordia/utils/next_asset/__init__.py
@@ -1,3 +1,5 @@
+import structlog
+
 from concordia.models import (
     NextReviewableCampaignAsset,
     NextReviewableTopicAsset,
@@ -62,6 +64,8 @@ __all__ = [
     "find_invalid_next_transcribable_topic_assets",
 ]
 
+structured_logger = structlog.get_logger(f"structlog.{__name__}")
+
 
 def remove_next_asset_objects(asset_id):
     """
@@ -80,6 +84,10 @@ def remove_next_asset_objects(asset_id):
     Args:
         asset_id (int): The ID of the asset to remove from next-asset tables.
     """
+    structured_logger.info(
+        "remove_next_asset_objects",
+        asset_id=asset_id,
+    )
     NextTranscribableCampaignAsset.objects.filter(asset_id=asset_id).delete()
     NextTranscribableTopicAsset.objects.filter(asset_id=asset_id).delete()
     NextReviewableCampaignAsset.objects.filter(asset_id=asset_id).delete()

--- a/concordia/utils/next_asset/__init__.py
+++ b/concordia/utils/next_asset/__init__.py
@@ -1,5 +1,4 @@
-import structlog
-
+from concordia.logging import ConcordiaLogger
 from concordia.models import (
     NextReviewableCampaignAsset,
     NextReviewableTopicAsset,
@@ -64,7 +63,7 @@ __all__ = [
     "find_invalid_next_transcribable_topic_assets",
 ]
 
-structured_logger = structlog.get_logger(f"structlog.{__name__}")
+structured_logger = ConcordiaLogger.get_logger(__name__)
 
 
 def remove_next_asset_objects(asset_id):
@@ -85,7 +84,8 @@ def remove_next_asset_objects(asset_id):
         asset_id (int): The ID of the asset to remove from next-asset tables.
     """
     structured_logger.info(
-        "remove_next_asset_objects",
+        "Removing next asset objects",
+        event_code="remove_next_asset_objects",
         asset_id=asset_id,
     )
     NextTranscribableCampaignAsset.objects.filter(asset_id=asset_id).delete()

--- a/concordia/views/ajax.py
+++ b/concordia/views/ajax.py
@@ -36,6 +36,7 @@ from concordia.utils import (
     get_anonymous_user,
     get_or_create_reservation_token,
 )
+from concordia.utils.logging import get_logging_user_id
 from configuration.utils import configuration_value
 
 from .decorators import reserve_rate, validate_anonymous_user
@@ -403,23 +404,26 @@ def rollback_transcription(
     except ValueError as e:
         logger.exception("No previous transcription available for rollback", exc_info=e)
         structured_logger.warning(
-            "transcription_rollback_failed",
-            action="rollback",
-            result="error",
+            "Rollback failed: no previous transcription to revert to.",
+            event="rollback_failed",
+            reason_code="no_valid_target",
+            reason=str(e),
             asset_id=asset.pk,
-            user_id=user.id if user.is_authenticated else "anonymous",
-            error=str(e),
+            campaign_slug=asset.campaign.slug,
+            item_id=asset.item.item_id,
+            user_id=get_logging_user_id(user),
         )
         return JsonResponse(
             {"error": "No previous transcription available"}, status=400
         )
 
     structured_logger.info(
-        "transcription_rollback_success",
-        action="rollback",
-        result="success",
+        "Rollback successfully performed.",
+        event="rollback_success",
         asset_id=asset.pk,
-        user_id=user.id if user.is_authenticated else "anonymous",
+        campaign_slug=asset.campaign.slug,
+        item_id=asset.item.item_id,
+        user_id=get_logging_user_id(user),
         transcription_id=transcription.pk,
     )
 
@@ -513,21 +517,24 @@ def rollforward_transcription(
     except ValueError as e:
         logger.exception("No transcription available for rollforward", exc_info=e)
         structured_logger.warning(
-            "transcription_rollforward_failed",
-            action="rollforward",
-            result="error",
+            "Rollforward failed: no transcription available to restore.",
+            event="rollforward_failed",
+            reason_code="no_valid_target",
+            reason=str(e),
             asset_id=asset.pk,
-            user_id=user.id if user.is_authenticated else "anonymous",
-            error=str(e),
+            campaign_slug=asset.campaign.slug,
+            item_id=asset.item.item_id,
+            user_id=get_logging_user_id(user),
         )
         return JsonResponse({"error": "No transcription to restore"}, status=400)
 
     structured_logger.info(
-        "transcription_rollforward_success",
-        action="rollforward",
-        result="success",
+        "Rollforward successfully performed.",
+        event="rollforward_success",
         asset_id=asset.pk,
-        user_id=user.id if user.is_authenticated else "anonymous",
+        campaign_slug=asset.campaign.slug,
+        item_id=asset.item.item_id,
+        user_id=get_logging_user_id(user),
         transcription_id=transcription.pk,
     )
 

--- a/concordia/views/ajax.py
+++ b/concordia/views/ajax.py
@@ -405,7 +405,7 @@ def rollback_transcription(
         logger.exception("No previous transcription available for rollback", exc_info=e)
         structured_logger.warning(
             "Rollback failed: no previous transcription to revert to.",
-            event="rollback_failed",
+            event_code="rollback_failed",
             reason_code="no_valid_target",
             reason=str(e),
             asset_id=asset.pk,
@@ -419,7 +419,7 @@ def rollback_transcription(
 
     structured_logger.info(
         "Rollback successfully performed.",
-        event="rollback_success",
+        event_code="rollback_success",
         asset_id=asset.pk,
         campaign_slug=asset.campaign.slug,
         item_id=asset.item.item_id,
@@ -518,7 +518,7 @@ def rollforward_transcription(
         logger.exception("No transcription available for rollforward", exc_info=e)
         structured_logger.warning(
             "Rollforward failed: no transcription available to restore.",
-            event="rollforward_failed",
+            event_code="rollforward_failed",
             reason_code="no_valid_target",
             reason=str(e),
             asset_id=asset.pk,
@@ -530,7 +530,7 @@ def rollforward_transcription(
 
     structured_logger.info(
         "Rollforward successfully performed.",
-        event="rollforward_success",
+        event_code="rollforward_success",
         asset_id=asset.pk,
         campaign_slug=asset.campaign.slug,
         item_id=asset.item.item_id,


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-1216

When I started working on this, I realized I was repeating a lot of the same code over and over again (always passing asset.pk, asset.item.item_id, asset.campaign.slug, for instance.)

To avoid that, I've written a custom logging wrapper that will take care of most of the boilerplate for us, and simplify adding structured logging. I then refactored logging I already added to use the new functionality before adding the logging to utils.next_asset.*.