### PR TITLE
CONCD-1326 resolving ValueError (on dev server only)

### DIFF
--- a/concordia/templates/base.html
+++ b/concordia/templates/base.html
@@ -34,7 +34,7 @@
         {% endblock prefetch %}
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
         {% block head_content %}
-            {% if debug %}
+            {% if LOCAL_DEV %}
                 <script type="module" src="http://localhost:5173/static/src/main.js"></script>
             {% else %}
                 <script type="module" src="{% static 'js/main.js' %}"></script>


### PR DESCRIPTION
Updated the template to look for main.js in the static folder, rather than from the vite server (unless LOCAL_DEV is set to True in django settings)