### PR TITLE
Build all images first to fail fast and keep ECR images insync.

### DIFF
--- a/.github/workflows/dev-main-deploy.yml
+++ b/.github/workflows/dev-main-deploy.yml
@@ -88,20 +88,20 @@ jobs:
                   TARGET_SERVICE: ${{ secrets.TARGET_SERVICE }}
               run: |
                   docker build -t concordia .
+                  docker build -t concordia/importer --file importer/Dockerfile .
+                  docker build -t concordia/celerybeat --file celerybeat/Dockerfile .
+
                   docker tag concordia:latest $REGISTRY/concordia:$version_number
                   docker tag concordia:latest $REGISTRY/concordia:$IMAGE_TAG
-                  docker push $REGISTRY/concordia:$version_number
-                  docker push $REGISTRY/concordia:$IMAGE_TAG
-
-                  docker build -t concordia/importer --file importer/Dockerfile .
                   docker tag concordia/importer:latest $REGISTRY/concordia/importer:$version_number
                   docker tag concordia/importer:latest $REGISTRY/concordia/importer:$IMAGE_TAG
-                  docker push $REGISTRY/concordia/importer:$version_number
-                  docker push $REGISTRY/concordia/importer:$IMAGE_TAG
-
-                  docker build -t concordia/celerybeat --file celerybeat/Dockerfile .
                   docker tag concordia/celerybeat:latest $REGISTRY/concordia/celerybeat:$version_number
                   docker tag concordia/celerybeat:latest $REGISTRY/concordia/celerybeat:$IMAGE_TAG
+
+                  docker push $REGISTRY/concordia:$version_number
+                  docker push $REGISTRY/concordia:$IMAGE_TAG
+                  docker push $REGISTRY/concordia/importer:$version_number
+                  docker push $REGISTRY/concordia/importer:$IMAGE_TAG
                   docker push $REGISTRY/concordia/celerybeat:$version_number
                   docker push $REGISTRY/concordia/celerybeat:$IMAGE_TAG
 

--- a/.github/workflows/feature-branch-deploy.yml
+++ b/.github/workflows/feature-branch-deploy.yml
@@ -84,20 +84,20 @@ jobs:
                   TARGET_SERVICE: ${{ secrets.TARGET_SERVICE }}
               run: |
                   docker build -t concordia .
+                  docker build -t concordia/importer --file importer/Dockerfile .
+                  docker build -t concordia/celerybeat --file celerybeat/Dockerfile .
+
                   docker tag concordia:latest $REGISTRY/concordia:$version_number
                   docker tag concordia:latest $REGISTRY/concordia:$IMAGE_TAG
-                  docker push $REGISTRY/concordia:$version_number
-                  docker push $REGISTRY/concordia:$IMAGE_TAG
-
-                  docker build -t concordia/importer --file importer/Dockerfile .
                   docker tag concordia/importer:latest $REGISTRY/concordia/importer:$version_number
                   docker tag concordia/importer:latest $REGISTRY/concordia/importer:$IMAGE_TAG
-                  docker push $REGISTRY/concordia/importer:$version_number
-                  docker push $REGISTRY/concordia/importer:$IMAGE_TAG
-
-                  docker build -t concordia/celerybeat --file celerybeat/Dockerfile .
                   docker tag concordia/celerybeat:latest $REGISTRY/concordia/celerybeat:$version_number
                   docker tag concordia/celerybeat:latest $REGISTRY/concordia/celerybeat:$IMAGE_TAG
+
+                  docker push $REGISTRY/concordia:$version_number
+                  docker push $REGISTRY/concordia:$IMAGE_TAG
+                  docker push $REGISTRY/concordia/importer:$version_number
+                  docker push $REGISTRY/concordia/importer:$IMAGE_TAG
                   docker push $REGISTRY/concordia/celerybeat:$version_number
                   docker push $REGISTRY/concordia/celerybeat:$IMAGE_TAG
 

--- a/.github/workflows/stage-container-environment-update.yml
+++ b/.github/workflows/stage-container-environment-update.yml
@@ -73,20 +73,21 @@ jobs:
                   TARGET_SERVICE: ${{ secrets.TARGET_SERVICE }}
               run: |
                   docker build -t concordia .
+                  docker build -t concordia/importer --file importer/Dockerfile .
+                  docker build -t concordia/celerybeat --file celerybeat/Dockerfile .
+
                   docker tag concordia:latest $REGISTRY/concordia:$version_number
                   docker tag concordia:latest $REGISTRY/concordia:$IMAGE_TAG
-                  docker push $REGISTRY/concordia:$version_number
-                  docker push $REGISTRY/concordia:$IMAGE_TAG
-
-                  docker build -t concordia/importer --file importer/Dockerfile .
                   docker tag concordia/importer:latest $REGISTRY/concordia/importer:$version_number
                   docker tag concordia/importer:latest $REGISTRY/concordia/importer:$IMAGE_TAG
-                  docker push $REGISTRY/concordia/importer:$version_number
-                  docker push $REGISTRY/concordia/importer:$IMAGE_TAG
-
-                  docker build -t concordia/celerybeat --file celerybeat/Dockerfile .
                   docker tag concordia/celerybeat:latest $REGISTRY/concordia/celerybeat:$version_number
                   docker tag concordia/celerybeat:latest $REGISTRY/concordia/celerybeat:$IMAGE_TAG
