### PR TITLE
Added check and error for non-printable characters, 

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -2,8 +2,9 @@ root: true
 extends:
     - eslint:recommended
     - plugin:unicorn/recommended
-plugins:
+    - plugin:prettier/recommended
     - prettier
+plugins:
     - unicorn
 rules:
     indent:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,7 @@ repos:
                 - eslint-plugin-unicorn@^50.0.1
                 - eslint@^8.56.0
                 - prettier@^2.7.1
+                - eslint-config-prettier@^8.10.0
     - repo: https://github.com/awebdeveloper/pre-commit-stylelint
       rev: 0.0.2
       hooks:

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,2 +1,3 @@
 singleQuote: true
 bracketSpacing: false
+trailingComma: all

--- a/concordia/static/js/src/contribute.js
+++ b/concordia/static/js/src/contribute.js
@@ -332,6 +332,7 @@ function setupPage() {
             $transcriptionEditor.trigger('update-ui-state');
         })
         .on('form-submit-failure', function (event, info) {
+            let errorData = info.jqXHR.responseJSON;
             displayMessage(
                 'error',
                 'Unable to save your work: ' +
@@ -343,6 +344,18 @@ function setupPage() {
                 'transcription-save-result',
             );
             resetTurnstile();
+
+            // Check for unacceptable characters error
+            if (
+                errorData &&
+                errorData['error-code'] === 'unacceptable_characters' &&
+                Array.isArray(errorData['unacceptable-characters'])
+            ) {
+                displayUnacceptableCharacterError(
+                    errorData['unacceptable-characters'],
+                );
+            }
+
             $transcriptionEditor.trigger('update-ui-state');
         });
 
@@ -807,5 +820,267 @@ $('#asset-reservation-failure-modal').click(function () {
     document.getElementById('transcription-input').placeholder =
         "Someone else is already transcribing this page.\n\nYou can help by transcribing a new page, adding tags to this page, or coming back later to review this page's transcription.";
 });
+
+/**
+ * Convenience wrapper to display unacceptable-character violations.
+ *
+ * Runs the raw violations through `tallyUnacceptableCharacters()` and then
+ * delegates rendering to `displayUnacceptableCharacterErrorFromTally()`.
+ *
+ * @param {Array<[number, number, string]>} violations
+ *   Each item is [lineNumber, columnNumber, character].
+ */
+function displayUnacceptableCharacterError(violations) {
+    if (!Array.isArray(violations) || violations.length === 0) {
+        return;
+    }
+    const tally = tallyUnacceptableCharacters(violations);
+    displayUnacceptableCharacterErrorFromTally(tally);
+}
+
+function toHexString(number, width) {
+    let hexString = number.toString(16).toUpperCase();
+    while (hexString.length < width) {
+        hexString = '0' + hexString;
+    }
+    return hexString;
+}
+
+function getCodePointInfo(character) {
+    const codePoint = character.codePointAt(0);
+    const unicodeLabel =
+        'U+' + toHexString(codePoint, codePoint <= 0xff_ff ? 4 : 6);
+    const jsEscape =
+        codePoint <= 0xff_ff
+            ? '\\u' + toHexString(codePoint, 4)
+            : '\\u{' + codePoint.toString(16).toUpperCase() + '}';
+    return {codePoint, unicodeLabel, jsEscape};
+}
+
+/**
+ * Tally unacceptable characters from a list of violations.
+ *
+ * Each violation is a tuple: [lineNumber, columnNumber, character].
+ * This function produces a summary including:
+ *
+ * - Total number of unacceptable characters found.
+ * - Count of unique code points.
+ * - A per-code-point breakdown with counts and Unicode information.
+ * - A list of all positions where violations occurred.
+ *
+ * @param {Array<[number, number, string]>} violations
+ *   An array where each element is a tuple:
+ *   - lineNumber {number} - 1-based line number where the character was found.
+ *   - columnNumber {number} - 1-based column number where the character was found.
+ *   - character {string} - The offending character itself.
+ *
+ * @returns {{
+ *   totalOccurrences: number,
+ *   uniqueCharacterCount: number,
+ *   byCodePoint: Array<{
+ *     codePoint: number,
+ *     unicodeLabel: string,
+ *     jsEscape: string,
+ *     count: number
+ *   }>,
+ *   positions: Array<{
+ *     lineNumber: number,
+ *     columnNumber: number,
+ *     codePoint: number,
+ *     unicodeLabel: string,
+ *     jsEscape: string
+ *   }>
+ * }}
+ *   An object containing:
+ *   - `totalOccurrences`: Total number of unacceptable characters found.
+ *   - `uniqueCharacterCount`: Number of unique code points found.
+ *   - `byCodePoint`: Array of objects summarizing each unique character's count
+ *     and code point info.
+ *   - `positions`: Array of all violation positions with associated code point info.
+ */
+function tallyUnacceptableCharacters(violations) {
+    if (!Array.isArray(violations)) {
+        return {
+            totalOccurrences: 0,
+            uniqueCharacterCount: 0,
+            byCodePoint: [],
+            positions: [],
+        };
+    }
+
+    const countsByCodePoint = new Map();
+    const positions = [];
+
+    for (const [lineNumber, columnNumber, character] of violations) {
+        const {codePoint, unicodeLabel, jsEscape} = getCodePointInfo(character);
+
+        // Record position (use only metadata, never raw character text)
+        positions.push({
+            lineNumber,
+            columnNumber,
+            codePoint,
+            unicodeLabel,
+            jsEscape,
+        });
+
+        // Increment per-code-point count
+        const existing = countsByCodePoint.get(codePoint) || {
+            codePoint,
+            unicodeLabel,
+            jsEscape,
+            count: 0,
+        };
+        existing.count += 1;
+        countsByCodePoint.set(codePoint, existing);
+    }
+
+    const byCodePoint = [...countsByCodePoint.values()];
+
+    return {
+        totalOccurrences: positions.length,
+        uniqueCharacterCount: byCodePoint.length,
+        byCodePoint,
+        positions,
+    };
+}
+
+// ---------- Temporary display until UI is designed/decided ----------
+
+function ensureUnacceptableCharactersModal() {
+    let modalElement = document.getElementById('unacceptable-characters-modal');
+    if (modalElement) return modalElement;
+
+    modalElement = document.createElement('div');
+    modalElement.id = 'unacceptable-characters-modal';
+    modalElement.className = 'modal';
+    modalElement.tabIndex = -1;
+    modalElement.setAttribute(
+        'aria-labelledby',
+        'unacceptable-characters-title',
+    );
+    modalElement.setAttribute('aria-hidden', 'true');
+
+    modalElement.innerHTML = `
+      <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 id="unacceptable-characters-title" class="modal-title">
+              Unacceptable characters detected
+            </h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div id="unacceptable-characters-body" class="modal-body"></div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+          </div>
+        </div>
+      </div>
+    `;
+
+    document.body.append(modalElement);
+    return modalElement;
+}
+
+function displayUnacceptableCharacterErrorFromTally(tally) {
+    if (!tally) return;
+
+    const modalElement = ensureUnacceptableCharactersModal();
+    const bodyElement = modalElement.querySelector(
+        '#unacceptable-characters-body',
+    );
+    bodyElement.textContent = '';
+
+    const summary = document.createElement('p');
+    summary.className = 'mb-2';
+    summary.textContent =
+        'Please remove these characters and try again. ' +
+        tally.uniqueCharacterCount +
+        ' unique, ' +
+        tally.totalOccurrences +
+        ' total occurrence' +
+        (tally.totalOccurrences === 1 ? '' : 's') +
+        '.';
+    bodyElement.append(summary);
+
+    const listGroup = document.createElement('ul');
+    listGroup.className = 'list-group list-group-flush mb-3';
+    for (const entry of tally.byCodePoint) {
+        const li = document.createElement('li');
+        li.className =
+            'list-group-item d-flex justify-content-between align-items-center';
+
+        const code = document.createElement('code');
+        code.textContent = `${entry.unicodeLabel} (${entry.jsEscape})`;
+
+        const badge = document.createElement('span');
+        badge.className = 'badge bg-secondary rounded-pill';
+        badge.textContent = String(entry.count);
+
+        li.append(code);
+        li.append(badge);
+        listGroup.append(li);
+    }
+    bodyElement.append(listGroup);
+
+    const accordionId = 'uc-accordion';
+    const headingId = 'uc-positions-heading';
+    const collapseId = 'uc-positions-collapse';
+
+    const accordion = document.createElement('div');
+    accordion.className = 'accordion';
+    accordion.id = accordionId;
+
+    const item = document.createElement('div');
+    item.className = 'accordion-item';
+
+    const header = document.createElement('h2');
+    header.className = 'accordion-header';
+    header.id = headingId;
+
+    const button = document.createElement('button');
+    button.className = 'accordion-button collapsed';
+    button.type = 'button';
+    button.dataset.bsToggle = 'collapse';
+    button.dataset.bsTarget = `#${collapseId}`;
+    button.setAttribute('aria-expanded', 'false');
+    button.setAttribute('aria-controls', collapseId);
+    button.textContent = 'Exact positions';
+
+    header.append(button);
+
+    const collapse = document.createElement('div');
+    collapse.id = collapseId;
+    collapse.className = 'accordion-collapse collapse';
+    collapse.setAttribute('aria-labelledby', headingId);
+    collapse.dataset.bsParent = `#${accordionId}`;
+
+    const body = document.createElement('div');
+    body.className = 'accordion-body';
+
+    const positionsList = document.createElement('ul');
+    positionsList.className = 'mb-0';
+    for (const pos of tally.positions) {
+        const li = document.createElement('li');
+        const code = document.createElement('code');
+        code.textContent = `${pos.unicodeLabel} (${pos.jsEscape})`;
+        li.append(
+            document.createTextNode(
+                `line ${pos.lineNumber}, col ${pos.columnNumber} — `,
+            ),
+        );
+        li.append(code);
+        positionsList.append(li);
+    }
+    body.append(positionsList);
+
+    collapse.append(body);
+    item.append(header);
+    item.append(collapse);
+    accordion.append(item);
+    bodyElement.append(accordion);
+
+    const modal = Modal.getOrCreateInstance(modalElement);
+    modal.show();
+}
 
 setupPage();

--- a/concordia/templates/transcriptions/asset_detail.html
+++ b/concordia/templates/transcriptions/asset_detail.html
@@ -58,6 +58,7 @@
 
 {% block main_content %}
     {% flag_enabled 'ADVERTISE_ACTIVITY_UI' as ADVERTISE_ACTIVITY_UI %}
+    <div id="unacceptable-characters-content"></div>
 
     <div id="contribute-main-content" class="container-fluid flex-grow-1 d-flex flex-column d-print-block">
         <div id="navigation-container" class="row p-1 px-3 d-print-none bg-light">


### PR DESCRIPTION
As well as a temporary UI for displaying error specifics, to be replaced by real UI/language after it's been designed.

https://staff.loc.gov/tasks/browse/CONCD-1247

I ran into some issues with prettier making a change to a file, then eslint complaining about that change, so I made some changes to configs, particularly with precommit. If you're not running into an issue with prettier and eslint conflicting, you might not need to do anything at the moment, but if you do have a problem, you'll need to clean your precommit set up so it will reinstall/reconfigure everything when you do a commit.

This change does cause eslint to run prettier checks now. This should be fine, since prettier was already being run against the code. However, I did have it try to enforce a rule that prettier itself was doing, where trailing commas weren't allowed. I changed that rule in prettier, but keep an eye out for anything similar--we may need to adjust prettier's rules now that eslint is directly using it (to avoid conflicts like before).