### PR TITLE
ci: add pip resolver debug steps to pip-audit workflow

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -30,6 +30,22 @@ jobs:
               run: |
                   pipx run pipfile-requirements Pipfile.lock > requirements.txt
 
+            - name: 'Show generated requirements'
+              run: |
+                  echo "---- requirements.txt (top 200 lines) ----"
+                  sed -n '1,200p' requirements.txt || true
+                  echo "---- end requirements ----"
+
+            - name: 'Debug: pip dry-run to show resolver errors'
+              run: |
+                  python -m venv .venv
+                  . .venv/bin/activate
+                  python -m pip install --upgrade pip
+                  pip --version
+                  python --version
+                  # Use --dry-run so we don't actually mutate environment; capture resolver output
+                  pip install --dry-run -r requirements.txt || true
+
             - uses: pypa/gh-action-pip-audit@v1.1.0
               with:
                   inputs: requirements.txt


### PR DESCRIPTION
Co-pilot generated with my approval - 
Added resolver-debugging steps to a new branch and committed the updated workflow.

What changed:
Branch: ci/pip-audit-debug-resolver
Commit: ci: add pip resolver debug steps to pip-audit workflow
File updated: .github/workflows/pip-audit.yml
Patch summary: after requirements.txt is generated the workflow now prints the top of requirements.txt and runs a pip dry-run inside a temporary venv so the pip resolver errors (ResolutionImpossible and conflicting constraints) appear in the job logs.