### PR TITLE
Updated bagit version

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,6 @@ name = "pypi"
 gunicorn = "==23.0.0"
 celery = { extras = ["redis"], version = "==5.4.0" }
 requests = "==2.32.4"
-bagit = "==1.8.1"
 django-tinymce = "==4.1.0"
 django-debug-toolbar = "==5.2.0"
 whitenoise = "==6.9.0"
@@ -54,6 +53,7 @@ django-registration = "==5.2.1"
 defusedxml = "==0.7.1"
 django-ninja = "==1.4.3"
 urllib3 = "==2.5.0"
+bagit = "==1.9.0"
 
 [dev-packages]
 invoke = "==2.2.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5ec0379051000cf8b1b4f0400d09822210723343a801f5ab7effef5ef31cb920"
+            "sha256": "f5010a40d7f0fc457f7cf100fc15abe4543a775c49d6e1b1db1bb41e6c842e30"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -88,11 +88,10 @@
         },
         "bagit": {
             "hashes": [
-                "sha256:37df1330d2e8640c8dee8ab6d0073ac701f0614d25f5252f9e05263409cee60c",
-                "sha256:d14dd7e373dd24d41f6748c42f123f7db77098dfa4a0125dbacb4c8bdf767c09"
+                "sha256:9455006c2d1df88be95ec1fccabc5ea623389589ea4c85b3d85bd256f29d7656"
             ],
             "index": "pypi",
-            "version": "==1.8.1"
+            "version": "==1.9.0"
         },
         "bidict": {
             "hashes": [


### PR DESCRIPTION
The last PR that updated some libraries started causing a warning:
```
 /usr/local/lib/python3.12/site-packages/bagit.py:24: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```

This upgrades to that latest version of bagit, which doesn't use pkg_resources any longer.