### PR TITLE
Added validation of non-printable characters in transcription bagit export

### DIFF
--- a/concordia/admin/views.py
+++ b/concordia/admin/views.py
@@ -181,7 +181,9 @@ def project_level_export(request):
         with tempfile.TemporaryDirectory(
             prefix=export_filename_base
         ) as export_base_dir:
-            return do_bagit_export(assets, export_base_dir, export_filename_base)
+            return do_bagit_export(
+                assets, export_base_dir, export_filename_base, request
+            )
 
     if idx is not None:
         context["campaigns"] = []

--- a/concordia/templatetags/concordia_text_tags.py
+++ b/concordia/templatetags/concordia_text_tags.py
@@ -14,3 +14,12 @@ def normalize_whitespace(text):
     a single space
     """
     return WHITESPACE_NORMALIZER.sub(" ", text)
+
+
+@register.filter
+def reprchar(character: str) -> str:
+    """
+    Return a Python-style literal representation of `character`
+    without the surrounding quotes, e.g. '\\u200b', '\\x00', '\\n'.
+    """
+    return repr(character)[1:-1]  # strip the outer quotes

--- a/exporter/exceptions.py
+++ b/exporter/exceptions.py
@@ -1,0 +1,22 @@
+from typing import List, Tuple
+
+
+class UnacceptableCharacterError(ValueError):
+    """
+    Raised when unacceptable characters are discovered in text to be exported.
+
+    Each violation is stored so that callers can inspect which line / column held
+    the character.
+
+    Args:
+        violations: A list of `(line, column, character)` triples representing
+            every disallowed character found.  Line and column numbers are both
+            **1-based** so they can be reported directly to users.
+    """
+
+    def __init__(self, violations: List[Tuple[int, int, str]]):
+        self.violations: List[Tuple[int, int, str]] = violations
+        details = ", ".join(
+            f"line {ln} col {col} -> {ch!r}" for ln, col, ch in violations
+        )
+        super().__init__(f"Unacceptable characters found: {details}")

--- a/exporter/templates/admin/exporter/unacceptable_character_report.html
+++ b/exporter/templates/admin/exporter/unacceptable_character_report.html
@@ -1,0 +1,77 @@
+{% extends "admin/base.html" %}
+
+{% load concordia_text_tags %}
+
+{% comment %}
+Template: admin/exporter/unacceptable_character_report.html
+Displays per-asset lists of unacceptable characters detected during export.
+Each error entry provides a link to the asset's admin change page.
+{% endcomment %}
+
+{% block messages %}
+    {# Messages are rendered elsewhere in the admin; suppress duplicate view #}
+{% endblock messages %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <style>
+        .char-error-table th {
+            text-align: left;
+        }
+
+        .char-error-table td,
+        .char-error-table th {
+            padding: 0.25rem 0.75rem;
+        }
+
+        .char-error-table tr:nth-child(even) {
+            background: #f9f9f9;
+        }
+
+        .char-error-table code {
+            font-weight: bold;
+            color: #dc3545; /* bootstrap danger */
+            background: transparent;
+        }
+    </style>
+{% endblock extrahead %}
+
+{% block content %}
+    <div id="content-main">
+        <h2>Unacceptable Characters Report</h2>
+
+        {% if errors %}
+            <table class="char-error-table">
+                <thead>
+                    <tr>
+                        <th>Asset</th>
+                        <th>Violations&nbsp;(line, column, char)</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for entry in errors %}
+                        <tr>
+                            <td>
+                                <a href="{% url 'admin:concordia_asset_change' entry.asset.pk %}">
+                                    {{ entry.asset }}
+                                </a>
+                            </td>
+                            <td>
+                                <ul>
+                                    {% for v in entry.violations %}
+                                        <li>
+                                            Line&nbsp;{{ v.0 }},&nbsp;Col&nbsp;{{ v.1 }}:
+                                            <code>{{ v.2|reprchar }}</code>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <p>No unacceptable characters were found.</p>
+        {% endif %}
+    </div>
+{% endblock content %}

--- a/exporter/templates/admin/exporter/unacceptable_character_report.html
+++ b/exporter/templates/admin/exporter/unacceptable_character_report.html
@@ -3,7 +3,6 @@
 {% load concordia_text_tags %}
 
 {% comment %}
-Template: admin/exporter/unacceptable_character_report.html
 Displays per-asset lists of unacceptable characters detected during export.
 Each error entry provides a link to the asset's admin change page.
 {% endcomment %}

--- a/exporter/tests/test_exceptions.py
+++ b/exporter/tests/test_exceptions.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+
+from exporter.exceptions import UnacceptableCharacterError
+
+
+class UnacceptableCharacterErrorTests(TestCase):
+    def test_violations_are_stored(self):
+        """The `violations` list passed to `__init__` is stored unmodified."""
+        violations = [(2, 3, "\u200b"), (4, 1, "\x00")]
+        err = UnacceptableCharacterError(violations)
+        self.assertEqual(err.violations, violations)
+
+    def test_message_contains_formatted_details(self):
+        """The exception message should embed a human-readable summary."""
+        violations = [(1, 1, "\x00")]
+        err = UnacceptableCharacterError(violations)
+        msg = str(err)
+        self.assertIn("line 1 col 1", msg)
+        # The backslash in "\\x00" is escaped once by repr() and once in the
+        # string literal, so we search for the double-escaped form.
+        self.assertIn("\\x00", msg)

--- a/exporter/tests/test_utils.py
+++ b/exporter/tests/test_utils.py
@@ -1,0 +1,47 @@
+from django.test import TestCase
+
+from exporter.exceptions import UnacceptableCharacterError
+from exporter.utils import (
+    find_unacceptable_characters,
+    is_acceptable_character,
+    validate_text_for_export,
+)
+
+
+class UtilsValidationTests(TestCase):
+    def test_printable_ascii_is_acceptable(self):
+        self.assertTrue(is_acceptable_character("A"))
+        self.assertTrue(is_acceptable_character("9"))
+        self.assertTrue(is_acceptable_character(" "))
+
+    def test_whitelisted_nonprintable_is_acceptable(self):
+        # Tab (\t) and NBSP (\xa0) are explicitly whitelisted
+        self.assertTrue(is_acceptable_character("\t"))
+        self.assertTrue(is_acceptable_character("\xa0"))
+
+    def test_control_char_is_rejected(self):
+        self.assertFalse(is_acceptable_character("\x00"))
+        self.assertFalse(is_acceptable_character("\x1f"))
+
+    def test_find_unacceptable_characters_returns_positions(self):
+        sample = "ok\nBad\x00line\nnext\tgood"
+        violations = find_unacceptable_characters(sample)
+        # Expect the single null-byte at line 2, column 4 (1-based)
+        self.assertEqual(violations, [(2, 4, "\x00")])
+
+    def test_duplicate_violations_are_recorded(self):
+        sample = "a\x00b\x00"  # two null bytes same line
+        violations = find_unacceptable_characters(sample)
+        self.assertEqual(violations, [(1, 2, "\x00"), (1, 4, "\x00")])
+
+    def test_validate_text_for_export_passes_clean_text(self):
+        clean = "Hello world!\nThis\u3000is ok."
+        # \u3000 (ideographic space) is whitelisted
+        self.assertTrue(validate_text_for_export(clean))
+
+    def test_validate_text_for_export_raises_on_bad_text(self):
+        bad = "Bad\u200bText"  # zero-width space is not allowed
+        with self.assertRaises(UnacceptableCharacterError) as cm:
+            validate_text_for_export(bad)
+        err = cm.exception
+        self.assertEqual(err.violations, [(1, 4, "\u200b")])

--- a/exporter/utils.py
+++ b/exporter/utils.py
@@ -1,0 +1,83 @@
+"""
+Utility helpers for validating outgoing text.
+
+The primary public entry-point is `exporter.utils.validate_text_for_export`,
+which raises an `exporter.exceptions.UnacceptableCharacterError` when any
+non-printable Unicode character is detected.  Validation is performed per
+line so the caller receives the exact location of every problem character.
+"""
+
+from typing import List, Tuple
+
+from exporter.exceptions import UnacceptableCharacterError
+
+_WHITELIST = [
+    "\t",  # Tab
+    "\xa0",  # Non-breaking space
+    "\u3000",  # Ideographic space; used in Chinese/Japanese/Korean
+    "\u2003",  # em space (space the width of the 'm' character)
+]
+
+
+def is_acceptable_character(character: str) -> bool:
+    """
+    Return `True` when `character` is considered printable.
+
+    The function simply wraps `str.isprintable()` so behaviour stays in sync
+    with the official Unicode definition of *printable*.
+
+    Args:
+        character: A single Unicode character.
+
+    Returns:
+        `True` if the character is printable; otherwise `False`.
+    """
+
+    return character.isprintable() or character in _WHITELIST
+
+
+def find_unacceptable_characters(text: str) -> List[Tuple[int, int, str]]:
+    """
+    Locate every non-printable character in *text*.
+
+    The scan is performed line by line so that the exact position (line and
+    column) of each offending character can be fed back to the caller.
+
+    Args:
+        text: The string to validate.
+
+    Returns:
+        A list of `(line_number, column_number, character)` triples.  The list
+        may contain duplicates because each instance of an invalid character is
+        recorded individually.
+    """
+
+    violations: List[Tuple[int, int, str]] = []
+
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        for col_no, ch in enumerate(line, start=1):
+            if not is_acceptable_character(ch):
+                violations.append((line_no, col_no, ch))
+
+    return violations
+
+
+def validate_text_for_export(text: str) -> bool:
+    """
+    Validate `text` and raise if it contains any unacceptable characters.
+
+    Args:
+        text: The text destined for export.
+
+    Returns:
+        `True` if the text is valid for export
+
+    Raises:
+        UnacceptableCharacterError: If at least one non-printable character is
+        found.
+    """
+
+    violations = find_unacceptable_characters(text)
+    if violations:
+        raise UnacceptableCharacterError(violations)
+    return True


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-1248

This produces a report in the admin for the export that displays the invalid characters so the CMs can choose how to deal with them (by removing them or replacing them with a valid character).