### PR TITLE
CONCD-1182

### DIFF
--- a/concordia/static/js/src/base.js
+++ b/concordia/static/js/src/base.js
@@ -1,7 +1,5 @@
-/* global $ screenfull Sentry */
+/* global $ Cookies screenfull Sentry */
 /* exported displayMessage displayHtmlMessage buildErrorMessage trackUIInteraction */
-
-import Cookies from 'js-cookie';
 
 (function () {
     /*

--- a/concordia/templates/fragments/common-scripts.html
+++ b/concordia/templates/fragments/common-scripts.html
@@ -5,8 +5,5 @@
 <script src="{% static '@popperjs/core/dist/esm/popper.js' %}" type="module"></script>
 <script src="{% static 'bootstrap/dist/js/bootstrap.esm.js' %}" type="module"></script>
 <script src="{% static 'screenfull/dist/screenfull.js' %}"></script>
-<script type="module">
-  import Cookies from 'js-cookie';
-</script>
 <script src="{% static 'js/base.js' %}"></script>
 <script src="{% static 'chart.js/dist/chart.umd.js' %}"></script>

--- a/concordia/templates/fragments/common-scripts.html
+++ b/concordia/templates/fragments/common-scripts.html
@@ -1,9 +1,12 @@
 {% load static %}
 
 <script src="{% static 'jquery/dist/jquery.min.js' %}"></script>
-<script src="{% static 'js-cookie/dist/js.cookie.mjs' %}" type="module"></script>
+<script src="{% static 'js-cookie/dist/js.cookie.js' %}"></script>
 <script src="{% static '@popperjs/core/dist/esm/popper.js' %}" type="module"></script>
 <script src="{% static 'bootstrap/dist/js/bootstrap.esm.js' %}" type="module"></script>
 <script src="{% static 'screenfull/dist/screenfull.js' %}"></script>
-<script src="{% static 'js/base.js' %}" type="module"></script>
+<script type="module">
+  import Cookies from 'js-cookie';
+</script>
+<script src="{% static 'js/base.js' %}"></script>
 <script src="{% static 'chart.js/dist/chart.umd.js' %}"></script>


### PR DESCRIPTION
use the UMD version of js.cookie, until we're ready to refactor all of our javascript code to be ESM