### PR TITLE
Corrected state-only migration for ProjectTopic

### DIFF
--- a/concordia/migrations/0111_auto_20250428_1023.py
+++ b/concordia/migrations/0111_auto_20250428_1023.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
                     fields=[
                         (
                             "id",
-                            models.BigAutoField(
+                            models.AutoField(
                                 auto_created=True,
                                 primary_key=True,
                                 serialize=False,


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-1295

Turned out there was only a single migration issue, rather than two.

It also turned out the issue was only the representation of the model, not the actual database, so changing the migration that set the incorrect state resolved the issue without needing to create a new migration.