+
+
+                  docker push $REGISTRY/concordia:$version_number
+                  docker push $REGISTRY/concordia:$IMAGE_TAG
+                  docker push $REGISTRY/concordia/importer:$version_number
+                  docker push $REGISTRY/concordia/importer:$IMAGE_TAG
                   docker push $REGISTRY/concordia/celerybeat:$version_number
                   docker push $REGISTRY/concordia/celerybeat:$IMAGE_TAG
 

--- a/.github/workflows/stage-container-environment-update.yml
+++ b/.github/workflows/stage-container-environment-update.yml
@@ -83,7 +83,6 @@ jobs:
                   docker tag concordia/celerybeat:latest $REGISTRY/concordia/celerybeat:$version_number
                   docker tag concordia/celerybeat:latest $REGISTRY/concordia/celerybeat:$IMAGE_TAG
 
-
                   docker push $REGISTRY/concordia:$version_number
                   docker push $REGISTRY/concordia:$IMAGE_TAG
                   docker push $REGISTRY/concordia/importer:$version_number

--- a/.github/workflows/stage-hotfix-rel-deploy.yml
+++ b/.github/workflows/stage-hotfix-rel-deploy.yml
@@ -72,20 +72,20 @@ jobs:
                   echo "version number: $version_number"
 
                   docker build -t concordia .
+                  docker build -t concordia/importer --file importer/Dockerfile .
+                  docker build -t concordia/celerybeat --file celerybeat/Dockerfile .
+
                   docker tag concordia:latest $REGISTRY/concordia:$version_number
                   docker tag concordia:latest $REGISTRY/concordia:$IMAGE_TAG
-                  docker push $REGISTRY/concordia:$version_number
-                  docker push $REGISTRY/concordia:$IMAGE_TAG
-
-                  docker build -t concordia/importer --file importer/Dockerfile .
                   docker tag concordia/importer:latest $REGISTRY/concordia/importer:$version_number
                   docker tag concordia/importer:latest $REGISTRY/concordia/importer:$IMAGE_TAG
-                  docker push $REGISTRY/concordia/importer:$version_number
-                  docker push $REGISTRY/concordia/importer:$IMAGE_TAG
-
-                  docker build -t concordia/celerybeat --file celerybeat/Dockerfile .
                   docker tag concordia/celerybeat:latest $REGISTRY/concordia/celerybeat:$version_number
                   docker tag concordia/celerybeat:latest $REGISTRY/concordia/celerybeat:$IMAGE_TAG
+
+                  docker push $REGISTRY/concordia:$version_number
+                  docker push $REGISTRY/concordia:$IMAGE_TAG
+                  docker push $REGISTRY/concordia/importer:$version_number
+                  docker push $REGISTRY/concordia/importer:$IMAGE_TAG
                   docker push $REGISTRY/concordia/celerybeat:$version_number
                   docker push $REGISTRY/concordia/celerybeat:$IMAGE_TAG
 

--- a/.github/workflows/stage-image-refresh.yml
+++ b/.github/workflows/stage-image-refresh.yml
@@ -1,4 +1,4 @@
-name: 'Deploy container environment update to stage'
+name: 'Deploy image refresh to stage'
 
 on:
     workflow_dispatch:

--- a/.github/workflows/stage-release-deploy.yml
+++ b/.github/workflows/stage-release-deploy.yml
@@ -85,20 +85,20 @@ jobs:
                   TARGET_SERVICE: ${{ secrets.TARGET_SERVICE }}
               run: |
                   docker build -t concordia .
+                  docker build -t concordia/importer --file importer/Dockerfile .
+                  docker build -t concordia/celerybeat --file celerybeat/Dockerfile .
+
                   docker tag concordia:latest $REGISTRY/concordia:$version_number
                   docker tag concordia:latest $REGISTRY/concordia:$IMAGE_TAG
-                  docker push $REGISTRY/concordia:$version_number
-                  docker push $REGISTRY/concordia:$IMAGE_TAG
-
-                  docker build -t concordia/importer --file importer/Dockerfile .
                   docker tag concordia/importer:latest $REGISTRY/concordia/importer:$version_number
                   docker tag concordia/importer:latest $REGISTRY/concordia/importer:$IMAGE_TAG
-                  docker push $REGISTRY/concordia/importer:$version_number
-                  docker push $REGISTRY/concordia/importer:$IMAGE_TAG
-
-                  docker build -t concordia/celerybeat --file celerybeat/Dockerfile .
                   docker tag concordia/celerybeat:latest $REGISTRY/concordia/celerybeat:$version_number
                   docker tag concordia/celerybeat:latest $REGISTRY/concordia/celerybeat:$IMAGE_TAG
+
+                  docker push $REGISTRY/concordia:$version_number
+                  docker push $REGISTRY/concordia:$IMAGE_TAG
+                  docker push $REGISTRY/concordia/importer:$version_number
+                  docker push $REGISTRY/concordia/importer:$IMAGE_TAG
                   docker push $REGISTRY/concordia/celerybeat:$version_number
                   docker push $REGISTRY/concordia/celerybeat:$IMAGE_TAG
 


### PR DESCRIPTION
CONCD-1510
This change groups the build commands together, then tag, then push. 
Previously, if the second or third image build failed, causing the workflow to stop, the ECR images for the app would be out of sync.