### PR TITLE
Direct Dependabot to update both default and dev packages in PRs.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,5 +25,8 @@ updates:
       directory: '/' # Location of package manifests
       schedule:
           interval: 'weekly'
+      allow:
+          - dependency-type: 'production'
+          - dependency-type: 'development'
       cooldown:
           default-days: 7


### PR DESCRIPTION
Addresses Dependabot not updating dev packages in bump PRs.
CONCD-1633