### PR TITLE
Test workflow update pipenv cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,12 +62,14 @@ jobs:
               with:
                   persist-credentials: false
 
+            # Ensures cache key matches the Pipfile in the Pull Request and not main.
             - name: Set up Python 3.12
               uses: actions/setup-python@v7.0.0
               with:
                   python-version: '3.12'
                   architecture: 'x64'
                   cache: 'pipenv'
+                  cache-dependency-path: '**/Pipfile.lock'
 
             - name: Display Python version
               run: python -c "import sys; print(sys.version)"

--- a/Pipfile
+++ b/Pipfile
@@ -71,5 +71,4 @@ python_version = "3.12"
 
 [pipenv]
 allow_prereleases = false
-cool-down-period = "7d"
 sort_pipfile = true


### PR DESCRIPTION
CONCD-1647
Changes setup-python section to point to the PR pipenv cache.
Also, change of heart, removed pipenv Pipfile cooldown period since it doesn't let security updates through. Will use only the dependabot cooldown since it allows security updates through.