### PR TITLE
Add in-line documentation for views.maintenance, rate_limit and simple_pages

### DIFF
--- a/concordia/views/maintenance_mode.py
+++ b/concordia/views/maintenance_mode.py
@@ -1,14 +1,20 @@
 from time import time
 
 from django.core.cache import cache
-from django.http import HttpResponseRedirect
+from django.http import HttpRequest, HttpResponseRedirect
 from maintenance_mode.core import set_maintenance_mode
 
 
-def maintenance_mode_off(request):
+def maintenance_mode_off(request: HttpRequest) -> HttpResponseRedirect:
     """
-    Deactivate maintenance-mode and redirect to site root.
-    Only superusers are allowed to use this view.
+    Deactivates maintenance mode and redirects to the site root.
+
+    Only superusers are allowed to use this view. If the requesting user is not a
+    superuser, no change is made to the system state.
+
+    Returns:
+        HttpResponseRedirect: Redirect to the root path with a timestamp parameter
+        used for cache busting.
     """
     if request.user.is_superuser:
         set_maintenance_mode(False)
@@ -18,10 +24,16 @@ def maintenance_mode_off(request):
     return HttpResponseRedirect("/?t={}".format(int(time())))
 
 
-def maintenance_mode_on(request):
+def maintenance_mode_on(request: HttpRequest) -> HttpResponseRedirect:
     """
-    Activate maintenance-mode and redirect to site root.
-    Only superusers are allowed to use this view.
+    Activates maintenance mode and redirects to the site root.
+
+    Only superusers are allowed to use this view. If the requesting user is not a
+    superuser, no change is made to the system state.
+
+    Returns:
+        HttpResponseRedirect: Redirect to the root path with a timestamp parameter
+        used for cache busting.
     """
     if request.user.is_superuser:
         set_maintenance_mode(True)
@@ -31,11 +43,17 @@ def maintenance_mode_on(request):
     return HttpResponseRedirect("/?t={}".format(int(time())))
 
 
-def maintenance_mode_frontend_available(request):
+def maintenance_mode_frontend_available(request: HttpRequest) -> HttpResponseRedirect:
     """
-    Allow staff and superusers to use the front-end
-    while maintenance mode is active
+    Enables frontend access during maintenance mode and redirects to the site root.
+
+    This sets a cache key (`maintenance_mode_frontend_available`) to allow staff and
+    superusers to bypass maintenance restrictions while the site is otherwise disabled.
     Only superusers are allowed to use this view.
+
+    Returns:
+        HttpResponseRedirect: Redirect to the root path with a timestamp parameter
+        used for cache busting.
     """
     if request.user.is_superuser:
         cache.set("maintenance_mode_frontend_available", True, None)
@@ -43,11 +61,17 @@ def maintenance_mode_frontend_available(request):
     return HttpResponseRedirect("/?t={}".format(int(time())))
 
 
-def maintenance_mode_frontend_unavailable(request):
+def maintenance_mode_frontend_unavailable(request: HttpRequest) -> HttpResponseRedirect:
     """
-    Disallow all use of the front-end while maintenance
-    mode is active
+    Disables frontend access during maintenance mode and redirects to the site root.
+
+    This clears the `maintenance_mode_frontend_available` cache key, fully locking out
+    all users (including staff) from the site frontend during maintenance mode.
     Only superusers are allowed to use this view.
+
+    Returns:
+        HttpResponseRedirect: Redirect to the root path with a timestamp parameter
+        used for cache busting.
     """
     if request.user.is_superuser:
         cache.set("maintenance_mode_frontend_available", False, None)

--- a/concordia/views/simple_pages.py
+++ b/concordia/views/simple_pages.py
@@ -1,7 +1,9 @@
 import datetime
+from typing import Any
 
 import markdown
 from django.core.cache import cache
+from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.template import Context, Template
 from django.utils.http import http_date
@@ -16,16 +18,30 @@ from .decorators import default_cache_control
 
 @default_cache_control
 def simple_page(
-    request, path=None, slug=None, body_ctx=None, template="static-page.html"
-):
+    request: HttpRequest,
+    path: str | None = None,
+    slug: str | None = None,
+    body_ctx: dict[str, Any] | None = None,
+    template: str = "static-page.html",
+) -> HttpResponse:
     """
-    Basic content management using Markdown managed in the SimplePage model
+    Renders a simple Markdown-based page stored in the `SimplePage` model.
 
-    This expects a pre-existing URL path matching the path specified in the database::
+    If no `path` is provided, defaults to the current request path. Markdown is
+    rendered with optional associated guide content. Breadcrumbs and language
+    detection are computed from the URL structure.
 
-        path("about/", views.simple_page, name="about"),
+    Request Parameters:
+        path (str, optional): The database path of the page. Defaults to the
+            current request path.
+        slug (str, optional): Unused in current logic; passed for route compatibility.
+        body_ctx (dict[str, Any], optional): Additional context injected into the page
+            body during rendering.
+        template (str): Template used to render the page.
+
+    Returns:
+        HttpResponse: Rendered HTML of the simple page.
     """
-
     if not path:
         path = request.path
 
@@ -72,9 +88,23 @@ def simple_page(
 
 
 @default_cache_control
-def about_simple_page(request, path=None, slug=None):
+def about_simple_page(
+    request: HttpRequest, path: str | None = None, slug: str | None = None
+) -> HttpResponse:
     """
-    Adds additional context to the "about" SimplePage
+    Renders the "about" simple page with additional cached campaign and blog stats.
+
+    Adds the following keys to the context:
+        - `report_date` (datetime): Yesterday’s date.
+        - `campaigns_published` (int): Count from active SiteReport.
+        - `assets_published` (int): Active + retired total.
+        - `assets_completed` (int): Active + retired total.
+        - `assets_waiting_review` (int): Active + retired total.
+        - `users_activated` (int): From active SiteReport.
+        - `blog_posts` (Callable): Reference to blog post fetcher.
+
+    Returns:
+        HttpResponse: Rendered HTML of the about page with campaign stats.
     """
     context_cache_key = "about_simple_page-about_context"
     about_context = cache.get(context_cache_key)


### PR DESCRIPTION
https://staff.loc.gov/tasks/browse/CONCD-1190

Originally the simple_pages was a separate ticket, but all three modules were small enough I combined them into this one ticket. With this, all our views (except the help center redirect views that are slated to be removed) are now documented, I believe.