### PR TITLE
CONCD-1183 Upgrade django-registration to version 5

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,6 @@ gunicorn = "==23.0.0"
 celery = { extras = ["redis"], version = "==5.4.0" }
 requests = "==2.32.4"
 bagit = "==1.8.1"
-django-registration = "==3.4"
 django-tinymce = "==4.1.0"
 django-debug-toolbar = "==5.2.0"
 whitenoise = "==6.9.0"
@@ -51,6 +50,7 @@ django-opensearch-dsl = "==0.7.0"
 django-structlog = {extras = ["celery"], version = "==9.1.1"}
 locust = "==2.37.4"
 django = "==4.2.22"
+django-registration = "==5.2.1"
 
 [dev-packages]
 invoke = "==2.2.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "692f4e21b017f82fa7d46cbbaa1358bf27f61c3fc1a0a75a8d360edc5e3c8d69"
+            "sha256": "6b6258d7932c4f92aeb55158a9fe6d852619b1083ed6a22763134745c4a67745"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -743,12 +743,12 @@
         },
         "django-registration": {
             "hashes": [
-                "sha256:1a0ccef7ef71e67a78a551abd8ad378977dc14a036f1fcd8be422a68bd5254a9",
-                "sha256:fa76df481189794f47eb73043ee5cc9bfb0963194b901d7bd8cf914beab1ddd0"
+                "sha256:06864f9da0bc4d7b073fb2da98d95d12428357ab0bc46e33f79c26707ec06bbe",
+                "sha256:7079e2364b15fc6bef18b81ae94c5e947b556abdbbfb19c9bcca14feafde6a3d"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==3.4"
+            "markers": "python_version >= '3.9'",
+            "version": "==5.2.1"
         },
         "django-robots": {
             "hashes": [

--- a/concordia/templates/django_registration/activation_email_body.txt
+++ b/concordia/templates/django_registration/activation_email_body.txt
@@ -3,7 +3,7 @@ Thank you for registering as a Library of Congress virtual volunteer with By the
 
 To complete your activation, please verify your email address in the next {{ expiration_days }} days by clicking the link below:
 
-https://{{ site }}{% url "django_registration_activate" activation_key %}
+https://{{ site }}{% url "django_registration:django_registration_activate" activation_key %}
 
 Once your email is verified, your account will be active! As a registered user you can complete pages by reviewing other volunteers' transcriptions, tag pages, and see a history of your activity on your account page.
 

--- a/concordia/templates/django_registration/activation_email_body.txt
+++ b/concordia/templates/django_registration/activation_email_body.txt
@@ -3,7 +3,7 @@ Thank you for registering as a Library of Congress virtual volunteer with By the
 
 To complete your activation, please verify your email address in the next {{ expiration_days }} days by clicking the link below:
 
-https://{{ site }}{% url "django_registration:django_registration_activate" activation_key %}
+https://{{ site }}{% url "django_registration_activate" %}?activation_key={{ activation_key }}
 
 Once your email is verified, your account will be active! As a registered user you can complete pages by reviewing other volunteers' transcriptions, tag pages, and see a history of your activity on your account page.
 

--- a/concordia/urls.py
+++ b/concordia/urls.py
@@ -4,7 +4,7 @@ from django.http import Http404, HttpResponseForbidden
 from django.urls import include, path
 from django.urls.converters import register_converter
 from django.views.defaults import page_not_found, permission_denied, server_error
-from django.views.generic import RedirectView, TemplateView
+from django.views.generic import RedirectView
 
 from exporter import views as exporter_views
 from prometheus_metrics.views import MetricsView
@@ -280,18 +280,7 @@ urlpatterns = [
         views.accounts.ConcordiaPasswordResetConfirmView.as_view(),
         name="password_reset_confirm",
     ),
-    path(
-        "account/",
-        include(
-            ("django_registration.backends.activation.urls", "django_registration"),
-            namespace="django_registration",
-        ),
-    ),
-    path(
-        "account/register/complete/",
-        TemplateView.as_view(template_name="registration/registration_complete.html"),
-        name="django_registration_complete",
-    ),
+    path("accounts/", include("django_registration.backends.activation.urls")),
     path("account/", include("django.contrib.auth.urls")),
     path(
         "account/email_confirmation/<str:confirmation_key>/",

--- a/concordia/urls.py
+++ b/concordia/urls.py
@@ -4,7 +4,7 @@ from django.http import Http404, HttpResponseForbidden
 from django.urls import include, path
 from django.urls.converters import register_converter
 from django.views.defaults import page_not_found, permission_denied, server_error
-from django.views.generic import RedirectView
+from django.views.generic import RedirectView, TemplateView
 
 from exporter import views as exporter_views
 from prometheus_metrics.views import MetricsView
@@ -280,7 +280,18 @@ urlpatterns = [
         views.accounts.ConcordiaPasswordResetConfirmView.as_view(),
         name="password_reset_confirm",
     ),
-    path("account/", include("django_registration.backends.activation.urls")),
+    path(
+        "account/",
+        include(
+            ("django_registration.backends.activation.urls", "django_registration"),
+            namespace="django_registration",
+        ),
+    ),
+    path(
+        "account/register/complete/",
+        TemplateView.as_view(template_name="registration/registration_complete.html"),
+        name="django_registration_complete",
+    ),
     path("account/", include("django.contrib.auth.urls")),
     path(
         "account/email_confirmation/<str:confirmation_key>/",

--- a/concordia/urls.py
+++ b/concordia/urls.py
@@ -280,7 +280,7 @@ urlpatterns = [
         views.accounts.ConcordiaPasswordResetConfirmView.as_view(),
         name="password_reset_confirm",
     ),
-    path("accounts/", include("django_registration.backends.activation.urls")),
+    path("account/", include("django_registration.backends.activation.urls")),
     path("account/", include("django.contrib.auth.urls")),
     path(
         "account/email_confirmation/<str:confirmation_key>/",


### PR DESCRIPTION
Most important thing to note here is that django-registration 5 changes how the activation_key gets passed to the django_registration_activate view.

https://staff.loc.gov/tasks/browse/CONCD-1183