### PR TITLE
CONCD-1183 reverting django-registration upgrade

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -49,11 +49,11 @@ django-opensearch-dsl = "==0.7.0"
 django-structlog = {extras = ["celery"], version = "==9.1.1"}
 locust = "==2.37.4"
 django = "==4.2.22"
-django-registration = "==5.2.1"
 defusedxml = "==0.7.1"
 django-ninja = "==1.4.3"
 urllib3 = "==2.5.0"
 bagit = "==1.9.0"
+django-registration = "==3.4"
 
 [dev-packages]
 invoke = "==2.2.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f5010a40d7f0fc457f7cf100fc15abe4543a775c49d6e1b1db1bb41e6c842e30"
+            "sha256": "35492f8f40a55c9e516ea3c55081a74e021a9bb1ce2ef891aa66648be492cf03"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -49,11 +49,11 @@
         },
         "asgiref": {
             "hashes": [
-                "sha256:3e1e3ecc849832fe52ccf2cb6686b7a55f82bb1d6aee72a58826471390335e47",
-                "sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590"
+                "sha256:a5ab6582236218e5ef1648f242fd9f10626cfd4de8dc377db215d5d5098e3142",
+                "sha256:f3bba7092a48005b5f5bacd747d36ee4a5a61f4a269a6df590b43144355ebd2c"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==3.8.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.9.1"
         },
         "attrs": {
             "hashes": [
@@ -760,12 +760,12 @@
         },
         "django-registration": {
             "hashes": [
-                "sha256:06864f9da0bc4d7b073fb2da98d95d12428357ab0bc46e33f79c26707ec06bbe",
-                "sha256:7079e2364b15fc6bef18b81ae94c5e947b556abdbbfb19c9bcca14feafde6a3d"
+                "sha256:1a0ccef7ef71e67a78a551abd8ad378977dc14a036f1fcd8be422a68bd5254a9",
+                "sha256:fa76df481189794f47eb73043ee5cc9bfb0963194b901d7bd8cf914beab1ddd0"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
-            "version": "==5.2.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==3.4"
         },
         "django-robots": {
             "hashes": [

--- a/concordia/templates/django_registration/activation_email_body.txt
+++ b/concordia/templates/django_registration/activation_email_body.txt
@@ -3,7 +3,7 @@ Thank you for registering as a Library of Congress virtual volunteer with By the
 
 To complete your activation, please verify your email address in the next {{ expiration_days }} days by clicking the link below:
 
-https://{{ site }}{% url "django_registration_activate" %}?activation_key={{ activation_key }}
+https://{{ site }}{% url "django_registration_activate" activation_key %}
 
 Once your email is verified, your account will be active! As a registered user you can complete pages by reviewing other volunteers' transcriptions, tag pages, and see a history of your activity on your account page.
 


### PR DESCRIPTION
Before we can use django-registration 5, we'll need to at least create an activation_form.html template.